### PR TITLE
Add llm-d P/D disaggregation deployment for Llama 3.1 8B

### DIFF
--- a/scripts/k8s/llm-d/README.md
+++ b/scripts/k8s/llm-d/README.md
@@ -1,0 +1,339 @@
+# Llama 3.1 8B Prefill-Decode Disaggregation with llm-d
+
+Production-ready deployment of Llama 3.1 8B with GAIE-powered Prefill/Decode (P/D) disaggregation using pure Kubernetes pod replication for data parallelism.
+
+## Overview
+
+This deployment implements **DP8TP1** (8-way data parallelism, 1-way tensor parallelism) with P/D disaggregation:
+- **8 Prefill pods**: Handle prompt processing (1 GPU each)
+- **8 Decode pods**: Handle token generation (1 GPU each) + routing-proxy sidecar
+- **Total**: 16 GPUs across 16 pods
+- **Routing**: GAIE (Gateway API Inference Extension) with EPP (Endpoint Picker Plugin) for intelligent P/D routing
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    Client Request                            │
+└────────────────────────┬────────────────────────────────────┘
+                         │
+                         ▼
+┌─────────────────────────────────────────────────────────────┐
+│          Istio Gateway (infra-llama31-inference-gateway)     │
+└────────────────────────┬────────────────────────────────────┘
+                         │
+                         ▼
+┌─────────────────────────────────────────────────────────────┐
+│                HTTPRoute (llm-d-llama31-pd-disaggregation)   │
+│                      ↓                                        │
+│                InferencePool (gaie-llama31)                  │
+│                      ↓                                        │
+│                  GAIE EPP (scheduling)                       │
+└──────────────────┬───────────────┬──────────────────────────┘
+                   │               │
+         ┌─────────┘               └─────────┐
+         ▼                                   ▼
+┌─────────────────────┐           ┌─────────────────────┐
+│  Prefill Pods (×8)  │           │  Decode Pods (×8)   │
+│  • 1 GPU each       │           │  • 1 GPU each       │
+│  • Port 8000        │←─────────→│  • Port 8200        │
+│  • vLLM only        │  KV Cache │  • vLLM + proxy     │
+│  • Prompt proc.     │  Transfer │  • Token gen.       │
+└─────────────────────┘  (Nixl)   └─────────────────────┘
+```
+
+## Key Configuration Pattern
+
+**Critical**: The llm-d-modelservice chart uses pure Kubernetes replication for data parallelism, NOT vLLM's internal `--data-parallel-size`.
+
+### Correct Pattern (DP8TP1):
+```yaml
+decode/prefill:
+  create: true
+  replicas: 8              # 8 Kubernetes pods
+  # NO parallelism section!
+  containers:
+  - name: vllm
+    env:
+      - name: CUDA_VISIBLE_DEVICES
+        value: "0"         # Single GPU per pod
+    resources:
+      limits:
+        nvidia.com/gpu: "1"  # 1 GPU per pod
+        memory: 100Gi        # Per-pod resources
+        cpu: "22"
+```
+
+### ❌ WRONG Pattern (causes crashes):
+```yaml
+decode/prefill:
+  parallelism:
+    data: 8    # This passes --data-parallel-size 8 to vLLM
+  replicas: 8  # But each pod only has 1 GPU!
+  resources:
+    nvidia.com/gpu: "8"  # Doesn't work - chart divides by parallelism.data
+```
+
+## Prerequisites
+
+- Kubernetes cluster with 16+ GPUs across multiple nodes
+- `kubectl` and `helmfile` installed
+- HuggingFace token with Llama 3.1 access
+
+## Deployment
+
+### 1. Create Secret
+
+```bash
+kubectl create namespace llm-d-llama31
+
+kubectl create secret generic llm-d-hf-token \
+  --from-literal=HF_TOKEN=hf_xxxxxxxxxxxxx \
+  -n llm-d-llama31
+```
+
+### 2. Deploy
+
+```bash
+cd /home/congc/router/scripts/k8s/llm-d
+helmfile apply
+```
+
+Wait for all pods to be ready (5-10 minutes first time for model download, ~2 minutes after).
+
+### 3. Verify Deployment
+
+```bash
+# Check all 16 pods are running
+kubectl get pods -n llm-d-llama31 -l llm-d.ai/inferenceServing=true
+
+# Expected output:
+# - 8 prefill pods (1/1 ready)
+# - 8 decode pods (2/2 ready: vllm + routing-proxy)
+
+# Check GAIE components
+kubectl get inferencepool -n llm-d-llama31
+kubectl get httproute -n llm-d-llama31
+kubectl get gateway -n llm-d-llama31
+```
+
+### 4. Test Inference
+
+```bash
+# Get a pod to run test from
+PREFILL_POD=$(kubectl get pods -n llm-d-llama31 -l llm-d.ai/role=prefill -o jsonpath='{.items[0].metadata.name}')
+
+# Test inference through gateway
+kubectl exec -n llm-d-llama31 $PREFILL_POD -c vllm -- \
+  curl -s -X POST "http://infra-llama31-inference-gateway-istio/v1/completions" \
+  -H "Content-Type: application/json" \
+  -d '{"model": "meta-llama/Llama-3.1-8B-Instruct", "prompt": "Hello, what is AI?", "max_tokens": 50}'
+```
+
+## Benchmark Results
+
+Performance with 1K input / 1K output tokens:
+
+| Concurrency | Output Tok/s | Peak Tok/s | Mean TTFT | Mean TPOT | Duration |
+|-------------|--------------|------------|-----------|-----------|----------|
+| 32          | 3,710        | 5,463      | 829ms     | 7.41ms    | 53.9s    |
+| 64          | 5,814        | 9,195      | 1.47s     | 8.46ms    | 34.4s    |
+| **128**     | **7,590**    | **15,252** | 3.70s     | 9.01ms    | 26.4s    |
+
+**Key Metrics:**
+- ✅ **Throughput Scaling**: 57% increase from 32→64, 31% increase from 64→128 concurrency
+- ✅ **Peak Performance**: 15,252 tok/s at concurrency 128
+- ✅ **Stable Latency**: TPOT remains 7-9ms across all concurrency levels
+
+## Running Benchmarks
+
+```bash
+# Get a decode pod to run benchmark from
+DECODE_POD=$(kubectl get pods -n llm-d-llama31 -l llm-d.ai/role=decode -o jsonpath='{.items[0].metadata.name}')
+
+# Run benchmark (200 prompts, concurrency 32)
+kubectl exec -n llm-d-llama31 $DECODE_POD -c vllm -- \
+  vllm bench serve \
+    --dataset-name random \
+    --num-prompts 200 \
+    --model meta-llama/Llama-3.1-8B-Instruct \
+    --random-input-len 1000 \
+    --random-output-len 1000 \
+    --endpoint /v1/completions \
+    --max-concurrency 32 \
+    --save-result \
+    --ignore-eos \
+    --served-model-name meta-llama/Llama-3.1-8B-Instruct \
+    --host infra-llama31-inference-gateway-istio \
+    --port 80
+```
+
+## Monitoring
+
+### Check Pod Logs
+
+```bash
+# Prefill pod logs
+kubectl logs -n llm-d-llama31 -l llm-d.ai/role=prefill -c vllm --tail=50
+
+# Decode pod logs (vLLM container)
+kubectl logs -n llm-d-llama31 -l llm-d.ai/role=decode -c vllm --tail=50
+
+# Decode pod logs (routing-proxy sidecar)
+kubectl logs -n llm-d-llama31 -l llm-d.ai/role=decode -c routing-proxy --tail=50
+
+# GAIE EPP logs
+kubectl logs -n llm-d-llama31 -l inferencepool=gaie-llama31-epp --tail=50
+```
+
+### Check InferencePool Status
+
+```bash
+kubectl describe inferencepool gaie-llama31 -n llm-d-llama31
+```
+
+### Monitor GPU Utilization
+
+```bash
+# Check GPU usage on prefill pod
+PREFILL_POD=$(kubectl get pods -n llm-d-llama31 -l llm-d.ai/role=prefill -o jsonpath='{.items[0].metadata.name}')
+kubectl exec -n llm-d-llama31 $PREFILL_POD -c vllm -- nvidia-smi
+
+# Check GPU usage on decode pod
+DECODE_POD=$(kubectl get pods -n llm-d-llama31 -l llm-d.ai/role=decode -o jsonpath='{.items[0].metadata.name}')
+kubectl exec -n llm-d-llama31 $DECODE_POD -c vllm -- nvidia-smi
+```
+
+## Troubleshooting
+
+### Pods Not Scheduling
+
+```bash
+kubectl describe pod -n llm-d-llama31 <pod-name>
+```
+
+Check for: GPU availability, node resources, memory constraints
+
+### Pods Crashing (CrashLoopBackOff)
+
+```bash
+# Check logs for error
+kubectl logs -n llm-d-llama31 <pod-name> -c vllm --tail=100
+```
+
+**Common issue**: If you see `RuntimeError: Engine core initialization failed` with `Failed core proc(s): {'EngineCore_DP1': 1, ...}`, this means:
+- The chart is passing `--data-parallel-size N` to vLLM, but the pod only has 1 GPU
+- **Solution**: Remove the `parallelism` section from values.yaml (use pure Kubernetes replication)
+
+### InferencePool Not Found
+
+```bash
+# Check if InferencePool exists
+kubectl get inferencepool -n llm-d-llama31
+
+# If not found, manually create it
+kubectl apply -f - <<EOF
+apiVersion: inference.networking.x-k8s.io/v1alpha2
+kind: InferencePool
+metadata:
+  name: gaie-llama31
+  namespace: llm-d-llama31
+spec:
+  targetPortNumber: 8000
+  selector:
+    llm-d.ai/inferenceServing: "true"
+  extensionRef:
+    name: gaie-llama31-epp
+    portNumber: 9002
+    failureMode: FailClose
+EOF
+```
+
+### No Inference Response / Gateway Timeout
+
+1. Check if vLLM is ready:
+```bash
+PREFILL_POD=$(kubectl get pods -n llm-d-llama31 -l llm-d.ai/role=prefill -o jsonpath='{.items[0].metadata.name}')
+kubectl exec -n llm-d-llama31 $PREFILL_POD -c vllm -- \
+  curl -s http://localhost:8000/v1/models
+```
+
+2. Check GAIE EPP is discovering pods:
+```bash
+kubectl logs -n llm-d-llama31 -l inferencepool=gaie-llama31-epp | grep -i "pod\|endpoint"
+```
+
+3. Check HTTPRoute status:
+```bash
+kubectl describe httproute llm-d-llama31-pd-disaggregation -n llm-d-llama31
+```
+
+## Cleanup
+
+```bash
+# Remove deployment
+helmfile destroy
+
+# Delete namespace (including PVCs with cached model)
+kubectl delete namespace llm-d-llama31
+```
+
+## Key Differences from vllm-native Multi-Node DP
+
+| Aspect | llm-d (This Setup) | vllm-native Multi-Node |
+|--------|-------------------|------------------------|
+| **DP Implementation** | Kubernetes pod replication | vLLM internal `--data-parallel-size` |
+| **Coordination** | GAIE EPP for P/D routing | vLLM DP Coordinator (rank 0) |
+| **Service Discovery** | InferencePool + Gateway | Kubernetes Service + RPC |
+| **Load Balancing** | GAIE intelligent routing | vLLM internal round-robin |
+| **P/D Disaggregation** | Native GAIE feature | Manual configuration |
+| **Scaling** | Independent prefill/decode scaling | Must scale ranks together |
+
+## Configuration Reference
+
+### Model Configuration
+
+Located in `values.yaml`:
+
+```yaml
+modelArtifacts:
+  uri: "hf://meta-llama/Llama-3.1-8B-Instruct"
+  size: 200Gi
+  authSecretName: "llm-d-hf-token"
+  name: "meta-llama/Llama-3.1-8B-Instruct"
+```
+
+### Routing Configuration
+
+```yaml
+routing:
+  servicePort: 8000
+  proxy:
+    image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.3.0
+    connector: nixlv2
+    secure: false
+```
+
+### Resource Limits
+
+Per-pod (for 8 replicas):
+- **GPU**: 1 × H100 (or similar)
+- **Memory**: 100 Gi
+- **CPU**: 22 cores
+- **Shared Memory**: 16 Gi
+
+Total for deployment:
+- **GPUs**: 16 (8 prefill + 8 decode)
+- **Memory**: 1.6 Ti (16 × 100 Gi)
+- **CPUs**: 352 cores (16 × 22)
+
+## References
+
+- [llm-d GitHub](https://github.com/llm-d-incubation)
+- [llm-d-modelservice Helm Chart](https://github.com/llm-d-incubation/llm-d-modelservice)
+- [Gateway API Inference Extension (GAIE)](https://github.com/kubernetes-sigs/gateway-api-inference-extension)
+- [vLLM P/D Disaggregation](https://docs.vllm.ai/en/latest/serving/disaggregated_prefill.html)
+
+---
+
+**Built for production-grade Prefill-Decode disaggregation with intelligent GAIE routing.** 🚀

--- a/scripts/k8s/llm-d/cleanup.sh
+++ b/scripts/k8s/llm-d/cleanup.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Cleanup Llama 3.1 8B P/D deployment
+# This script removes all deployed resources
+
+set -e
+
+NAMESPACE="llm-d-llama31"
+
+echo "=========================================="
+echo "Cleaning up P/D Disaggregation Deployment"
+echo "=========================================="
+echo "Namespace: $NAMESPACE"
+echo ""
+
+# Remove helmfile releases
+echo "Removing helmfile releases..."
+helmfile destroy
+
+echo ""
+echo "=========================================="
+echo "Cleanup completed!"
+echo "=========================================="
+echo ""
+echo "Note: Namespace $NAMESPACE still exists with:"
+echo "  - Secret (llm-d-hf-token)"
+echo "  - PVCs (cached model artifacts)"
+echo ""
+echo "To completely remove everything including cached model:"
+echo "  kubectl delete namespace $NAMESPACE"

--- a/scripts/k8s/llm-d/deploy.sh
+++ b/scripts/k8s/llm-d/deploy.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+# Deploy Llama 3.1 8B with P/D disaggregation using llm-d
+# This script deploys the model service, GAIE components, and gateway infrastructure
+
+set -e
+
+NAMESPACE="llm-d-llama31"
+
+echo "=========================================="
+echo "Deploying Llama 3.1 8B P/D Disaggregation"
+echo "=========================================="
+echo "Namespace: $NAMESPACE"
+echo ""
+
+# Check if namespace exists
+if ! kubectl get namespace "$NAMESPACE" &> /dev/null; then
+    echo "Error: Namespace $NAMESPACE does not exist"
+    echo "Please create namespace and secret first:"
+    echo ""
+    echo "  kubectl create namespace $NAMESPACE"
+    echo "  kubectl create secret generic llm-d-hf-token \\"
+    echo "    --from-literal=HF_TOKEN=hf_xxxxx \\"
+    echo "    -n $NAMESPACE"
+    echo ""
+    exit 1
+fi
+
+# Check if secret exists
+if ! kubectl get secret llm-d-hf-token -n "$NAMESPACE" &> /dev/null; then
+    echo "Error: Secret llm-d-hf-token does not exist in $NAMESPACE"
+    echo "Please create secret first:"
+    echo ""
+    echo "  kubectl create secret generic llm-d-hf-token \\"
+    echo "    --from-literal=HF_TOKEN=hf_xxxxx \\"
+    echo "    -n $NAMESPACE"
+    echo ""
+    exit 1
+fi
+
+echo "Prerequisites check passed"
+echo ""
+echo "Deploying with helmfile..."
+helmfile apply
+
+echo ""
+echo "=========================================="
+echo "Deployment initiated!"
+echo "=========================================="
+echo ""
+echo "Monitor deployment progress:"
+echo "  kubectl get pods -n $NAMESPACE -w"
+echo ""
+echo "Expected pods:"
+echo "  - 8 prefill pods (1/1 ready)"
+echo "  - 8 decode pods (2/2 ready)"
+echo "  - 1 GAIE EPP pod (1/1 ready)"
+echo "  - 1 gateway pod (1/1 ready)"
+echo ""
+echo "This may take 5-10 minutes for first deployment (model download)"
+echo "Subsequent deployments take ~2 minutes (model cached)"

--- a/scripts/k8s/llm-d/gaie-llama31/values.yaml
+++ b/scripts/k8s/llm-d/gaie-llama31/values.yaml
@@ -1,0 +1,59 @@
+inferenceExtension:
+  replicas: 1
+  image:
+    name: llm-d-inference-scheduler
+    hub: ghcr.io/llm-d
+    tag: v0.3.2
+    pullPolicy: Always
+  extProcPort: 9002
+  pluginsConfigFile: "pd-config.yaml"
+  pluginsCustomConfig: # THIS CONFIG NEEDS TO BE CHECKED FOR INF SCHEDULER NEW IMAGE
+    pd-config.yaml: |
+      # ALWAYS DO PD IN THIS EXAMPLE (THRESHOLD 0)
+      apiVersion: inference.networking.x-k8s.io/v1alpha1
+      kind: EndpointPickerConfig
+      plugins:
+      - type: prefill-header-handler
+      - type: prefill-filter
+      - type: decode-filter
+      - type: max-score-picker
+      - type: queue-scorer
+        parameters:
+          hashBlockSize: 5
+          maxPrefixBlocksToMatch: 256
+          lruCapacityPerServer: 31250
+      - type: pd-profile-handler
+        parameters:
+          threshold: 0
+          hashBlockSize: 5
+      schedulingProfiles:
+      - name: prefill
+        plugins:
+        - pluginRef: prefill-filter
+        - pluginRef: queue-scorer
+          weight: 1.0
+        - pluginRef: max-score-picker
+      - name: decode
+        plugins:
+        - pluginRef: decode-filter
+        - pluginRef: queue-scorer
+          weight: 1.0
+        - pluginRef: max-score-picker
+
+  # Monitoring configuration for EPP
+  monitoring:
+    interval: "10s"
+    # Service account token secret for authentication
+    secret:
+      name: llama31-gateway-sa-metrics-reader-secret
+    # Prometheus ServiceMonitor will be created when enabled for EPP metrics collection
+    prometheus:
+      enabled: true
+
+inferencePool:
+  apiVersion: inference.networking.x-k8s.io/v1alpha2 # use old API version for inference
+  targetPortNumber: 8000
+  modelServerType: vllm
+  modelServers:
+    matchLabels:
+      llm-d.ai/inferenceServing: "true"

--- a/scripts/k8s/llm-d/gateway-configs/benchmarking.yaml
+++ b/scripts/k8s/llm-d/gateway-configs/benchmarking.yaml
@@ -1,0 +1,42 @@
+# Infra values
+gateway:
+  gatewayParameters:
+    accessLogging: false
+    logLevel: error
+    resources:
+      limits:
+        cpu: "4"
+        memory: 4Gi
+      requests:
+        cpu: "1"
+        memory: 1Gi
+
+# MS values
+routing:
+  proxy:
+    debugLevel: 1
+  # IF epp is created through ms, set its debugLevel
+  epp:
+    debugLevel: 1
+
+# GAIE values
+inferenceExtension:
+  flags:
+    - name: v
+      value: 1
+  # include pool group, whole flags get overwritten
+    - name: "pool-group"
+      value: "inference.networking.x-k8s.io"
+istio:
+  destinationRule:
+    trafficPolicy:
+      connectionPool:
+        http:
+          http1MaxPendingRequests: 256000
+          maxRequestsPerConnection: 256000
+          http2MaxRequests: 256000
+          idleTimeout: "900s"
+        tcp:
+          maxConnections: 256000
+          maxConnectionDuration: "1800s"
+          connectTimeout: "900s"

--- a/scripts/k8s/llm-d/gateway-configs/gke.yaml
+++ b/scripts/k8s/llm-d/gateway-configs/gke.yaml
@@ -1,0 +1,10 @@
+gateway:
+  gatewayClassName: gke-l7-regional-external-managed
+  gatewayParameters:
+    accessLogging: false
+
+provider:
+  name: gke
+
+inferencePool:
+  apiVersion: "inference.networking.k8s.io/v1"

--- a/scripts/k8s/llm-d/gateway-configs/gke_tpu.yaml
+++ b/scripts/k8s/llm-d/gateway-configs/gke_tpu.yaml
@@ -1,0 +1,10 @@
+gateway:
+  gatewayClassName: gke-l7-regional-external-managed
+  gatewayParameters:
+    accessLogging: false
+
+provider:
+  name: gke
+
+inferencePool:
+  apiVersion: "inference.networking.k8s.io/v1"

--- a/scripts/k8s/llm-d/gateway-configs/istio.yaml
+++ b/scripts/k8s/llm-d/gateway-configs/istio.yaml
@@ -1,0 +1,21 @@
+# Infra values
+gateway:
+  gatewayClassName: istio
+
+# GAIE values
+inferenceExtension:
+  flags: # empty flag overrides, so key always exists to pull values from, its just empty
+provider:
+  name: istio
+istio:
+  destinationRule:
+    trafficPolicy:
+      tls:
+        mode: SIMPLE
+        insecureSkipVerify: true
+
+routing:  # empty debugLevel overrides, so keys always exist to pull values from, its just empty
+  proxy:
+    debugLevel:
+  epp:
+    debugLevel:

--- a/scripts/k8s/llm-d/gateway-configs/kgateway.yaml
+++ b/scripts/k8s/llm-d/gateway-configs/kgateway.yaml
@@ -1,0 +1,2 @@
+gateway:
+  gatewayClassName: kgateway

--- a/scripts/k8s/llm-d/helmfile.yaml.gotmpl
+++ b/scripts/k8s/llm-d/helmfile.yaml.gotmpl
@@ -1,0 +1,138 @@
+environments:
+  istio: &I
+    values:
+      - gateway-configs/istio.yaml
+  istioBench: &IB
+    values:
+      - gateway-configs/istio.yaml
+      - gateway-configs/benchmarking.yaml
+  kgateway: &KG
+    values:
+      - gateway-configs/kgateway.yaml
+  gke: &GKE
+    values:
+      - gateway-configs/gke.yaml
+  xpu: &XPU
+    values:
+      - gateway-configs/istio.yaml
+  aks: &AKS
+    <<: *IB
+  default:
+    <<: *IB
+
+---
+
+{{- $ns := .Namespace | default "llm-d-llama31" -}}
+{{- $rn := (env "RELEASE_NAME_POSTFIX") | default "llama31" -}}
+
+repositories:
+  - name: llm-d-modelservice
+    url: https://llm-d-incubation.github.io/llm-d-modelservice/
+  - name: llm-d-infra
+    url: https://llm-d-incubation.github.io/llm-d-infra/
+
+releases:
+  - name: {{ printf "infra-%s" $rn | quote }}
+    namespace: {{ $ns }}
+    chart: llm-d-infra/llm-d-infra
+    version: v1.3.3
+    installed: true
+    labels:
+      type: infrastructure
+      kind: inference-stack
+    values:
+      - gateway:
+          {{ .Environment.Values.gateway | toYaml | nindent 10 }}
+
+  - name: {{ printf "gaie-%s" $rn | quote }}
+    namespace: {{ $ns }}
+    chart: oci://registry.k8s.io/gateway-api-inference-extension/charts/inferencepool
+    version: v1.0.1
+    installed: true
+    needs:
+      - {{ printf "infra-%s" $rn | quote }}
+    values:
+      - gaie-llama31/values.yaml
+    # Apply provider name if on GKE
+    {{- if or (eq .Environment.Name "gke") (eq .Environment.Name "gke_tpu") }}
+      - provider:
+          name: {{ .Environment.Values.provider.name }}
+        inferencePool:
+          apiVersion: {{ .Environment.Values.inferencePool.apiVersion }}
+        inferenceExtension:
+          monitoring:
+            gke:
+              enabled: true
+            prometheus:
+              enabled: false
+    {{- end }}
+    # Apply destination rule for anything istio
+    {{- if or (eq .Environment.Name "istio") (eq .Environment.Name "default") (eq .Environment.Name "istioBench") (eq .Environment.Name "aks") (eq .Environment.Name "xpu") }}
+      - provider:
+          name: {{ .Environment.Values.provider.name }}
+      - istio:
+        {{ .Environment.Values.istio | toYaml | nindent 10 }}
+      - istio:
+          destinationRule:
+            host: {{ printf "gaie-%s-epp.%s.svc.cluster.local" $rn $ns | quote }}
+    {{- end }}
+    # Apply log level only in bench setting
+    {{- if or (eq .Environment.Name "istioBench") (eq .Environment.Name "default") }}
+      - inferenceExtension:
+          flags:
+            {{ .Environment.Values.inferenceExtension.flags | toYaml | nindent 12 }}
+    {{- end }}
+    labels:
+      kind: inference-stack
+
+  - name: {{ printf "ms-%s" $rn | quote }}
+    namespace: {{ $ns }}
+    chart: llm-d-modelservice/llm-d-modelservice
+    version: v0.2.11
+    installed: true
+    needs:
+      - {{ printf "infra-%s" $rn | quote }}
+      - {{ printf "gaie-%s" $rn | quote }}
+    values:
+      - values.yaml
+    {{- if or (eq .Environment.Name "istioBench") (eq .Environment.Name "default") }}
+      - routing:
+          {{ .Environment.Values.routing | toYaml | nindent 10 }}
+    {{- end }}
+    {{- if eq .Environment.Name "aks" }}
+      # Set pod annotations for ulimits on AKS (16GiB memlock)
+      - decode:
+          podAnnotations:
+            ulimits.nri.containerd.io/container.vllm: |
+              - type: memlock
+                hard: 17179869184
+                soft: 17179869184
+        prefill:
+          podAnnotations:
+            ulimits.nri.containerd.io/container.vllm: |
+              - type: memlock
+                hard: 17179869184
+                soft: 17179869184
+    {{- end }}
+    set:
+    # apply release name derived values
+      - name: "routing.inferencePool.name"
+        value: {{ printf "gaie-%s" $rn | quote }}
+      - name: "routing.parentRefs[0].name"
+        value: {{ printf "infra-%s-inference-gateway" $rn | quote }}
+    {{- if eq .Environment.Name "gke" }}
+      - name: 'decode.containers[0].resources.limits.rdma/ib'
+        value: "null"
+      - name: 'decode.containers[0].resources.requests.rdma/ib'
+        value: "null"
+      - name: 'prefill.containers[0].resources.limits.rdma/ib'
+        value: "null"
+      - name: 'prefill.containers[0].resources.requests.rdma/ib'
+        value: "null"
+      - name: "decode.monitoring.podmonitor.enabled"
+        value: false
+      - name: "prefill.monitoring.podmonitor.enabled"
+        value: false
+    {{- end }}
+    labels:
+      kind: inference-stack

--- a/scripts/k8s/llm-d/values.yaml
+++ b/scripts/k8s/llm-d/values.yaml
@@ -1,0 +1,145 @@
+multinode: false
+
+modelArtifacts:
+  uri: "hf://meta-llama/Llama-3.1-8B-Instruct"
+  size: 200Gi
+  authSecretName: "llm-d-hf-token"
+  name: "meta-llama/Llama-3.1-8B-Instruct"
+
+routing:
+  servicePort: 8000
+  proxy:
+    image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.3.0
+    connector: nixlv2
+    secure: false
+
+  inferencePool:
+    create: false
+
+  httpRoute:
+    create: false
+
+  epp:
+    create: false
+
+decode:
+  create: true
+  replicas: 8
+  monitoring:
+    podmonitor:
+      enabled: true
+      portName: "metrics" # decode vLLM service port (from routing.proxy.targetPort)
+      path: "/metrics"
+      interval: "30s"
+  containers:
+  - name: "vllm"
+    image: ghcr.io/llm-d/llm-d-cuda:v0.3.0
+    modelCommand: vllmServe
+    args:
+      - "--block-size"
+      - "128"
+      - "--kv-transfer-config"
+      - '{"kv_connector":"NixlConnector", "kv_role":"kv_both"}'
+      - "--disable-uvicorn-access-log"
+      - "--max-model-len"
+      - "32000"
+    env:
+      - name: CUDA_VISIBLE_DEVICES
+        value: "0"
+      - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      - name: VLLM_LOGGING_LEVEL
+        value: DEBUG
+    ports:
+      - containerPort: 8200
+        name: metrics
+        protocol: TCP
+    resources:
+      limits:
+        memory: 100Gi
+        cpu: "22"
+        nvidia.com/gpu: "1"
+      requests:
+        memory: 100Gi
+        cpu: "22"
+        nvidia.com/gpu: "1"
+    mountModelVolume: true
+    volumeMounts:
+    - name: metrics-volume
+      mountPath: /.config
+    - name: shm
+      mountPath: /dev/shm
+    - name: torch-compile-cache
+      mountPath: /.cache
+  volumes:
+  - name: metrics-volume
+    emptyDir: {}
+  - name: shm
+    emptyDir:
+      medium: Memory
+      sizeLimit: "16Gi"
+  - name: torch-compile-cache
+    emptyDir: {}
+
+prefill:
+  create: true
+  replicas: 8
+  monitoring:
+    podmonitor:
+      enabled: true
+      portName: "metrics" # prefill vLLM service port (from routing.servicePort)
+      path: "/metrics"
+      interval: "30s"
+  containers:
+  - name: "vllm"
+    image: ghcr.io/llm-d/llm-d-cuda:v0.3.0
+    modelCommand: vllmServe
+    args:
+      - "--block-size"
+      - "128"
+      - "--kv-transfer-config"
+      - '{"kv_connector":"NixlConnector", "kv_role":"kv_both"}'
+      - "--disable-uvicorn-access-log"
+      - "--max-model-len"
+      - "32000"
+    env:
+      - name: CUDA_VISIBLE_DEVICES
+        value: "0"
+      - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      - name: VLLM_LOGGING_LEVEL
+        value: DEBUG
+    ports:
+      - containerPort: 8000
+        name: metrics
+        protocol: TCP
+    resources:
+      limits:
+        memory: 100Gi
+        cpu: "22"
+        nvidia.com/gpu: "1"
+      requests:
+        memory: 100Gi
+        cpu: "22"
+        nvidia.com/gpu: "1"
+    mountModelVolume: true
+    volumeMounts:
+    - name: metrics-volume
+      mountPath: /.config
+    - name: shm
+      mountPath: /dev/shm
+    - name: torch-compile-cache
+      mountPath: /.cache
+  volumes:
+  - name: metrics-volume
+    emptyDir: {}
+  - name: shm
+    emptyDir:
+      medium: Memory
+      sizeLimit: "16Gi"
+  - name: torch-compile-cache
+    emptyDir: {}


### PR DESCRIPTION
Implements DP8TP1 (8-way data parallelism, 1-way tensor parallelism) with Prefill-Decode disaggregation using llm-d-modelservice chart and GAIE routing.

Architecture:
- 8 prefill pods (1 GPU each) for prompt processing
- 8 decode pods (1 GPU each + routing-proxy sidecar) for token generation
- GAIE EPP for intelligent P/D routing
- Istio gateway for external access
- Total: 16 GPUs across 16 pods

Key Configuration Pattern:
The llm-d-modelservice chart uses pure Kubernetes pod replication for data parallelism, NOT vLLM's internal --data-parallel-size flag.

Correct pattern (DP8TP1):
- replicas: 8 (creates 8 Kubernetes pods)
- NO parallelism section
- nvidia.com/gpu: "1" (1 GPU per pod)
- CUDA_VISIBLE_DEVICES: "0" (single GPU visibility)

This differs from vllm-native multi-node DP which uses --data-parallel-size internally with a coordinator process.

Performance Results (1K input / 1K output):
- Concurrency 32:  3,710 tok/s output, 5,463 tok/s peak
- Concurrency 64:  5,814 tok/s output, 9,195 tok/s peak
- Concurrency 128: 7,590 tok/s output, 15,252 tok/s peak

Files Added:
- scripts/k8s/llm-d/README.md: Comprehensive deployment documentation
- scripts/k8s/llm-d/deploy.sh: Deployment script with prerequisite checks
- scripts/k8s/llm-d/cleanup.sh: Safe cleanup preserving cached models
- scripts/k8s/llm-d/helmfile.yaml.gotmpl: Multi-release deployment template
- scripts/k8s/llm-d/values.yaml: Model service configuration
- scripts/k8s/llm-d/gaie-llama31/: GAIE EPP configuration
- scripts/k8s/llm-d/gateway-configs/: Gateway configurations for different platforms