### PR TITLE
Fix the logic for vllm_native

### DIFF
--- a/scripts/k8s/llama3/vllm-native/values.yaml
+++ b/scripts/k8s/llama3/vllm-native/values.yaml
@@ -1,4 +1,4 @@
-multinode: false  # Not using chart's multinode, doing manual
+multinode: false
 
 modelArtifacts:
   uri: "hf://meta-llama/Llama-3.1-8B-Instruct"
@@ -25,10 +25,10 @@ routing:
 # RANK 0 - MASTER (using "decode" section)
 decode:
   parallelism:
-    tensor: 1  # No tensor parallelism (TP=1)
-    data: 8    # 8 data parallel workers (one per GPU)
+    tensor: 8  # TP=8 (8 GPUs per pod)
+    data: 2    # DP=2 (2 pods total)
   create: true
-  replicas: 1  # Only 1 master pod
+  replicas: 1  # Only 1 master pod with 8 GPUs
 
   # Service configuration - CRITICAL for rank 1 to connect
   service:
@@ -56,7 +56,7 @@ decode:
     modelCommand: vllmServe
     args:
       - "--tensor-parallel-size"
-      - "1"
+      - "8"                    # Use 8 GPUs per pod via TP
       - "--data-parallel-size"
       - "2"                    # 2 ranks (2 pods)
       - "--data-parallel-rank"
@@ -69,14 +69,14 @@ decode:
       - "128"
       - "--max-model-len"
       - "32000"
-      - "--disable-uvicorn-access-log"
+      - "--disable-log-requests"
     env:
       - name: POD_IP
         valueFrom:
           fieldRef:
             fieldPath: status.podIP
       - name: VLLM_LOGGING_LEVEL
-        value: DEBUG
+        value: INFO
     ports:
       - containerPort: 8000
         name: http
@@ -88,12 +88,12 @@ decode:
       limits:
         memory: 800Gi
         cpu: "180"
-        nvidia.com/gpu: "8"
+        nvidia.com/gpu: "8"  # 8 GPUs on this pod
       requests:
         memory: 800Gi
         cpu: "180"
         nvidia.com/gpu: "8"
-    mountModelVolume: true  # Uses PVC - model cached!
+    mountModelVolume: true  # Helm handles PVC automatically
     volumeMounts:
     - name: metrics-volume
       mountPath: /.config
@@ -114,10 +114,10 @@ decode:
 # RANK 1 - WORKER (cleverly using "prefill" section)
 prefill:
   parallelism:
-    tensor: 1  # No tensor parallelism (TP=1)
-    data: 8    # 8 data parallel workers (one per GPU)
+    tensor: 8  # TP=8 (8 GPUs per pod)
+    data: 2    # DP=2 (2 pods total)
   create: true
-  replicas: 1  # Only 1 worker pod
+  replicas: 1  # Only 1 worker pod with 8 GPUs
 
   # Ensure this goes to different node than rank 0
   podAntiAffinity:
@@ -143,9 +143,9 @@ prefill:
     modelCommand: vllmServe
     args:
       - "--tensor-parallel-size"
-      - "1"
+      - "8"                    # Use 8 GPUs per pod via TP
       - "--data-parallel-size"
-      - "2"                    # 2 ranks (same as rank 0)
+      - "2"                    # 2 ranks (2 pods)
       - "--data-parallel-rank"
       - "1"                    # THIS IS RANK 1 (WORKER)
       - "--data-parallel-address"
@@ -158,10 +158,10 @@ prefill:
       - "128"
       - "--max-model-len"
       - "32000"
-      - "--disable-uvicorn-access-log"
+      - "--disable-log-requests"
     env:
       - name: VLLM_LOGGING_LEVEL
-        value: DEBUG
+        value: INFO
     ports:
       - containerPort: 8000
         name: http
@@ -173,7 +173,7 @@ prefill:
       limits:
         memory: 800Gi
         cpu: "180"
-        nvidia.com/gpu: "8"
+        nvidia.com/gpu: "8"  # 8 GPUs on this pod
       requests:
         memory: 800Gi
         cpu: "180"


### PR DESCRIPTION
Updated the configuration for vLLM-Native which uses DP-Coordinator to handle the load-balancing for the requests.
Earlier, we were using an incorrect approach where all the requests were being processed by only 2 GPUs (one each from master and worker node), which led to having low throughput values.
Realised that we need to have all the 16 GPU workers handling the requests (with each pod having 8 GPU workers).

This changes fixes the configuration, and following is the configuration:
```
Pods: 2 pods - Rank 0 master (8 GPUs) + Rank 1 worker (8 GPUs) = 16 GPUs total
Request flow: Client → Rank 0 HTTP API (port 8000) → vLLM DP Coordinator → distributes work to 2 DP ranks via RPC (port 13345) → each rank processes on 8 GPUs using TP → response from Rank 0.
Load balancing: Internal vLLM DP Coordinator in Rank 0 distributes work across 2 DP ranks, each rank uses Tensor Parallelism (TP=8) to process on 8 GPUs in parallel.
Services: One service pointing to Rank 0 only (ms-llama31-multinode-llm-d-modelservice-decode:8000,13345)
Configuration: 
Rank 0: --tensor-parallel-size 8 --data-parallel-size 2 --data-parallel-rank 0 --data-parallel-address $(POD_IP) --data-parallel-rpc-port 13345, 

Rank 1: --tensor-parallel-size 8 --data-parallel-size 2 --data-parallel-rank 1 --data-parallel-address ms-llama31-multinode-llm-d-modelservice-decode.llm-d-llama31-multinode.svc.cluster.local --data-parallel-rpc-port 13345
```

Verified from the GPU utilization that both master and decode workers are receiving the requests, and all the 8 GPU workers from each node are processing them.
Commands for verification:
1. Decode server (Master node): `watch -n 1 kubectl exec -n llm-d-llama31-multinode \
    $(kubectl get pod -n llm-d-llama31-multinode -l llm-d.ai/role=decode -o jsonpath='{.items[0].metadata.name}') \
    -c vllm -- nvidia-smi --query-gpu=utilization.gpu --format=csv,noheader`
2. Prefill server (Rank-1 node): `watch -n 1 kubectl exec -n llm-d-llama31-multinode \
    $(kubectl get pod -n llm-d-llama31-multinode -l llm-d.ai/role=prefill -o jsonpath='{.items[0].metadata.name}') \
    -c vllm -- nvidia-smi --query-gpu=utilization.gpu --format=csv,noheader`
