### PR TITLE
Perf: Vllm-router implementation for deepseek-v3.1

### DIFF
--- a/scripts/k8s/deepseek-v31/vllm-router/README.md
+++ b/scripts/k8s/deepseek-v31/vllm-router/README.md
@@ -1,0 +1,180 @@
+# DeepSeek V3.1 with vllm-router (P/D Disaggregation)
+
+This directory contains configurations for deploying DeepSeek V3.1 with Prefill/Decode disaggregation using vllm-router.
+
+## Architecture
+
+- **Model**: DeepSeek-V3.1 (~700GB)
+- **Prefill Pod**: 1 pod with TP=8 (8 H100 GPUs)
+- **Decode Pod**: 1 pod with TP=8 (8 H100 GPUs)
+- **Routing**: vllm-router with consistent_hash policy
+- **Total GPUs**: 16 H100 GPUs
+
+## Prerequisites
+
+1. Kubernetes cluster with:
+   - At least 16 H100 GPUs available
+   - GPU operator installed
+
+2. HuggingFace token with access to DeepSeek-V3.1 model
+
+## Deployment
+
+### Step 1: Set HF Token (Optional)
+
+```bash
+export HF_TOKEN=hf_xxxxx
+```
+
+Or create secret manually:
+
+```bash
+kubectl create namespace vllm-router-deepseek-v31
+kubectl create secret generic llm-d-hf-token \
+  --from-literal=HF_TOKEN=hf_xxxxx \
+  -n vllm-router-deepseek-v31
+```
+
+### Step 2: Deploy
+
+```bash
+./deploy.sh
+```
+
+This will:
+- Create namespace and secret (if not exists)
+- Deploy prefill and decode pods via Helm
+- Create backend services
+- Deploy vllm-router
+
+### Step 3: Wait for Pods
+
+The deployment takes 10-15 minutes on first run (model download ~700GB). Subsequent deployments take 3-5 minutes.
+
+```bash
+kubectl get pods -n vllm-router-deepseek-v31 -w
+```
+
+Expected pods:
+- 1 prefill pod (1/1 ready)
+- 1 decode pod (1/1 ready)
+- 1 vllm-router pod (1/1 ready)
+
+## Configuration
+
+### Model Configuration
+
+The `values.yaml` file contains the main configuration:
+
+- **Tensor Parallelism**: 8 (uses all 8 GPUs per pod)
+- **Data Parallelism**: 1 (single replica per role)
+- **Max Model Length**: 32,000 tokens
+- **Block Size**: 128
+- **Memory**: 1500Gi per pod
+- **KV Transfer**: NixlConnector for P/D communication
+
+### DeepSeek V3.1 Optimizations
+
+The configuration includes several optimizations:
+
+1. **Chunked Prefill**: Enabled for better throughput
+2. **Max Batched Tokens**: 32,768 for efficient batching
+3. **Scheduler Steps**: 10 for better scheduling
+4. **Expert Parallelism**: Distributes 256 MoE experts across 8 GPUs
+5. **VLLM V1**: Enabled for CUDA graphs and better performance
+6. **Shared Memory**: 32Gi for large model operations
+
+### vllm-router Configuration
+
+The router is configured with:
+- **Policy**: consistent_hash for request routing
+- **Data Parallel Size**: 1 (single instance per role)
+- **Port**: 10001 for client requests
+- **Metrics Port**: 29000 for monitoring
+
+## Benchmarking
+
+Run benchmarks with:
+
+```bash
+./run-benchmark.sh [num_prompts] [concurrency]
+```
+
+Examples:
+```bash
+./run-benchmark.sh           # 100 prompts, 16 concurrency
+./run-benchmark.sh 200 32    # 200 prompts, 32 concurrency
+./run-benchmark.sh 200 64    # 200 prompts, 64 concurrency
+```
+
+## Cleanup
+
+```bash
+./cleanup.sh
+```
+
+To completely remove including cached model:
+```bash
+kubectl delete namespace vllm-router-deepseek-v31
+```
+
+## Files
+
+- `values.yaml` - vLLM backend configuration (prefill + decode)
+- `helmfile.yaml` - Helmfile for deploying backends
+- `deploy.sh` - Deployment script
+- `cleanup.sh` - Cleanup script
+- `run-benchmark.sh` - Benchmarking script
+- `backend-services.yaml` - Service definitions for prefill/decode
+- `router-deployment.yaml` - vllm-router deployment
+- `router-service.yaml` - vllm-router service (ClusterIP + NodePort)
+
+## Troubleshooting
+
+### Check pod logs
+
+```bash
+# Prefill pod
+kubectl logs -n vllm-router-deepseek-v31 -l llm-d.ai/role=prefill -f
+
+# Decode pod
+kubectl logs -n vllm-router-deepseek-v31 -l llm-d.ai/role=decode -f
+
+# vllm-router
+kubectl logs -n vllm-router-deepseek-v31 -l app=vllm-router -f
+```
+
+### Test router endpoint
+
+```bash
+# Port forward to router
+kubectl port-forward -n vllm-router-deepseek-v31 svc/vllm-router-deepseek-v31 10001:10001
+
+# Test in another terminal
+curl -X POST "http://localhost:10001/v1/completions" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "deepseek-ai/DeepSeek-V3.1",
+    "prompt": "Hello, how are you?",
+    "max_tokens": 50
+  }'
+```
+
+### Check router health
+
+```bash
+curl http://localhost:10001/health
+```
+
+## Comparison with llm-d
+
+This setup uses vllm-router instead of GAIE (Gateway API Inference Extension). Key differences:
+
+| Feature | vllm-router | llm-d (GAIE) |
+|---------|-------------|--------------|
+| Routing | consistent_hash policy | Queue scoring + prefix matching |
+| Components | 3 pods (prefill, decode, router) | 4 pods (prefill, decode, EPP, gateway) |
+| Integration | Standalone router | Istio gateway integration |
+| Metrics | vllm-router metrics | GAIE EPP metrics + Istio |
+
+Both setups use the same backend configuration (TP=8, expert parallelism, etc.).

--- a/scripts/k8s/deepseek-v31/vllm-router/backend-services.yaml
+++ b/scripts/k8s/deepseek-v31/vllm-router/backend-services.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ms-deepseek-v31-llm-d-modelservice-prefill
+  namespace: vllm-router-deepseek-v31
+  labels:
+    app: vllm-backend
+    role: prefill
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8000
+    targetPort: 8000
+    protocol: TCP
+    name: http
+  selector:
+    llm-d.ai/role: prefill
+    llm-d.ai/inferenceServing: "true"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ms-deepseek-v31-llm-d-modelservice-decode
+  namespace: vllm-router-deepseek-v31
+  labels:
+    app: vllm-backend
+    role: decode
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8200
+    targetPort: 8200
+    protocol: TCP
+    name: http
+  selector:
+    llm-d.ai/role: decode
+    llm-d.ai/inferenceServing: "true"

--- a/scripts/k8s/deepseek-v31/vllm-router/cleanup.sh
+++ b/scripts/k8s/deepseek-v31/vllm-router/cleanup.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Cleanup DeepSeek V3.1 vllm-router deployment
+# This script removes all deployed resources
+
+set -e
+
+NAMESPACE="vllm-router-deepseek-v31"
+
+echo "=========================================="
+echo "Cleaning up vllm-router deployment"
+echo "=========================================="
+echo "Namespace: $NAMESPACE"
+echo ""
+
+# Delete router
+echo "Deleting vllm-router..."
+kubectl delete -f router-service.yaml --ignore-not-found=true
+kubectl delete -f router-deployment.yaml --ignore-not-found=true
+
+# Delete backend services
+echo "Deleting backend services..."
+kubectl delete -f backend-services.yaml --ignore-not-found=true
+
+# Delete helmfile releases
+echo "Deleting vLLM prefill and decode pods..."
+cd "$(dirname "$0")"
+helmfile destroy -n "$NAMESPACE" || echo "Helmfile destroy completed with warnings"
+
+echo ""
+echo "=========================================="
+echo "Cleanup completed!"
+echo "=========================================="
+echo ""
+echo "Note: Namespace $NAMESPACE still exists with:"
+echo "  - Secret (llm-d-hf-token)"
+echo "  - PVCs (cached model artifacts)"
+echo ""
+echo "To completely remove everything including cached model:"
+echo "  kubectl delete namespace $NAMESPACE"
+echo ""

--- a/scripts/k8s/deepseek-v31/vllm-router/deploy.sh
+++ b/scripts/k8s/deepseek-v31/vllm-router/deploy.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+
+# Deploy vLLM with vllm-router (P-D disaggregation) for DeepSeek V3.1
+# Usage: ./deploy.sh
+
+set -e
+
+NAMESPACE="vllm-router-deepseek-v31"
+
+echo "=========================================="
+echo "Deploying vLLM with vllm-router (P-D)"
+echo "=========================================="
+echo "Namespace: $NAMESPACE"
+echo "Model: DeepSeek-V3.1"
+echo ""
+
+# Check if namespace exists, create if not
+if ! kubectl get namespace "$NAMESPACE" &> /dev/null; then
+    echo "Creating namespace: $NAMESPACE"
+    kubectl create namespace "$NAMESPACE"
+fi
+
+# Check if HF token secret exists
+if ! kubectl get secret llm-d-hf-token -n "$NAMESPACE" &> /dev/null; then
+    echo ""
+    echo "HuggingFace token secret 'llm-d-hf-token' not found in namespace $NAMESPACE"
+
+    # Check if HF_TOKEN environment variable is set
+    if [ -z "$HF_TOKEN" ]; then
+        echo "ERROR: HF_TOKEN environment variable is not set"
+        echo ""
+        echo "Please set your HuggingFace token as an environment variable:"
+        echo "  export HF_TOKEN=hf_your_token_here"
+        echo ""
+        echo "Or create the secret manually:"
+        echo "  kubectl create secret generic llm-d-hf-token \\"
+        echo "    --from-literal=HF_TOKEN=hf_xxxxx \\"
+        echo "    -n $NAMESPACE"
+        echo ""
+        exit 1
+    fi
+
+    echo "Creating HF token secret from environment variable..."
+    kubectl create secret generic llm-d-hf-token \
+        --from-literal=HF_TOKEN="$HF_TOKEN" \
+        -n "$NAMESPACE"
+    echo "✓ HF token secret created successfully"
+fi
+
+# Deploy using helmfile
+echo ""
+echo "Deploying vLLM prefill and decode with helmfile..."
+cd "$(dirname "$0")"
+helmfile apply -n "$NAMESPACE"
+
+# Deploy backend services
+echo ""
+echo "Deploying backend services..."
+kubectl apply -f backend-services.yaml
+
+echo ""
+echo "Waiting for vLLM prefill and decode to be ready..."
+echo "This may take 10-15 minutes on first deployment (model download ~700GB)"
+echo ""
+
+kubectl wait --for=condition=ready --timeout=1200s \
+    pod -l llm-d.ai/role=prefill -n "$NAMESPACE" 2>/dev/null || \
+    echo "Prefill pod not ready yet, continuing..."
+
+kubectl wait --for=condition=ready --timeout=1200s \
+    pod -l llm-d.ai/role=decode -n "$NAMESPACE" 2>/dev/null || \
+    echo "Decode pod not ready yet, continuing..."
+
+# Deploy vllm-router
+echo ""
+echo "Deploying vllm-router..."
+kubectl apply -f router-deployment.yaml
+kubectl apply -f router-service.yaml
+
+echo ""
+echo "=========================================="
+echo "Deployment Status"
+echo "=========================================="
+kubectl get pods -n "$NAMESPACE"
+
+echo ""
+echo "=========================================="
+echo "Next Steps"
+echo "=========================================="
+echo ""
+echo "1. Check deployment status:"
+echo "   kubectl get all -n $NAMESPACE"
+echo ""
+echo "2. View logs:"
+echo "   kubectl logs -n $NAMESPACE -l llm-d.ai/role=prefill -f"
+echo "   kubectl logs -n $NAMESPACE -l llm-d.ai/role=decode -f"
+echo "   kubectl logs -n $NAMESPACE -l app=vllm-router -f"
+echo ""
+echo "3. Port forward to router:"
+echo "   kubectl port-forward -n $NAMESPACE svc/vllm-router-deepseek-v31 10001:10001"
+echo ""
+echo "4. Run benchmarks:"
+echo "   ./run-benchmark.sh"
+echo ""

--- a/scripts/k8s/deepseek-v31/vllm-router/helmfile.yaml
+++ b/scripts/k8s/deepseek-v31/vllm-router/helmfile.yaml
@@ -1,0 +1,14 @@
+repositories:
+  - name: llm-d-modelservice
+    url: https://llm-d-incubation.github.io/llm-d-modelservice/
+
+releases:
+  - name: ms-deepseek-v31
+    namespace: vllm-router-deepseek-v31
+    chart: llm-d-modelservice/llm-d-modelservice
+    version: v0.2.11
+    installed: true
+    values:
+      - values.yaml
+    labels:
+      kind: vllm-backends

--- a/scripts/k8s/deepseek-v31/vllm-router/router-deployment.yaml
+++ b/scripts/k8s/deepseek-v31/vllm-router/router-deployment.yaml
@@ -1,0 +1,69 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vllm-router-deepseek-v31
+  namespace: vllm-router-deepseek-v31
+  labels:
+    app: vllm-router
+    mode: pd-disaggregation
+    model: deepseek-v31
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: vllm-router
+      mode: pd-disaggregation
+      model: deepseek-v31
+  template:
+    metadata:
+      labels:
+        app: vllm-router
+        mode: pd-disaggregation
+        model: deepseek-v31
+    spec:
+      containers:
+      - name: router
+        image: 584868043064.dkr.ecr.us-west-2.amazonaws.com/dev-vllm-repo:router-dp-fallback
+        command:
+          - vllm-router
+          - --pd-disaggregation
+          - --prefill
+          - http://ms-deepseek-v31-llm-d-modelservice-prefill.vllm-router-deepseek-v31.svc.cluster.local:8000
+          - --decode
+          - http://ms-deepseek-v31-llm-d-modelservice-decode.vllm-router-deepseek-v31.svc.cluster.local:8200
+          - --host
+          - "0.0.0.0"
+          - --port
+          - "10001"
+          - --data-parallel-size
+          - "1"
+          - --policy
+          - consistent_hash
+          - --log-level
+          - info
+        ports:
+        - containerPort: 10001
+          name: router
+          protocol: TCP
+        - containerPort: 29000
+          name: metrics
+          protocol: TCP
+        resources:
+          requests:
+            cpu: "2"
+            memory: "4Gi"
+          limits:
+            cpu: "4"
+            memory: "8Gi"
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 10001
+          initialDelaySeconds: 10
+          periodSeconds: 30
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 10001
+          initialDelaySeconds: 5
+          periodSeconds: 10

--- a/scripts/k8s/deepseek-v31/vllm-router/router-service.yaml
+++ b/scripts/k8s/deepseek-v31/vllm-router/router-service.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: vllm-router-deepseek-v31
+  namespace: vllm-router-deepseek-v31
+  labels:
+    app: vllm-router
+    mode: pd-disaggregation
+    model: deepseek-v31
+spec:
+  selector:
+    app: vllm-router
+    mode: pd-disaggregation
+    model: deepseek-v31
+  ports:
+  - name: router
+    port: 10001
+    targetPort: 10001
+    protocol: TCP
+  - name: metrics
+    port: 29000
+    targetPort: 29000
+    protocol: TCP
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: vllm-router-deepseek-v31-nodeport
+  namespace: vllm-router-deepseek-v31
+  labels:
+    app: vllm-router
+    mode: pd-disaggregation
+    model: deepseek-v31
+spec:
+  selector:
+    app: vllm-router
+    mode: pd-disaggregation
+    model: deepseek-v31
+  ports:
+  - name: router
+    port: 10001
+    targetPort: 10001
+    nodePort: 30015
+    protocol: TCP
+  - name: metrics
+    port: 29000
+    targetPort: 29000
+    nodePort: 30016
+    protocol: TCP
+  type: NodePort

--- a/scripts/k8s/deepseek-v31/vllm-router/run-benchmark.sh
+++ b/scripts/k8s/deepseek-v31/vllm-router/run-benchmark.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+# Run benchmark for DeepSeek V3.1 with vllm-router (P-D disaggregation)
+# This script runs the benchmark from inside a pod against the vllm-router
+# Usage: ./run-benchmark.sh [num_prompts] [concurrency]
+#
+# Examples:
+#   ./run-benchmark.sh           # 100 prompts, 16 concurrency
+#   ./run-benchmark.sh 200 32    # 200 prompts, 32 concurrency
+
+set -e
+
+NAMESPACE="vllm-router-deepseek-v31"
+NUM_PROMPTS="${1:-100}"
+MAX_CONCURRENCY="${2:-16}"
+MODEL="deepseek-ai/DeepSeek-V3.1"
+INPUT_LEN="${INPUT_LEN:-1000}"
+OUTPUT_LEN="${OUTPUT_LEN:-1000}"
+ROUTER_SERVICE="vllm-router-deepseek-v31"
+ROUTER_PORT="10001"
+
+echo "=========================================="
+echo "Running Benchmark - vllm-router (P-D)"
+echo "=========================================="
+echo "Namespace: $NAMESPACE"
+echo "Model: $MODEL"
+echo "Num Prompts: $NUM_PROMPTS"
+echo "Concurrency: $MAX_CONCURRENCY"
+echo "Input Length: $INPUT_LEN"
+echo "Output Length: $OUTPUT_LEN"
+echo "Router Service: $ROUTER_SERVICE:$ROUTER_PORT"
+echo ""
+
+# Get any vllm pod to run benchmark from (needs vllm bench command)
+VLLM_POD=$(kubectl get pod -n "$NAMESPACE" -l llm-d.ai/role=prefill -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
+if [ -z "$VLLM_POD" ]; then
+    # Try decode pods if prefill not found
+    VLLM_POD=$(kubectl get pod -n "$NAMESPACE" -l llm-d.ai/role=decode -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
+fi
+if [ -z "$VLLM_POD" ]; then
+    echo "Error: Cannot find vllm pod to run benchmark from"
+    exit 1
+fi
+
+echo "Running benchmark from pod: $VLLM_POD"
+echo ""
+echo "Starting benchmark..."
+echo "This may take several minutes..."
+echo ""
+
+# Build benchmark command - connect to router service from inside the cluster
+BENCH_CMD="vllm bench serve \
+    --dataset-name random \
+    --num-prompts $NUM_PROMPTS \
+    --model $MODEL \
+    --random-input-len $INPUT_LEN \
+    --random-output-len $OUTPUT_LEN \
+    --endpoint /v1/completions \
+    --max-concurrency $MAX_CONCURRENCY \
+    --save-result \
+    --ignore-eos \
+    --served-model-name $MODEL \
+    --host $ROUTER_SERVICE \
+    --port $ROUTER_PORT"
+
+# Run benchmark from inside the vllm pod
+kubectl exec -n "$NAMESPACE" "$VLLM_POD" -c vllm -- bash -c "$BENCH_CMD"
+
+echo ""
+echo "=========================================="
+echo "Benchmark completed!"
+echo "=========================================="
+echo ""
+echo "Configuration:"
+echo "  Routing: vllm-router with consistent_hash policy"
+echo "  Architecture: 1 prefill pod + 1 decode pod (8 GPUs each, TP=8)"
+echo "  Concurrency: $MAX_CONCURRENCY"
+echo "  Prompts: $NUM_PROMPTS"
+echo ""
+echo "Compare with llm-d by running:"
+echo "  cd ../llm-d"
+echo "  ./run-benchmark.sh $NUM_PROMPTS $MAX_CONCURRENCY"
+echo ""

--- a/scripts/k8s/deepseek-v31/vllm-router/values.yaml
+++ b/scripts/k8s/deepseek-v31/vllm-router/values.yaml
@@ -1,0 +1,179 @@
+multinode: false
+
+modelArtifacts:
+  uri: "hf://deepseek-ai/DeepSeek-V3.1"
+  size: 1500Gi
+  authSecretName: "llm-d-hf-token"
+  name: "deepseek-ai/DeepSeek-V3.1"
+
+routing:
+  servicePort: 8000
+  proxy:
+    image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.3.0
+    connector: nixlv2
+    secure: false
+
+  inferencePool:
+    create: false
+
+  httpRoute:
+    create: false
+
+  epp:
+    create: false
+
+decode:
+  create: true
+  replicas: 1  # Single pod with TP=8 (8 GPUs)
+  parallelism:
+    tensor: 8
+    data: 1
+  monitoring:
+    podmonitor:
+      enabled: true
+      portName: "metrics" # decode vLLM service port (from routing.proxy.targetPort)
+      path: "/metrics"
+      interval: "30s"
+  containers:
+  - name: "vllm"
+    image: ghcr.io/llm-d/llm-d-cuda:v0.3.0
+    modelCommand: vllmServe
+    args:
+      - "--tensor-parallel-size"
+      - "8"
+      # - "--distributed-executor-backend"
+      # - "mp"
+      - "--block-size"
+      - "128"
+      - "--kv-transfer-config"
+      - '{"kv_connector":"NixlConnector", "kv_role":"kv_both"}'
+      - "--disable-uvicorn-access-log"
+      - "--max-model-len"
+      - "32000"
+      # DeepSeek V3.1 optimizations
+      - "--enable-chunked-prefill"
+      - "--enable-expert-parallel"
+    env:
+      - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      - name: VLLM_LOGGING_LEVEL
+        value: INFO
+      - name: VLLM_USE_V1
+        value: "1"
+      - name: CUDA_VISIBLE_DEVICES
+        value: "0,1,2,3,4,5,6,7"
+      - name: HF_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: llm-d-hf-token
+            key: HF_TOKEN
+    ports:
+      - containerPort: 8200
+        name: metrics
+        protocol: TCP
+    resources:
+      limits:
+        memory: 1500Gi
+        cpu: "180"
+        nvidia.com/gpu: "8"
+      requests:
+        memory: 1500Gi
+        cpu: "180"
+        nvidia.com/gpu: "8"
+    mountModelVolume: true
+    volumeMounts:
+    - name: metrics-volume
+      mountPath: /.config
+    - name: shm
+      mountPath: /dev/shm
+    - name: torch-compile-cache
+      mountPath: /.cache
+  volumes:
+  - name: metrics-volume
+    emptyDir: {}
+  - name: shm
+    emptyDir:
+      medium: Memory
+      sizeLimit: "32Gi"
+  - name: torch-compile-cache
+    emptyDir: {}
+
+prefill:
+  create: true
+  replicas: 1  # Single pod with TP=8 (8 GPUs)
+  parallelism:
+    tensor: 8
+    data: 1
+  monitoring:
+    podmonitor:
+      enabled: true
+      portName: "metrics" # decode vLLM service port (from routing.proxy.targetPort)
+      path: "/metrics"
+      interval: "30s"
+  containers:
+  - name: "vllm"
+    image: ghcr.io/llm-d/llm-d-cuda:v0.3.0
+    modelCommand: vllmServe
+    args:
+      - "--tensor-parallel-size"
+      - "8"
+      # - "--distributed-executor-backend"
+      # - "mp"
+      - "--block-size"
+      - "128"
+      - "--kv-transfer-config"
+      - '{"kv_connector":"NixlConnector", "kv_role":"kv_both"}'
+      - "--disable-uvicorn-access-log"
+      - "--max-model-len"
+      - "32000"
+      # DeepSeek V3.1 optimizations
+      - "--enable-chunked-prefill"
+      - "--enable-expert-parallel"
+    env:
+      - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      - name: VLLM_LOGGING_LEVEL
+        value: INFO
+      - name: VLLM_USE_V1
+        value: "1"
+      - name: CUDA_VISIBLE_DEVICES
+        value: "0,1,2,3,4,5,6,7"
+      - name: HF_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: llm-d-hf-token
+            key: HF_TOKEN
+    ports:
+      - containerPort: 8000
+        name: metrics
+        protocol: TCP
+    resources:
+      limits:
+        memory: 1500Gi
+        cpu: "180"
+        nvidia.com/gpu: "8"
+      requests:
+        memory: 1500Gi
+        cpu: "180"
+        nvidia.com/gpu: "8"
+    mountModelVolume: true
+    volumeMounts:
+    - name: metrics-volume
+      mountPath: /.config
+    - name: shm
+      mountPath: /dev/shm
+    - name: torch-compile-cache
+      mountPath: /.cache
+  volumes:
+  - name: metrics-volume
+    emptyDir: {}
+  - name: shm
+    emptyDir:
+      medium: Memory
+      sizeLimit: "32Gi"
+  - name: torch-compile-cache
+    emptyDir: {}


### PR DESCRIPTION
This change adds the implementation for the vllm-router for the deepseek-v3.1 model.

## Architecture

- **Model**: DeepSeek-V3.1 (~700GB)
- **Prefill Pod**: 1 pod with TP=8 (8 H100 GPUs)
- **Decode Pod**: 1 pod with TP=8 (8 H100 GPUs)
- **Routing**: vllm-router with consistent_hash policy
- **Total GPUs**: 16 H100 GPUs

## Testing
The router is benchmarked against all multiple configurations, and all the results are present here: https://docs.google.com/document/d/1d1gi5ex7yCpfMtmCQtwVcsmtOjDIevIOp8HLiA_WlPk/edit?pli=1&tab=t.cn9c4bholtya