### PR TITLE
fix: token bucket wait time calculation to ensure non-negative values

### DIFF
--- a/src/core/token_bucket.rs
+++ b/src/core/token_bucket.rs
@@ -90,8 +90,8 @@ impl TokenBucket {
         // Calculate wait time
         let wait_time = {
             let inner = self.inner.lock().await;
-            let tokens_needed = tokens - inner.tokens;
-            let wait_secs = tokens_needed / self.refill_rate;
+            let tokens_needed = (tokens - inner.tokens).max(0.0);
+            let wait_secs = (tokens_needed / self.refill_rate).max(0.0);
             Duration::from_secs_f64(wait_secs)
         };
 


### PR DESCRIPTION
In the issue, the `Duration::from_secs_f64(wait_secs)` panic happens because `wait_secs` can go negative when `tokens_needed = tokens - inner.tokens` goes negative. 

That can happen even if try_acquire() just failed, because between:
	1.	`try_acquire()` failing and releasing the mutex, and
	2.	`acquire()` re-locking to compute wait_time,

someone else can change inner.tokens (most obviously via return_tokens(), but also via any other code path that refills/adjusts while holding the lock). So you get inner.tokens > tokens, tokens_needed < 0, wait_secs < 0, and boom: Duration refuses negative time. 

fix #25 