### PR TITLE
fix: vllm-pd-disaggregation mode in python cli

### DIFF
--- a/py_src/vllm_router/router.py
+++ b/py_src/vllm_router/router.py
@@ -68,6 +68,7 @@ class Router:
         prometheus_port: Port to expose Prometheus metrics. Default: None
         prometheus_host: Host address to bind the Prometheus metrics server. Default: None
         pd_disaggregation: Enable PD (Prefill-Decode) disaggregated mode. Default: False
+        vllm_pd_disaggregation: Enable vLLM PD (Prefill-Decode) disaggregated mode. Default: False
         prefill_urls: List of (url, bootstrap_port) tuples for prefill servers (PD mode only)
         decode_urls: List of URLs for decode servers (PD mode only)
         prefill_policy: Specific load balancing policy for prefill nodes (PD mode only).
@@ -115,15 +116,15 @@ class Router:
         # Convert RouterArgs to _Router parameters
         args_dict["worker_urls"] = (
             []
-            if args_dict["service_discovery"] or args_dict["pd_disaggregation"]
+            if args_dict["service_discovery"] or args_dict["pd_disaggregation"] or args_dict["vllm_pd_disaggregation"]
             else args_dict["worker_urls"]
         )
         args_dict["policy"] = policy_from_str(args_dict["policy"])
         args_dict["prefill_urls"] = (
-            args_dict["prefill_urls"] if args_dict["pd_disaggregation"] else None
+            args_dict["prefill_urls"] if args_dict["pd_disaggregation"] or args_dict["vllm_pd_disaggregation"] else None
         )
         args_dict["decode_urls"] = (
-            args_dict["decode_urls"] if args_dict["pd_disaggregation"] else None
+            args_dict["decode_urls"] if args_dict["pd_disaggregation"] or args_dict["vllm_pd_disaggregation"] else None
         )
         args_dict["prefill_policy"] = policy_from_str(args_dict["prefill_policy"])
         args_dict["decode_policy"] = policy_from_str(args_dict["decode_policy"])

--- a/py_src/vllm_router/router_args.py
+++ b/py_src/vllm_router/router_args.py
@@ -16,6 +16,7 @@ class RouterArgs:
     # PD-specific configuration
     mini_lb: bool = False
     pd_disaggregation: bool = False  # Enable PD disaggregated mode
+    vllm_pd_disaggregation: bool = False  # Enable vLLM PD disaggregated mode
     prefill_urls: List[tuple] = dataclasses.field(
         default_factory=list
     )  # List of (url, bootstrap_port)
@@ -161,6 +162,11 @@ class RouterArgs:
             f"--{prefix}pd-disaggregation",
             action="store_true",
             help="Enable PD (Prefill-Decode) disaggregated mode",
+        )
+        parser.add_argument(
+            f"--{prefix}vllm-pd-disaggregation",
+            action="store_true",
+            help="Enable vLLM PD (Prefill-Decode) disaggregated mode",
         )
         parser.add_argument(
             f"--{prefix}prefill",
@@ -496,7 +502,7 @@ class RouterArgs:
 
     def _validate_router_args(self):
         # Validate configuration based on mode
-        if self.pd_disaggregation:
+        if self.pd_disaggregation or self.vllm_pd_disaggregation:
             # Validate PD configuration - skip URL requirements if using service discovery
             if not self.service_discovery:
                 if not self.prefill_urls:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,7 @@ struct Router {
     request_timeout_secs: u64,
     request_id_headers: Option<Vec<String>>,
     pd_disaggregation: bool,
+    vllm_pd_disaggregation: bool,
     prefill_urls: Option<Vec<(String, Option<u16>)>>,
     decode_urls: Option<Vec<String>>,
     prefill_policy: Option<PolicyType>,
@@ -139,7 +140,7 @@ impl Router {
             RoutingMode::Regular {
                 worker_urls: vec![],
             }
-        } else if self.pd_disaggregation {
+        } else if self.pd_disaggregation || self.vllm_pd_disaggregation {
             RoutingMode::PrefillDecode {
                 prefill_urls: self.prefill_urls.clone().unwrap_or_default(),
                 decode_urls: self.decode_urls.clone().unwrap_or_default(),
@@ -266,6 +267,7 @@ impl Router {
         request_timeout_secs = 1800,  // Add configurable request timeout
         request_id_headers = None,  // Custom request ID headers
         pd_disaggregation = false,  // New flag for PD mode
+        vllm_pd_disaggregation = false,  // New flag for PD mode
         prefill_urls = None,
         decode_urls = None,
         prefill_policy = None,
@@ -330,6 +332,7 @@ impl Router {
         request_timeout_secs: u64,
         request_id_headers: Option<Vec<String>>,
         pd_disaggregation: bool,
+        vllm_pd_disaggregation: bool,
         prefill_urls: Option<Vec<(String, Option<u16>)>>,
         decode_urls: Option<Vec<String>>,
         prefill_policy: Option<PolicyType>,
@@ -405,6 +408,7 @@ impl Router {
             request_timeout_secs,
             request_id_headers,
             pd_disaggregation,
+            vllm_pd_disaggregation,
             prefill_urls,
             decode_urls,
             prefill_policy,


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

--vllm-pd-disaggregation lost in vllm-router cli but available in rust built binary.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
