### PR TITLE
CI: Publish to PyPI

### DIFF
--- a/.buildkite/release-pipeline.yml
+++ b/.buildkite/release-pipeline.yml
@@ -7,27 +7,74 @@ env:
 
 steps:
   # ============================================================================
+  # Version Consistency Check
+  # ============================================================================
+  - label: ":mag: Verify Version Tag Matches pyproject.toml"
+    key: "version-check"
+    command: |
+      set -euo pipefail
+
+      # Extract version from git tag (e.g., v0.1.0 -> 0.1.0)
+      TAG_VERSION="$${BUILDKITE_TAG#v}"
+      echo "Git tag version: $TAG_VERSION"
+
+      # Extract version from pyproject.toml
+      PYPROJECT_VERSION=$(grep -E '^version\s*=' pyproject.toml | sed 's/.*=\s*"\(.*\)"/\1/')
+      echo "pyproject.toml version: $PYPROJECT_VERSION"
+
+      # Compare versions
+      if [ "$TAG_VERSION" != "$PYPROJECT_VERSION" ]; then
+        echo "❌ ERROR: Version mismatch!"
+        echo "   Git tag version:       $TAG_VERSION"
+        echo "   pyproject.toml version: $PYPROJECT_VERSION"
+        echo ""
+        echo "Please update pyproject.toml to match the git tag before releasing."
+        exit 1
+      fi
+
+      echo "✅ Version check passed: $TAG_VERSION"
+    if: build.tag =~ /^v.*/
+    agents:
+      queue: "cpu_queue_postmerge"
+
+  - wait
+
+  # ============================================================================
   # Build Release Artifacts
   # ============================================================================
   - label: ":package: Build Release Artifacts"
-    command: |
-      # Build Rust binary for release
-      cargo build --release
+    key: "build_wheels"
+    plugins:
+      - docker#v5.11.0:
+          image: "rustlang/rust:nightly-bullseye"
+          workdir: /workdir
+          volumes:
+            - ".:/workdir"
+          environment:
+            - "CARGO_INCREMENTAL=0"
+            - "RUST_BACKTRACE=1"
+          command:
+            - bash
+            - -c
+            - |
+              set -euo pipefail
 
-      # Build Python wheels for multiple platforms
-      pip install -U pip setuptools wheel setuptools-rust cibuildwheel
+              # Install system dependencies
+              apt-get update && apt-get install -y pkg-config libssl-dev protobuf-compiler python3 python3-pip
 
-      # Build wheels for Linux
-      python -m build
+              # Build Rust binary for release
+              cargo build --release
 
-      # If cibuildwheel is needed for multiple Python versions:
-      # cibuildwheel --platform linux
+              # Build Python wheels
+              pip3 install -U pip setuptools wheel setuptools-rust build
+              python3 -m build
     artifact_paths:
       - "target/release/vllm-router"
       - "dist/*.whl"
       - "dist/*.tar.gz"
+    depends_on: "version-check"
     agents:
-      queue: "cpu_queue_premerge"
+      queue: "cpu_queue_postmerge"
 
   - wait
 
@@ -38,10 +85,10 @@ steps:
     command: |
       buildkite-agent artifact download "target/release/vllm-router" .
       chmod +x target/release/vllm-router
-      ./target/release/vllm-router --version
-      ./target/release/vllm-router --help
+      docker run --rm -v "$$PWD:/workdir" -w /workdir rustlang/rust:nightly-bullseye ./target/release/vllm-router --version
+      docker run --rm -v "$$PWD:/workdir" -w /workdir rustlang/rust:nightly-bullseye ./target/release/vllm-router --help
     agents:
-      queue: "cpu_queue_premerge"
+      queue: "cpu_queue_postmerge"
 
   - label: ":python: Test Python Wheel"
     command: |
@@ -49,70 +96,44 @@ steps:
       pip install dist/*.whl
       python -c "import vllm_router; print(vllm_router.__version__)"
     agents:
-      queue: "cpu_queue_premerge"
+      queue: "cpu_queue_postmerge"
 
   - wait
 
   # ============================================================================
   # Publish to PyPI
   # ============================================================================
-  - block: ":pypi: Publish to PyPI?"
-    prompt: "Ready to publish to PyPI? This action cannot be undone."
+  - label: ":python: Publish to PyPI"
+    key: "publish-pypi"
+    plugins:
+      - docker#v5.11.0:
+          image: "python:3.11-slim"
+          workdir: /workdir
+          volumes:
+            - ".:/workdir"
+          environment:
+            - "TWINE_USERNAME=__token__"
+            - "TWINE_PASSWORD"
+          propagate-environment: true
+          command:
+            - bash
+            - -c
+            - |
+              set -euo pipefail
 
-  - label: ":pypi: Publish to PyPI"
-    command: |
-      buildkite-agent artifact download "dist/*" .
-      pip install twine
+              pip install twine
 
-      # Upload to PyPI (requires PYPI_TOKEN environment variable)
-      twine upload dist/*.whl dist/*.tar.gz --username __token__ --password "$PYPI_TOKEN"
+              echo "📦 Uploading packages to PyPI..."
+              twine upload dist/* --verbose
+
+              echo "✅ Successfully published to PyPI!"
+    env:
+      TWINE_PASSWORD: "${PYPI_TOKEN}"
+    depends_on: "build_wheels"
     if: build.tag =~ /^v.*/
+    soft_fail: false
     agents:
-      queue: "cpu_queue_premerge"
-
-  # ============================================================================
-  # Build and Publish Docker Images
-  # ============================================================================
-  - label: ":docker: Build Release Docker Images"
-    command: |
-      # Extract version from tag (e.g., v1.2.3 -> 1.2.3)
-      VERSION="${BUILDKITE_TAG#v}"
-
-      # Build Docker image
-      docker build -f Dockerfile.router \
-        -t vllm-router:${VERSION} \
-        -t vllm-router:latest \
-        --build-arg VERSION=${VERSION} \
-        .
-
-      # Save image info
-      docker images vllm-router
-    artifact_paths:
-      - "docker-images.txt"
-    agents:
-      queue: "cpu_queue_premerge"
-
-  - block: ":docker: Push Docker Images?"
-    prompt: "Ready to push Docker images? Requires Docker Hub credentials."
-
-  - label: ":docker: Publish Docker Images"
-    command: |
-      VERSION="${BUILDKITE_TAG#v}"
-
-      # Login to Docker Hub (requires DOCKER_USERNAME and DOCKER_PASSWORD)
-      echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-
-      # Push versioned image
-      docker push vllm-router:${VERSION}
-
-      # Push latest tag
-      docker push vllm-router:latest
-
-      # Logout
-      docker logout
-    if: build.tag =~ /^v.*/
-    agents:
-      queue: "cpu_queue_premerge"
+      queue: "cpu_queue_postmerge"
 
   # ============================================================================
   # Create GitHub Release
@@ -124,12 +145,12 @@ steps:
       buildkite-agent artifact download "dist/*" .
 
       # Create GitHub release (requires gh CLI and GITHUB_TOKEN)
-      gh release create ${BUILDKITE_TAG} \
-        --title "Release ${BUILDKITE_TAG}" \
-        --notes "Release ${BUILDKITE_TAG} of vLLM Router" \
+      gh release create $${BUILDKITE_TAG} \
+        --title "Release $${BUILDKITE_TAG}" \
+        --notes "Release $${BUILDKITE_TAG} of vLLM Router" \
         target/release/vllm-router \
         dist/*.whl \
         dist/*.tar.gz
     if: build.tag =~ /^v.*/
     agents:
-      queue: "cpu_queue_premerge"
+      queue: "cpu_queue_postmerge"


### PR DESCRIPTION
## Purpose
We want to be able to install vllm-router via pip: [context](https://docs.google.com/document/d/1roIdNVeICqj_5x_4BuwWB4rzmMkIVbS5IrHwM7Vqe5k/edit?usp=sharing)
Updating release-pipeline.yml to upload the python wheel to pypi.

- Add Version Consistency Check to check version tag and pyproject.toml version match
- Build wheel same way as in `pipeline.yml`
- Publish to PyPI

Tested pipeline [here](https://buildkite.com/vllm/router-release/builds/14/steps/canvas) but we need to merge this so we can trigger a test tag to run the PyPI publish step

