### PR TITLE
Fix router selection when vLLM P/D flag is enabled (python CLI)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,7 +140,15 @@ impl Router {
             RoutingMode::Regular {
                 worker_urls: vec![],
             }
-        } else if self.pd_disaggregation || self.vllm_pd_disaggregation {
+        } else if self.vllm_pd_disaggregation {
+            RoutingMode::VllmPrefillDecode {
+                prefill_urls: self.prefill_urls.clone().unwrap_or_default(),
+                decode_urls: self.decode_urls.clone().unwrap_or_default(),
+                prefill_policy: self.prefill_policy.as_ref().map(convert_policy),
+                decode_policy: self.decode_policy.as_ref().map(convert_policy),
+                discovery_address: None,
+            }
+        } else if self.pd_disaggregation {
             RoutingMode::PrefillDecode {
                 prefill_urls: self.prefill_urls.clone().unwrap_or_default(),
                 decode_urls: self.decode_urls.clone().unwrap_or_default(),


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

Fix the router mode selection logic bug (issue #46 ) when launching the router using `vllm-router` Python wrapper.

## Test Plan
Run some requests and observe the router and vLLM instance logs.

## Test Result

We can see that with this fix, the router is using the VllmPrefillDecode RouterMode and there are KV cache transfers being recorded on the decode instance. Please see issue #46 for the logs from before.

#### Prefill instance
```
(APIServer pid=2908257) INFO 01-14 20:30:19 [metrics.py:103] KV Transfer metrics: Num successful transfers=1, Avg xfer time (ms)=4.096, P90 xfer time (ms)=4.096, Avg post time (ms)=0.117, P90 post time (ms)=0.117, Avg MB per transfer=46.0, Throughput (MB/s)=11230.469, Avg number of descriptors=64.0
```
#### Decode instance
```
(APIServer pid=2908257) INFO 01-14 20:30:19 [loggers.py:248] Engine 000: Avg prompt throughput: 36.8 tokens/s, Avg generation throughput: 15.0 tokens/s, Running: 0 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.0%, Prefix cache hit rate: 70.9%, External prefix cache hit rate: 17.8%
(APIServer pid=2908257) INFO 01-14 20:30:19 [metrics.py:103] KV Transfer metrics: Num successful transfers=1, Avg xfer time (ms)=4.096, P90 xfer time (ms)=4.096, Avg post time (ms)=0.117, P90 post time (ms)=0.117, Avg MB per transfer=46.0, Throughput (MB/s)=11230.469, Avg number of descriptors=64.0
```

#### Router
```
2026-01-15 02:30:17 DEBUG http_request{method=POST uri=/v1/completions version=HTTP/1.1 request_id="cmpl-Ed4lG6IlaUQRpaugWzpnIB6a"}: vllm_router_rs::request: src/middleware.rs:175: started processing request
2026-01-15 02:30:17 DEBUG http_request{method=POST uri=/v1/completions version=HTTP/1.1 request_id="cmpl-Ed4lG6IlaUQRpaugWzpnIB6a"}: vllm_router_rs::core::token_bucket: src/core/token_bucket.rs:73: Token bucket: acquired 1 tokens, 32767 remaining
2026-01-15 02:30:17 DEBUG http_request{method=POST uri=/v1/completions version=HTTP/1.1 request_id="cmpl-Ed4lG6IlaUQRpaugWzpnIB6a"}: vllm_router_rs::middleware: src/middleware.rs:422: Acquired token immediately
2026-01-15 02:30:17  INFO http_request{method=POST uri=/v1/completions version=HTTP/1.1 request_id="cmpl-Ed4lG6IlaUQRpaugWzpnIB6a"}: vllm_router_rs::routers::http::vllm_pd_router: src/routers/http/vllm_pd_router.rs:1163: vLLM route_completion called, use_discovery=false
2026-01-15 02:30:17  INFO http_request{method=POST uri=/v1/completions version=HTTP/1.1 request_id="cmpl-Ed4lG6IlaUQRpaugWzpnIB6a"}: vllm_router_rs::routers::http::vllm_pd_router: src/routers/http/vllm_pd_router.rs:1195: Using direct URL mode with VllmPDRouter's own routing logic
2026-01-15 02:30:17  INFO http_request{method=POST uri=/v1/completions version=HTTP/1.1 request_id="cmpl-Ed4lG6IlaUQRpaugWzpnIB6a"}: vllm_router_rs::routers::http::vllm_pd_router: src/routers/http/vllm_pd_router.rs:1200: Serialized completion request: {
  "echo": false,
  "ignore_eos": false,
  "max_tokens": 150,
  "model": "meta-llama/Meta-Llama-3.1-8B-Instruct",
  "no_stop_trim": false,
  "prompt": "This is a short test. How are are you doing today? Hello Hello! How are are you doing today? Hello Hello! How are are you doing today? Hello Hello! How are are you doing today? Hello Hello! How are are you doing today? Hello Hello! How are are you doing today? Hello Hello! How are are you doing today? Hello Hello! How are are you doing today? Hello Hello! How are are you doing today? Hello Hello! How are are you doing today? Hello Hello! How are are you doing today? Hello Hello! How are are you doing today?v Hello Hello! How are are you doing today? Hello Hello! How are are you doing today? Hello Hello! How are are you doing today? Hello Hello! How are are you doing today? Hello Hello! How are are you doing today? are you alive??? Hello hello! Are you alive??? mMewoskxj Hello Hello! How are are you doing today? Hello Hello! How are are you doing today? Hello Hello! How are are you doing today? Hello Hello! How are are you doing today? Hello Hello! How are are you doing today? Hello Hello! How are are you doing today? Hello Hello! How are are you doing today? Hello Hello! How are are you doing today? Hello Hello! How are are you doing today? Hello Hello! How are are you doing today? Hello Hello! How are are you doing today? Hello Hello! How are are you doing today?v Hello Hello! How are are you doing today? Hello Hello! How are are you doing today? Hello Hello! How are are you doing today? Hello Hello! How are are you doing today? Hello Hello! How are are you doing today? are you alive??? Hello hello!",
  "return_hidden_states": false,
  "skip_special_tokens": true,
  "stream": false
}
2026-01-15 02:30:17  INFO http_request{method=POST uri=/v1/completions version=HTTP/1.1 request_id="cmpl-Ed4lG6IlaUQRpaugWzpnIB6a"}: vllm_router_rs::routers::http::vllm_pd_router: src/routers/http/vllm_pd_router.rs:1219: Found 1 prefill workers, 1 decode workers from worker_registry
2026-01-15 02:30:17  INFO http_request{method=POST uri=/v1/completions version=HTTP/1.1 request_id="cmpl-Ed4lG6IlaUQRpaugWzpnIB6a"}: vllm_router_rs::routers::http::vllm_pd_router: src/routers/http/vllm_pd_router.rs:1269: Selected prefill=<PREFILL_IP>:8000 [policy:cache_aware], decode=http://<DECODE_IP>:8000 [policy:cache_aware]
2026-01-15 02:30:17 DEBUG http_request{method=POST uri=/v1/completions version=HTTP/1.1 request_id="cmpl-Ed4lG6IlaUQRpaugWzpnIB6a"}: vllm_router_rs::routers::http::vllm_pd_router: src/routers/http/vllm_pd_router.rs:576: ENTERED process_vllm_two_stage_request method
2026-01-15 02:30:17 DEBUG http_request{method=POST uri=/v1/completions version=HTTP/1.1 request_id="cmpl-Ed4lG6IlaUQRpaugWzpnIB6a"}: vllm_router_rs::routers::http::vllm_pd_router: src/routers/http/vllm_pd_router.rs:577: Prefill worker: <PREFILL_IP>:8000, Decode worker: http://<DECODE_IP>:8000, Path: /v1/completions
2026-01-15 02:30:17 DEBUG http_request{method=POST uri=/v1/completions version=HTTP/1.1 request_id="cmpl-Ed4lG6IlaUQRpaugWzpnIB6a"}: vllm_router_rs::routers::http::vllm_pd_router: src/routers/http/vllm_pd_router.rs:76: No ZMQ discovery result for sprc00.csl.illinois.edu:8000 (Prefill), using fallback: sprc00.csl.illinois.edu:8000
2026-01-15 02:30:17 DEBUG http_request{method=POST uri=/v1/completions version=HTTP/1.1 request_id="cmpl-Ed4lG6IlaUQRpaugWzpnIB6a"}: vllm_router_rs::routers::http::vllm_pd_router: src/routers/http/vllm_pd_router.rs:76: No ZMQ discovery result for <DECODE_IP>:8000 (Decode), using fallback: <DECODE_IP>:8000
2026-01-15 02:30:17 DEBUG http_request{method=POST uri=/v1/completions version=HTTP/1.1 request_id="cmpl-Ed4lG6IlaUQRpaugWzpnIB6a"}: vllm_router_rs::routers::http::vllm_pd_router: src/routers/http/vllm_pd_router.rs:588: Generated vLLM request ID: ___prefill_addr_sprc00.csl.illinois.edu:8000___decode_addr_<DECODE_IP>:8000_d8a2a169db71436992b5de1f023db94a
2026-01-15 02:30:17 DEBUG http_request{method=POST uri=/v1/completions version=HTTP/1.1 request_id="cmpl-Ed4lG6IlaUQRpaugWzpnIB6a"}: vllm_router_rs::routers::http::vllm_pd_router: src/routers/http/vllm_pd_router.rs:589: 🔍 vLLM Proxy Comparison:
2026-01-15 02:30:17 DEBUG http_request{method=POST uri=/v1/completions version=HTTP/1.1 request_id="cmpl-Ed4lG6IlaUQRpaugWzpnIB6a"}: vllm_router_rs::routers::http::vllm_pd_router: src/routers/http/vllm_pd_router.rs:590:   📋 vLLM Proxy Request ID format: ___prefill_addr_{zmq_addr}___decode_addr_{zmq_addr}_{uuid}
2026-01-15 02:30:17 DEBUG http_request{method=POST uri=/v1/completions version=HTTP/1.1 request_id="cmpl-Ed4lG6IlaUQRpaugWzpnIB6a"}: vllm_router_rs::routers::http::vllm_pd_router: src/routers/http/vllm_pd_router.rs:591:   📋 Our Request ID format: ___prefill_addr_{http_addr}___decode_addr_{http_addr}_{uuid}
2026-01-15 02:30:17 DEBUG http_request{method=POST uri=/v1/completions version=HTTP/1.1 request_id="cmpl-Ed4lG6IlaUQRpaugWzpnIB6a"}: vllm_router_rs::routers::http::vllm_pd_router: src/routers/http/vllm_pd_router.rs:592:   📋 vLLM Proxy headers: Authorization: Bearer $OPENAI_API_KEY, X-Request-Id: {request_id}
2026-01-15 02:30:17 DEBUG http_request{method=POST uri=/v1/completions version=HTTP/1.1 request_id="cmpl-Ed4lG6IlaUQRpaugWzpnIB6a"}: vllm_router_rs::routers::http::vllm_pd_router: src/routers/http/vllm_pd_router.rs:593:   📋 Our headers: Authorization: Bearer $OPENAI_API_KEY, X-Request-Id: {request_id}
2026-01-15 02:30:17 DEBUG http_request{method=POST uri=/v1/completions version=HTTP/1.1 request_id="cmpl-Ed4lG6IlaUQRpaugWzpnIB6a"}: vllm_router_rs::routers::http::vllm_pd_router: src/routers/http/vllm_pd_router.rs:611: Added kv_transfer_params to prefill request for NixlConnector support
2026-01-15 02:30:17 DEBUG http_request{method=POST uri=/v1/completions version=HTTP/1.1 request_id="cmpl-Ed4lG6IlaUQRpaugWzpnIB6a"}: vllm_router_rs::routers::http::vllm_pd_router: src/routers/http/vllm_pd_router.rs:633: 🚀 vLLM Stage 1 - Prefill: <PREFILL_IP>:8000/v1/completions with request_id: ___prefill_addr_sprc00.csl.illinois.edu:8000___decode_addr_<DECODE_IP>:8000_d8a2a169db71436992b5de1f023db94a
2026-01-15 02:30:17 DEBUG http_request{method=POST uri=/v1/completions version=HTTP/1.1 request_id="cmpl-Ed4lG6IlaUQRpaugWzpnIB6a"}: vllm_router_rs::routers::http::vllm_pd_router: src/routers/http/vllm_pd_router.rs:640: 📤 Prefill request headers: Authorization=Bearer [REDACTED], X-Request-Id=___prefill_addr_sprc00.csl.illinois.edu:8000___decode_addr_<DECODE_IP>:8000_d8a2a169db71436992b5de1f023db94a
2026-01-15 02:30:17 DEBUG http_request{method=POST uri=/v1/completions version=HTTP/1.1 request_id="cmpl-Ed4lG6IlaUQRpaugWzpnIB6a"}: vllm_router_rs::routers::http::vllm_pd_router: src/routers/http/vllm_pd_router.rs:645: 📤 Prefill request payload: {
  "echo": false,
  "ignore_eos": false,
  "kv_transfer_params": {
    "do_remote_decode": true,
    "do_remote_prefill": false,
    "remote_block_ids": null,
    "remote_engine_id": null,
    "remote_host": null,
    "remote_port": null
  },
  "max_tokens": 1,
  "model": "meta-llama/Meta-Llama-3.1-8B-Instruct",
  "no_stop_trim": false,
  "prompt": "This is a short test. How are are you doing today? Hello Hello! How are are you doing today? Hello Hello! How are are you doing today? Hello Hello! How are are you doing today? Hello Hello! How are are you doing today? Hello Hello! How are are you doing today? Hello Hello! How are are you doing today? Hello Hello! How are are you doing today? Hello Hello! How are are you doing today? Hello Hello! How are are you doing today? Hello Hello! How are are you doing today? Hello Hello! How are are you doing today?v Hello Hello! How are are you doing today? Hello Hello! How are are you doing today? Hello Hello! How are are you doing today? Hello Hello! How are are you doing today? Hello Hello! How are are you doing today? are you alive??? Hello hello! Are you alive??? mMewoskxj Hello Hello! How are are you doing today? Hello Hello! How are are you doing today? Hello Hello! How are are you doing today? Hello Hello! How are are you doing today? Hello Hello! How are are you doing today? Hello Hello! How are are you doing today? Hello Hello! How are are you doing today? Hello Hello! How are are you doing today? Hello Hello! How are are you doing today? Hello Hello! How are are you doing today? Hello Hello! How are are you doing today? Hello Hello! How are are you doing today?v Hello Hello! How are are you doing today? Hello Hello! How are are you doing today? Hello Hello! How are are you doing today? Hello Hello! How are are you doing today? Hello Hello! How are are you doing today? are you alive??? Hello hello!",
  "return_hidden_states": false,
  "skip_special_tokens": true,
  "stream": false
}
2026-01-15 02:30:17 DEBUG http_request{method=POST uri=/v1/completions version=HTTP/1.1 request_id="cmpl-Ed4lG6IlaUQRpaugWzpnIB6a"}: vllm_router_rs::routers::http::vllm_pd_router: src/routers/http/vllm_pd_router.rs:681: 📥 Prefill response status: 200 OK
2026-01-15 02:30:17 DEBUG http_request{method=POST uri=/v1/completions version=HTTP/1.1 request_id="cmpl-Ed4lG6IlaUQRpaugWzpnIB6a"}: vllm_router_rs::routers::http::vllm_pd_router: src/routers/http/vllm_pd_router.rs:682: 📥 Prefill response headers: {"date": "Thu, 15 Jan 2026 02:30:17 GMT", "server": "uvicorn", "content-length": "994", "content-type": "application/json"}
2026-01-15 02:30:17 DEBUG http_request{method=POST uri=/v1/completions version=HTTP/1.1 request_id="cmpl-Ed4lG6IlaUQRpaugWzpnIB6a"}: vllm_router_rs::routers::http::vllm_pd_router: src/routers/http/vllm_pd_router.rs:699: 📥 Prefill response body size: 994 bytes
2026-01-15 02:30:17 DEBUG http_request{method=POST uri=/v1/completions version=HTTP/1.1 request_id="cmpl-Ed4lG6IlaUQRpaugWzpnIB6a"}: vllm_router_rs::routers::http::vllm_pd_router: src/routers/http/vllm_pd_router.rs:704: 📥 Prefill response body content: {"id":"cmpl-___prefill_addr_sprc00.csl.illinois.edu:8000___decode_addr_<DECODE_IP>:8000_d8a2a169db71436992b5de1f023db94a","object":"text_completion","created":1768444217,"model":"meta-llama/Meta-Llama-3.1-8B-Instruct","choices":[{"index":0,"text":" Are","logprobs":null,"finish_reason":"length","stop_reason":null,"token_ids":null,"prompt_logprobs":null,"prompt_token_ids":null}],"service_tier":null,"system_fingerprint":null,"usage":{"prompt_tokens":368,"total_tokens":369,"completion_tokens":1,"prompt_tokens_details":null},"kv_transfer_params":{"do_remote_prefill":true,"do_remote_decode":false,"remote_block_ids":[165,166,167,168,169,170,171,172,173,174,175,176,177,178,179,180,181,182,183,184,185,186,187],"remote_engine_id":"43bc2002-9e76-425b-ba6d-74466564a1ee","remote_request_id":"cmpl-___prefill_addr_sprc00.csl.illinois.edu:8000___decode_addr_<DECODE_IP>:8000_d8a2a169db71436992b5de1f023db94a-0","remote_host":"192.17.100.187","remote_port":5600,"tp_size":1}}
2026-01-15 02:30:17 DEBUG http_request{method=POST uri=/v1/completions version=HTTP/1.1 request_id="cmpl-Ed4lG6IlaUQRpaugWzpnIB6a"}: vllm_router_rs::routers::http::vllm_pd_router: src/routers/http/vllm_pd_router.rs:720: Extracted kv_transfer_params from prefill response: {
  "do_remote_decode": false,
  "do_remote_prefill": true,
  "remote_block_ids": [
    165,
    166,
    167,
    168,
    169,
    170,
    171,
    172,
    173,
    174,
    175,
    176,
    177,
    178,
    179,
    180,
    181,
    182,
    183,
    184,
    185,
    186,
    187
  ],
  "remote_engine_id": "43bc2002-9e76-425b-ba6d-74466564a1ee",
  "remote_host": "192.17.100.187",
  "remote_port": 5600,
  "remote_request_id": "cmpl-___prefill_addr_sprc00.csl.illinois.edu:8000___decode_addr_<DECODE_IP>:8000_d8a2a169db71436992b5de1f023db94a-0",
  "tp_size": 1
}
2026-01-15 02:30:17 DEBUG http_request{method=POST uri=/v1/completions version=HTTP/1.1 request_id="cmpl-Ed4lG6IlaUQRpaugWzpnIB6a"}: vllm_router_rs::routers::http::vllm_pd_router: src/routers/http/vllm_pd_router.rs:731: ✅ vLLM Stage 1 completed, starting Stage 2 - Decode
2026-01-15 02:30:17 DEBUG http_request{method=POST uri=/v1/completions version=HTTP/1.1 request_id="cmpl-Ed4lG6IlaUQRpaugWzpnIB6a"}: vllm_router_rs::routers::http::vllm_pd_router: src/routers/http/vllm_pd_router.rs:737: Added kv_transfer_params to decode request
2026-01-15 02:30:17 DEBUG http_request{method=POST uri=/v1/completions version=HTTP/1.1 request_id="cmpl-Ed4lG6IlaUQRpaugWzpnIB6a"}: vllm_router_rs::routers::http::vllm_pd_router: src/routers/http/vllm_pd_router.rs:760: 🚀 vLLM Stage 2 - Decode: http://<DECODE_IP>:8000/v1/completions with request_id: ___prefill_addr_sprc00.csl.illinois.edu:8000___decode_addr_<DECODE_IP>:8000_d8a2a169db71436992b5de1f023db94a
2026-01-15 02:30:17 DEBUG http_request{method=POST uri=/v1/completions version=HTTP/1.1 request_id="cmpl-Ed4lG6IlaUQRpaugWzpnIB6a"}: vllm_router_rs::routers::http::vllm_pd_router: src/routers/http/vllm_pd_router.rs:767: 📤 Decode request headers: Authorization=Bearer [REDACTED], X-Request-Id=___prefill_addr_sprc00.csl.illinois.edu:8000___decode_addr_<DECODE_IP>:8000_d8a2a169db71436992b5de1f023db94a
2026-01-15 02:30:17 DEBUG http_request{method=POST uri=/v1/completions version=HTTP/1.1 request_id="cmpl-Ed4lG6IlaUQRpaugWzpnIB6a"}: vllm_router_rs::routers::http::vllm_pd_router: src/routers/http/vllm_pd_router.rs:772: 📤 Decode request payload: {
  "echo": false,
  "ignore_eos": false,
  "kv_transfer_params": {
    "do_remote_decode": false,
    "do_remote_prefill": true,
    "remote_block_ids": [
      165,
      166,
      167,
      168,
      169,
      170,
      171,
      172,
      173,
      174,
      175,
      176,
      177,
      178,
      179,
      180,
      181,
      182,
      183,
      184,
      185,
      186,
      187
    ],
    "remote_engine_id": "43bc2002-9e76-425b-ba6d-74466564a1ee",
    "remote_host": "192.17.100.187",
    "remote_port": 5600,
    "remote_request_id": "cmpl-___prefill_addr_sprc00.csl.illinois.edu:8000___decode_addr_<DECODE_IP>:8000_d8a2a169db71436992b5de1f023db94a-0",
    "tp_size": 1
  },
  "max_tokens": 150,
  "model": "meta-llama/Meta-Llama-3.1-8B-Instruct",
  "no_stop_trim": false,
  "prompt": "This is a short test. How are are you doing today? Hello Hello! How are are you doing today? Hello Hello! How are are you doing today? Hello Hello! How are are you doing today? Hello Hello! How are are you doing today? Hello Hello! How are are you doing today? Hello Hello! How are are you doing today? Hello Hello! How are are you doing today? Hello Hello! How are are you doing today? Hello Hello! How are are you doing today? Hello Hello! How are are you doing today? Hello Hello! How are are you doing today?v Hello Hello! How are are you doing today? Hello Hello! How are are you doing today? Hello Hello! How are are you doing today? Hello Hello! How are are you doing today? Hello Hello! How are are you doing today? are you alive??? Hello hello! Are you alive??? mMewoskxj Hello Hello! How are are you doing today? Hello Hello! How are are you doing today? Hello Hello! How are are you doing today? Hello Hello! How are are you doing today? Hello Hello! How are are you doing today? Hello Hello! How are are you doing today? Hello Hello! How are are you doing today? Hello Hello! How are are you doing today? Hello Hello! How are are you doing today? Hello Hello! How are are you doing today? Hello Hello! How are are you doing today? Hello Hello! How are are you doing today?v Hello Hello! How are are you doing today? Hello Hello! How are are you doing today? Hello Hello! How are are you doing today? Hello Hello! How are are you doing today? Hello Hello! How are are you doing today? are you alive??? Hello hello!",
  "return_hidden_states": false,
  "skip_special_tokens": true,
  "stream": false
}
2026-01-15 02:30:18  INFO http_request{method=POST uri=/v1/completions version=HTTP/1.1 request_id="cmpl-Ed4lG6IlaUQRpaugWzpnIB6a"}: vllm_router_rs::routers::http::vllm_pd_router: src/routers/http/vllm_pd_router.rs:814: 📥 Decode response status: 200 OK
2026-01-15 02:30:18  INFO http_request{method=POST uri=/v1/completions version=HTTP/1.1 request_id="cmpl-Ed4lG6IlaUQRpaugWzpnIB6a"}: vllm_router_rs::routers::http::vllm_pd_router: src/routers/http/vllm_pd_router.rs:815: 📥 Decode response headers: {"date": "Thu, 15 Jan 2026 02:30:17 GMT", "server": "uvicorn", "content-length": "1178", "content-type": "application/json"}
2026-01-15 02:30:18 DEBUG http_request{method=POST uri=/v1/completions version=HTTP/1.1 request_id="cmpl-Ed4lG6IlaUQRpaugWzpnIB6a"}: vllm_router_rs::routers::http::vllm_pd_router: src/routers/http/vllm_pd_router.rs:879: No logprobs merging needed (streaming=false, needs_logprobs=false)
2026-01-15 02:30:18  INFO http_request{method=POST uri=/v1/completions version=HTTP/1.1 request_id="cmpl-Ed4lG6IlaUQRpaugWzpnIB6a"}: vllm_router_rs::routers::http::vllm_pd_router: src/routers/http/vllm_pd_router.rs:1288: Two-stage processing completed successfully
2026-01-15 02:30:18 DEBUG http_request{method=POST uri=/v1/completions version=HTTP/1.1 request_id="cmpl-Ed4lG6IlaUQRpaugWzpnIB6a"}: vllm_router_rs::core::token_bucket: src/core/token_bucket.rs:137: Token bucket: returned 1 tokens, 32768 available
2026-01-15 02:30:18 DEBUG http_request{method=POST uri=/v1/completions version=HTTP/1.1 request_id="cmpl-Ed4lG6IlaUQRpaugWzpnIB6a" status_code=200 latency="1.059049564s"}: vllm_router_rs::response: src/middleware.rs:217: finished processing request
2026-01-15 02:32:04  INFO vllm_router_rs::tree: src/tree.rs:436: Before eviction - Used size per tenant:
2026-01-15 02:32:04  INFO vllm_router_rs::tree: src/tree.rs:436: Before eviction - Used size per tenant:
2026-01-15 02:32:04  INFO vllm_router_rs::tree: src/tree.rs:438: Tenant: <PREFILL_IP>:8000, Size: 1727
2026-01-15 02:32:04  INFO vllm_router_rs::tree: src/tree.rs:438: Tenant: http://<DECODE_IP>:8000, Size: 1727
2026-01-15 02:32:04  INFO vllm_router_rs::tree: src/tree.rs:488: After eviction - Used size per tenant:
2026-01-15 02:32:04  INFO vllm_router_rs::tree: src/tree.rs:488: After eviction - Used size per tenant:
2026-01-15 02:32:04  INFO vllm_router_rs::tree: src/tree.rs:490: Tenant: <PREFILL_IP>:8000, Size: 1727
2026-01-15 02:32:04  INFO vllm_router_rs::tree: src/tree.rs:490: Tenant: http://<DECODE_IP>:8000, Size: 1727
2026-01-15 02:32:04 DEBUG vllm_router_rs::policies::cache_aware: src/policies/cache_aware.rs:105: Cache eviction completed for model default, max_size: 67108864
2026-01-15 02:32:04 DEBUG vllm_router_rs::policies::cache_aware: src/policies/cache_aware.rs:105: Cache eviction completed for model default, max_size: 67108864
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
