### PR TITLE
Fix flaky test_rate_limit_and_queue by adding mock worker latency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,10 @@ target
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 .idea/
+
+# Python virtual environment
+.venv/
+
+# Python bytecode cache
+__pycache__/
+*.pyc

--- a/py_test/integration/test_rate_limiting.py
+++ b/py_test/integration/test_rate_limiting.py
@@ -6,8 +6,9 @@ import requests
 
 @pytest.mark.integration
 def test_rate_limit_and_queue(router_manager, mock_workers):
-    # One fast backend
-    _, urls, _ = mock_workers(n=1)
+    # Add latency to ensure requests overlap and trigger rate limiting
+    # Without latency, requests may complete too fast to trigger concurrency limits
+    _, urls, _ = mock_workers(n=1, args=["--latency-ms", "100"])
     rh = router_manager.start_router(
         worker_urls=urls,
         policy="round_robin",


### PR DESCRIPTION
##purpose:
https://buildkite.com/vllm/router/builds/121/steps/canvas?sid=019bc811-b823-4fb6-b908-2dd0ae9d7b61
The test_rate_limit_and_queue test was flaky because the mock worker processed requests instantly. Without artificial latency, requests could complete faster than new ones arrived, causing the concurrency limit to never be reached. This resulted in intermittent test failures where sometimes all requests succeeded (200) instead of some being rate-limited (429).

Fix: Added --latency-ms 100 to the mock worker, ensuring requests take at least 100ms. This guarantees that when 16 concurrent requests hit a router with max_concurrent_requests=2, most requests will be rejected with 429 while 2 are being processed.

Also added  .venv/, __pycache__/ and *.pyc to gitignore
