### PR TITLE
fix: improve error handling in RoutingTreeBuilder::from_file

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -19,7 +19,7 @@ struct Core {
 
 impl RequestHandler {
     pub fn new(config: &std::path::PathBuf) -> Result<Self, ConfigurationError> {
-        let builder = RoutingTreeBuilder::from_file(config);
+        let builder = RoutingTreeBuilder::from_file(config)?;
         let root = builder.build_routing_tree()?;
 
         Ok(Self {

--- a/src/routes/routing_tree_builder.rs
+++ b/src/routes/routing_tree_builder.rs
@@ -13,10 +13,14 @@ impl RoutingTreeBuilder {
         Self { config }
     }
 
-    pub fn from_file(config: &std::path::PathBuf) -> Self {
-        let json = std::fs::read_to_string(config).unwrap();
-
-        RoutingTreeBuilder::new(json)
+    pub fn from_file(config: &std::path::PathBuf) -> Result<Self, ConfigurationError> {
+        let json = std::fs::read_to_string(config)
+            .map_err(|e| ConfigurationError(format!(
+                "Failed to read config file '{}': {}",
+                config.display(),
+                e
+            )))?;
+        Ok(RoutingTreeBuilder::new(json))
     }
 
     pub fn build_routing_tree(


### PR DESCRIPTION
Fixes #52

## Description

This PR fixes a bug where `RoutingTreeBuilder::from_file` panics when file reading fails (e.g., file not found, permission denied, etc.) instead of gracefully handling the error.

## Problem

The current implementation uses `unwrap()` which causes the program to panic:
ust
pub fn from_file(config: &std::path::PathBuf) -> Self {
    let json = std::fs::read_to_string(config).unwrap();  // Panics on error
    RoutingTreeBuilder::new(json)
}## Solution

Changed the return type to `Result<Self, ConfigurationError>` and use proper error handling with the `?` operator:

pub fn from_file(config: &std::path::PathBuf) -> Result<Self, ConfigurationError> {
    let json = std::fs::read_to_string(config)
        .map_err(|e| ConfigurationError(format!(
            "Failed to read config file '{}': {}",
            config.display(),
            e
        )))?;
    Ok(RoutingTreeBuilder::new(json))
}Also updated `RequestHandler::new` to handle the new return type.

## Changes

- Changed `from_file` return type from `Self` to `Result<Self, ConfigurationError>`
- Replaced `unwrap()` with proper error handling using `map_err` and `?` operator
- Updated `RequestHandler::new` to propagate errors correctly

## Files Changed

- `src/routes/routing_tree_builder.rs`
- `src/handler.rs`

## Testing

- [x] Code compiles successfully
- [x] Error handling works correctly (returns `ConfigurationError` instead of panicking)
- [x] Error messages are clear and informative

## Impact

- **Severity**: Medium
- **Breaking Change**: Yes (API change - return type changed)
- **Backward Compatibility**: No (callers need to handle `Result`)

## Related Issues

Closes #52