### PR TITLE
fix: improve error handling in JSON parsing for build_routing_tree

### DIFF
--- a/src/routes/routing_tree_builder.rs
+++ b/src/routes/routing_tree_builder.rs
@@ -22,7 +22,11 @@ impl RoutingTreeBuilder {
     pub fn build_routing_tree(
         self,
     ) -> Result<Box<dyn RouteHandle + Send + Sync>, ConfigurationError> {
-        let json: Value = serde_json::from_str(&self.config).unwrap();
+        let json: Value = serde_json::from_str(&self.config)
+            .map_err(|e| ConfigurationError(format!(
+                "Invalid JSON config: {}",
+                e
+            )))?;
         let route: &Map<String, Value> = json.require("route")?;
 
         let root: Box<dyn RouteHandle + Send + Sync> = match route.require::<&str>("type")? {


### PR DESCRIPTION
Fixes #54

## Description

This PR fixes a bug where `build_routing_tree` panics when JSON parsing fails instead of returning a proper error.

## Problem

The current implementation uses `unwrap()` for JSON parsing:

let json: Value = serde_json::from_str(&self.config).unwrap();  // Panics on errorWhen the JSON configuration is malformed, the program crashes with a panic instead of returning a proper error.

## Solution

Replaced `unwrap()` with proper error handling using `map_err` and the `?` operator:

let json: Value = serde_json::from_str(&self.config)
    .map_err(|e| ConfigurationError(format!(
        "Invalid JSON config: {}",
        e
    )))?;## Changes

- Replaced `unwrap()` with proper error handling using `map_err` and `?` operator
- Error messages now clearly indicate JSON parsing failures

## Files Changed

- `src/routes/routing_tree_builder.rs`

## Testing

- [x] Code compiles successfully
- [x] Invalid JSON returns `ConfigurationError` instead of panicking
- [x] Error messages are clear and informative

## Impact

- **Severity**: Medium
- **Breaking Change**: No
- **Backward Compatibility**: Yes (function already returns `Result`)

## Related Issues

Closes #54