### PR TITLE
fix: replace unimplemented!() with proper error for unsupported route types

### DIFF
--- a/src/routes/routing_tree_builder.rs
+++ b/src/routes/routing_tree_builder.rs
@@ -43,7 +43,12 @@ impl RoutingTreeBuilder {
                     .collect::<Result<Vec<(&str, u16)>, ConfigurationError>>()?;
                 Box::new(RoundRobinRoute::new(servers))
             }
-            _ => unimplemented!(),
+            unsupported_type => {
+                return Err(ConfigurationError(format!(
+                    "Unsupported route type: {}",
+                    unsupported_type
+                )));
+            }
         };
 
         Ok(root)


### PR DESCRIPTION
Fixes #56

## Description

This PR fixes a bug where encountering an unsupported route type causes a panic instead of returning a proper error.

## Problem

The current implementation uses `unimplemented!()` which causes the program to panic:

match route.require::<&str>("type")? {
    "SingleServerRoute" => { /* ... */ },
    "RoundRobinRoute" => { /* ... */ },
    _ => unimplemented!(),  // Panics with unhelpful message
}When an unsupported route type is encountered, the program crashes with a panic message that doesn't clearly indicate what went wrong.

## Solution

Replaced `unimplemented!()` with proper error handling:

unsupported_type => {
    return Err(ConfigurationError(format!(
        "Unsupported route type: {}",
        unsupported_type
    )));
}## Changes

- Replaced `unimplemented!()` with proper error handling
- Error messages now clearly indicate the unsupported route type
- Changed pattern matching from `_` to `unsupported_type` to capture the value

## Files Changed

- `src/routes/routing_tree_builder.rs`

## Testing

- [x] Code compiles successfully
- [x] Unsupported route types return `ConfigurationError` instead of panicking
- [x] Error messages include the unsupported route type name

## Impact

- **Severity**: Medium
- **Breaking Change**: No
- **Backward Compatibility**: Yes (function already returns `Result`)

## Related Issues

Closes #56