### PR TITLE
Add worker management methods to VllmPDRouter

### DIFF
--- a/src/routers/http/vllm_pd_router.rs
+++ b/src/routers/http/vllm_pd_router.rs
@@ -968,6 +968,40 @@ impl VllmPDRouter {
             })
         }
     }
+
+    /// Add a prefill server to the router
+    /// Delegates to the underlying PDRouter
+    pub async fn add_prefill_server(
+        &self,
+        url: String,
+        bootstrap_port: Option<u16>,
+    ) -> Result<String, PDRouterError> {
+        self.pd_router.add_prefill_server(url, bootstrap_port).await
+    }
+
+    /// Add a decode server to the router
+    /// Delegates to the underlying PDRouter
+    pub async fn add_decode_server(&self, url: String) -> Result<String, PDRouterError> {
+        self.pd_router.add_decode_server(url).await
+    }
+
+    /// Remove a prefill server from the router
+    /// Delegates to the underlying PDRouter
+    pub async fn remove_prefill_server(&self, url: &str) -> Result<String, PDRouterError> {
+        self.pd_router.remove_prefill_server(url).await
+    }
+
+    /// Remove a decode server from the router
+    /// Delegates to the underlying PDRouter
+    pub async fn remove_decode_server(&self, url: &str) -> Result<String, PDRouterError> {
+        self.pd_router.remove_decode_server(url).await
+    }
+
+    /// Get a reference to the underlying PDRouter's worker registry
+    /// This allows access to worker information for refresh operations
+    pub fn worker_registry(&self) -> &crate::core::WorkerRegistry {
+        &self.pd_router.worker_registry
+    }
 }
 
 // Delegate most RouterTrait methods to the underlying PDRouter,


### PR DESCRIPTION
<!-- markdownlint-disable -->
## Purpose
Add delegation methods to VllmPDRouter for dynamic worker management:
- add_prefill_server()
- add_decode_server()
- remove_prefill_server()
- remove_decode_server()
- worker_registry()

These methods delegate to the underlying PDRouter and enable external callers to dynamically add/remove prefill and decode workers.

## Test Plan
- Built success and ran with VllmPDRouter. Ensured add/remove commands worked as expected