### PR TITLE
CI: PyPI Publish Pipeline

### DIFF
--- a/.buildkite/release-pipeline.yml
+++ b/.buildkite/release-pipeline.yml
@@ -46,7 +46,7 @@ steps:
     key: "build_wheels"
     plugins:
       - docker#v5.11.0:
-          image: "rustlang/rust:nightly-bullseye"
+          image: "quay.io/pypa/manylinux_2_28_x86_64"
           workdir: /workdir
           volumes:
             - ".:/workdir"
@@ -59,15 +59,24 @@ steps:
             - |
               set -euo pipefail
 
-              # Install system dependencies
-              apt-get update && apt-get install -y pkg-config libssl-dev protobuf-compiler python3 python3-pip
+              # Install system dependencies (manylinux_2_28 uses dnf)
+              dnf install -y openssl-devel protobuf-compiler protobuf-devel
+
+              # Install Rust toolchain
+              curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain nightly
+              source $$HOME/.cargo/env
 
               # Build Rust binary for release
               cargo build --release
 
-              # Build Python wheels
-              pip3 install -U pip setuptools wheel setuptools-rust build
-              python3 -m build
+              # Build Python wheels using Python 3.9 (available in manylinux image)
+              /opt/python/cp39-cp39/bin/pip install -U pip setuptools wheel setuptools-rust build auditwheel
+              /opt/python/cp39-cp39/bin/python -m build
+
+              # Repair wheel to have proper manylinux tags
+              /opt/python/cp39-cp39/bin/auditwheel repair dist/*.whl -w dist/
+              # Remove the original non-manylinux wheel
+              rm dist/*-linux_x86_64.whl || true
     artifact_paths:
       - "target/release/vllm-router"
       - "dist/*.whl"
@@ -82,6 +91,7 @@ steps:
   # Run Release Tests
   # ============================================================================
   - label: ":test_tube: Smoke Test Release Binary"
+    key: "smoke-test-binary"
     command: |
       buildkite-agent artifact download "target/release/vllm-router" .
       chmod +x target/release/vllm-router
@@ -91,6 +101,7 @@ steps:
       queue: "cpu_queue_postmerge"
 
   - label: ":python: Test Python Wheel"
+    key: "test-python-wheel"
     command: |
       buildkite-agent artifact download "dist/*.whl" .
       pip install dist/*.whl
@@ -105,52 +116,30 @@ steps:
   # ============================================================================
   - label: ":python: Publish to PyPI"
     key: "publish-pypi"
-    plugins:
-      - docker#v5.11.0:
-          image: "python:3.11-slim"
-          workdir: /workdir
-          volumes:
-            - ".:/workdir"
-          environment:
-            - "TWINE_USERNAME=__token__"
-            - "TWINE_PASSWORD"
-          propagate-environment: true
-          command:
-            - bash
-            - -c
-            - |
-              set -euo pipefail
+    command: |
+      set -euo pipefail
 
-              pip install twine
+      # Download build artifacts
+      buildkite-agent artifact download "dist/*.whl" .
+      buildkite-agent artifact download "dist/*.tar.gz" .
 
-              echo "📦 Uploading packages to PyPI..."
-              twine upload dist/* --verbose
-
-              echo "✅ Successfully published to PyPI!"
-    env:
-      TWINE_PASSWORD: "${PYPI_TOKEN}"
-    depends_on: "build_wheels"
+      # Upload to PyPI using Docker
+      docker run --rm \
+        -v "$$PWD:/workdir" \
+        -w /workdir \
+        -e TWINE_USERNAME=__token__ \
+        -e TWINE_PASSWORD="$$PYPI_TOKEN" \
+        python:3.11-slim bash -c '
+          pip install twine
+          echo "📦 Uploading packages to PyPI..."
+          twine upload dist/* --verbose
+          echo "✅ Successfully published to PyPI!"
+        '
+    depends_on:
+      - "build_wheels"
+      - "test-python-wheel"
+      - "smoke-test-binary"
     if: build.tag =~ /^v.*/
     soft_fail: false
-    agents:
-      queue: "cpu_queue_postmerge"
-
-  # ============================================================================
-  # Create GitHub Release
-  # ============================================================================
-  - label: ":github: Create GitHub Release"
-    command: |
-      # Download all artifacts
-      buildkite-agent artifact download "target/release/vllm-router" .
-      buildkite-agent artifact download "dist/*" .
-
-      # Create GitHub release (requires gh CLI and GITHUB_TOKEN)
-      gh release create $${BUILDKITE_TAG} \
-        --title "Release $${BUILDKITE_TAG}" \
-        --notes "Release $${BUILDKITE_TAG} of vLLM Router" \
-        target/release/vllm-router \
-        dist/*.whl \
-        dist/*.tar.gz
-    if: build.tag =~ /^v.*/
     agents:
       queue: "cpu_queue_postmerge"


### PR DESCRIPTION
## Purpose
Updated release-pipeline.yml to publish to PyPI on new tag. 

## Test Plan
- Running pipeline: https://buildkite.com/vllm/router-release/builds/24/steps/canvas
- PyPI project version published here: https://pypi.org/project/vllm-router/0.1.9/
- Tried installing package (`pip install vllm-router==0.1.9`) on fresh linux env with Python 3.9 and it works well ([logs](https://www.internalfb.com/phabricator/paste/view/P2137748766)). On non-linux machines (i.e macos) command still works but defaults to building from source code (tar.gz included in wheel - requires rust compiler) as expected.

## How to publish a new tag
Once we have merged new PRs into main (with pyproject.toml version updated), run the following:
- `git checkout main`
- `git tag vX.X.X` -> tag version has to match version in pyproject.toml
- `git push origin vX.X.X`
- Check BuildKite UI for latest run with version tag ([here](https://buildkite.com/vllm/router-release))