### PR TITLE
fix(vllm-pd): adjust min_tokens when forcing max_tokens for prefill

### DIFF
--- a/src/routers/http/vllm_pd_router.rs
+++ b/src/routers/http/vllm_pd_router.rs
@@ -142,6 +142,13 @@ impl VllmPDRouter {
         if request.get("max_completion_tokens").is_some() {
             request["max_completion_tokens"] = json!(1);
         }
+        // Also adjust min_tokens to ensure min_tokens <= max_tokens
+        // This is required because vLLM validates that min_tokens <= max_tokens
+        if let Some(min_tokens) = request.get("min_tokens").and_then(|v| v.as_u64()) {
+            if min_tokens > 1 {
+                request["min_tokens"] = json!(1);
+            }
+        }
         // Force non-streaming for prefill to get JSON response with kv_transfer_params
         request["stream"] = json!(false);
         // Remove stream_options since we're setting stream=false


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
 When sending prefill requests to the prefill instance, we force `max_tokens` (or `max_completion_tokens`) to 1 to get the KV cache. However, if the original request contained `min_tokens` > 1, vLLM's validation fails because `min_tokens` cannot be greater than`max_tokens`. This change sets `min_tokens` to 1 if it is present and greater than 1, ensuring the validation passes.
## Test Plan
```
(APIServer pid=14615) Traceback (most recent call last):
(APIServer pid=14615)   File "/vllm-workspace/vllm/vllm/entrypoints/openai/serving_chat.py", line 376, in create_chat_completion
(APIServer pid=14615)     sampling_params = request.to_sampling_params(
(APIServer pid=14615)                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=14615)   File "/vllm-workspace/vllm/vllm/entrypoints/openai/protocol.py", line 821, in to_sampling_params
(APIServer pid=14615)     return SamplingParams.from_optional(
(APIServer pid=14615)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=14615)   File "/vllm-workspace/vllm/vllm/sampling_params.py", line 290, in from_optional
(APIServer pid=14615)     return SamplingParams(
(APIServer pid=14615)            ^^^^^^^^^^^^^^^
(APIServer pid=14615)   File "/vllm-workspace/vllm/vllm/sampling_params.py", line 360, in __post_init__
(APIServer pid=14615)     self._verify_args()
(APIServer pid=14615)   File "/vllm-workspace/vllm/vllm/sampling_params.py", line 430, in _verify_args
(APIServer pid=14615)     raise ValueError(
(APIServer pid=14615) ValueError: min_tokens must be less than or equal to max_tokens=1, got 100.
(APIServer pid=14615) INFO:     10.222.50.90:41642 - "POST /v1/chat/completions HTTP/1.1" 400 Bad Request
```
## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
