### PR TITLE
Upgrade PyO3 to 0.26

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2840,11 +2840,10 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.24.2"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5203598f366b11a02b13aa20cab591229ff0a89fd121a308a5df751d5fc9219"
+checksum = "7ba0117f4212101ee6544044dae45abe1083d30ce7b29c4b5cbdfa2354e07383"
 dependencies = [
- "cfg-if",
  "indoc",
  "libc",
  "memoffset",
@@ -2858,19 +2857,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.24.2"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99636d423fa2ca130fa5acde3059308006d46f98caac629418e53f7ebb1e9999"
+checksum = "4fc6ddaf24947d12a9aa31ac65431fb1b851b8f4365426e182901eabfb87df5f"
 dependencies = [
- "once_cell",
  "target-lexicon 0.13.3",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.24.2"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78f9cf92ba9c409279bc3305b5409d90db2d2c22392d443a87df3a1adad59e33"
+checksum = "025474d3928738efb38ac36d4744a74a400c901c7596199e20e45d98eb194105"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -2878,9 +2876,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.24.2"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b999cb1a6ce21f9a6b147dcf1be9ffedf02e0043aec74dc390f3007047cecd9"
+checksum = "2e64eb489f22fe1c95911b77c44cc41e7c19f3082fc81cce90f657cdc42ffded"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -2890,9 +2888,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.24.2"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "822ece1c7e1012745607d5cf0bcb2874769f0f7cb34c4cde03b9358eb9ef911a"
+checksum = "100246c0ecf400b475341b8455a9213344569af29a3c841d29270e53102e0fcf"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ rand = "0.9.2"
 reqwest = { version = "0.12.8", features = ["stream", "blocking", "json"] }
 futures-util = "0.3"
 futures = "0.3"
-pyo3 = { version = "0.24", features = ["extension-module"] }
+pyo3 = { version = "0.26", features = ["extension-module"] }
 dashmap = "6.1.0"
 http = "1.1.0"
 tokio = { version = "1.42.0", features = ["full"] }


### PR DESCRIPTION
## Purpose
Upgrading `pyo3` from `0.24` to `0.26`

## Test Plan
`cargo build && cargo test`

## Test Result

Cargo test produces the same errors before and with this change:
```
failures:
    cache_tests::test_flush_cache
    cache_tests::test_get_loads
    error_tests::test_404_not_found
    error_tests::test_invalid_json_payload
    error_tests::test_invalid_model
    error_tests::test_method_not_allowed
    error_tests::test_missing_required_fields
    error_tests::test_payload_too_large
    generation_tests::test_generate_streaming
    generation_tests::test_generate_success
    generation_tests::test_generate_with_worker_failure
    generation_tests::test_v1_chat_completions_success
    health_tests::test_health_endpoint_details
    health_tests::test_health_generate_endpoint
    health_tests::test_readiness_with_healthy_workers
    load_balancing_tests::test_request_distribution
    model_info_tests::test_get_model_info
    model_info_tests::test_get_server_info
    model_info_tests::test_model_info_with_multiple_workers
    model_info_tests::test_model_info_with_unhealthy_worker
    model_info_tests::test_v1_models
    request_id_tests::test_request_id_generation
    request_id_tests::test_request_id_with_custom_headers
    rerank_tests::test_rerank_invalid_request
    rerank_tests::test_rerank_success
    rerank_tests::test_rerank_with_top_k
    rerank_tests::test_rerank_without_documents
    rerank_tests::test_rerank_worker_failure
    rerank_tests::test_v1_rerank_compatibility
    responses_endpoint_tests::test_v1_responses_cancel
    responses_endpoint_tests::test_v1_responses_delete_and_list_not_implemented
    responses_endpoint_tests::test_v1_responses_get
    responses_endpoint_tests::test_v1_responses_get_multi_worker_fanout
    responses_endpoint_tests::test_v1_responses_non_streaming
    responses_endpoint_tests::test_v1_responses_streaming
    router_policy_tests::test_random_policy
    router_policy_tests::test_worker_selection
    worker_management_tests::test_add_duplicate_worker
    worker_management_tests::test_add_new_worker
    worker_management_tests::test_remove_existing_worker

test result: FAILED. 7 passed; 40 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.15s
```
with the following log printed to stdout for each failure:
```
thread 'model_info_tests::test_model_info_with_multiple_workers' (2572147) panicked at tests/api_endpoints_test.rs:108:71:
called `Result::unwrap()` on an `Err` value: "Timeout 1s waiting for hosts [\"http://127.0.0.1:18204\", \"http://127.0.0.1:18205\"] to become healthy. Please set --router-worker-startup-timeout-secs (vllm_router.launch_server) or --worker-startup-timeout-secs (vllm_worker.router) to a larger value"
```