### PR TITLE
Feat: add transparent proxy for unmatched routes

### DIFF
--- a/src/routers/mod.rs
+++ b/src/routers/mod.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use axum::{
     body::Body,
     extract::Request,
-    http::{HeaderMap, StatusCode},
+    http::{HeaderMap, Method, StatusCode},
     response::{IntoResponse, Response},
 };
 use std::fmt::Debug;
@@ -161,4 +161,18 @@ pub trait RouterTrait: Send + Sync + Debug + WorkerManagement {
 
     /// Server readiness check - is the server ready to handle requests
     fn readiness(&self) -> Response;
+
+    /// Route a transparent proxy request (any path/body)
+    /// Used for catch-all routing of unmatched paths
+    /// Returns the response from the backend or an error response
+    async fn route_transparent(
+        &self,
+        _headers: Option<&HeaderMap>,
+        _path: &str,
+        _method: &Method,
+        _body: serde_json::Value,
+    ) -> Response {
+        // Default: not supported - return 404
+        (StatusCode::NOT_FOUND, "Not Found").into_response()
+    }
 }

--- a/tests/common/test_app.rs
+++ b/tests/common/test_app.rs
@@ -50,5 +50,6 @@ pub fn create_test_app(
         router_config.max_payload_size,
         request_id_headers,
         router_config.cors_allowed_origins.clone(),
+        true, // enable_transparent_proxy
     )
 }

--- a/tests/mock_vllm_server.py
+++ b/tests/mock_vllm_server.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""
+Simple mock vLLM server for testing the router's transparent proxy feature.
+
+Usage:
+    python mock_vllm_server.py [--port PORT] [--host HOST]
+
+Example:
+    # Start server on port 8081
+    python mock_vllm_server.py --port 8081
+
+    # Test with curl
+    curl -X POST http://localhost:8081/generate \
+        -H "Content-Type: application/json" \
+        -d '{"prompt": "Hello world"}'
+"""
+
+import argparse
+import json
+import sys
+from datetime import datetime
+from http.server import HTTPServer, BaseHTTPRequestHandler
+
+
+class MockVLLMHandler(BaseHTTPRequestHandler):
+    """Handler for mock vLLM server requests."""
+
+    def log_request_info(self, method: str):
+        """Log request information to stdout."""
+        timestamp = datetime.now().isoformat()
+        print(f"\n{'='*60}")
+        print(f"[{timestamp}] {method} {self.path}")
+        print(f"{'='*60}")
+        print(f"Client: {self.client_address[0]}:{self.client_address[1]}")
+        print(f"Path: {self.path}")
+        print(f"Headers:")
+        for header, value in self.headers.items():
+            print(f"  {header}: {value}")
+
+    def send_json_response(self, status_code: int, data: dict):
+        """Send a JSON response."""
+        response_body = json.dumps(data, indent=2).encode('utf-8')
+        self.send_response(status_code)
+        self.send_header('Content-Type', 'application/json')
+        self.send_header('Content-Length', str(len(response_body)))
+        self.end_headers()
+        self.wfile.write(response_body)
+
+    def do_GET(self):
+        """Handle GET requests."""
+        self.log_request_info("GET")
+
+        if self.path == "/health" or self.path == "/healthz":
+            print("Body: (none)")
+            print(f"\n[SUCCESS] Health check passed")
+            self.send_json_response(200, {"status": "healthy"})
+
+        elif self.path == "/v1/models":
+            print("Body: (none)")
+            print(f"\n[SUCCESS] Models list requested")
+            self.send_json_response(200, {
+                "object": "list",
+                "data": [
+                    {
+                        "id": "mock-model",
+                        "object": "model",
+                        "owned_by": "mock-server"
+                    }
+                ]
+            })
+
+        else:
+            print("Body: (none)")
+            print(f"\n[SUCCESS] GET request received at {self.path}")
+            self.send_json_response(200, {
+                "message": f"GET request received at {self.path}",
+                "path": self.path
+            })
+
+    def do_POST(self):
+        """Handle POST requests."""
+        self.log_request_info("POST")
+
+        # Read request body
+        content_length = int(self.headers.get('Content-Length', 0))
+        body = self.rfile.read(content_length).decode('utf-8') if content_length > 0 else ""
+
+        # Try to parse as JSON for pretty printing
+        try:
+            body_json = json.loads(body) if body else {}
+            print(f"Body (JSON):")
+            print(json.dumps(body_json, indent=2))
+        except json.JSONDecodeError:
+            print(f"Body (raw): {body[:500]}{'...' if len(body) > 500 else ''}")
+            body_json = {"raw": body}
+
+        # Handle different endpoints
+        if self.path == "/generate":
+            print(f"\n[SUCCESS] /generate endpoint called")
+            response = {
+                "text": "This is a mock response from the generate endpoint.",
+                "prompt": body_json.get("prompt", ""),
+                "model": body_json.get("model", "mock-model"),
+                "usage": {
+                    "prompt_tokens": 10,
+                    "completion_tokens": 15,
+                    "total_tokens": 25
+                }
+            }
+            self.send_json_response(200, response)
+
+        elif self.path == "/v1/chat/completions":
+            print(f"\n[SUCCESS] /v1/chat/completions endpoint called")
+            response = {
+                "id": "mock-chat-completion",
+                "object": "chat.completion",
+                "model": body_json.get("model", "mock-model"),
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": "This is a mock response from chat completions."
+                        },
+                        "finish_reason": "stop"
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 10,
+                    "completion_tokens": 12,
+                    "total_tokens": 22
+                }
+            }
+            self.send_json_response(200, response)
+
+        elif self.path == "/v1/completions":
+            print(f"\n[SUCCESS] /v1/completions endpoint called")
+            response = {
+                "id": "mock-completion",
+                "object": "text_completion",
+                "model": body_json.get("model", "mock-model"),
+                "choices": [
+                    {
+                        "index": 0,
+                        "text": "This is a mock completion response.",
+                        "finish_reason": "stop"
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 5,
+                    "completion_tokens": 8,
+                    "total_tokens": 13
+                }
+            }
+            self.send_json_response(200, response)
+
+        else:
+            # Handle any other POST endpoint (transparent proxy test)
+            print(f"\n[SUCCESS] Custom endpoint {self.path} called (transparent proxy)")
+            response = {
+                "message": f"POST request received at {self.path}",
+                "path": self.path,
+                "body_received": body_json,
+                "server": "mock-vllm-server"
+            }
+            self.send_json_response(200, response)
+
+    def log_message(self, format, *args):
+        """Suppress default logging (we do our own)."""
+        pass
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Mock vLLM server for testing router transparent proxy"
+    )
+    parser.add_argument(
+        "--port", "-p",
+        type=int,
+        default=8081,
+        help="Port to listen on (default: 8081)"
+    )
+    parser.add_argument(
+        "--host", "-H",
+        type=str,
+        default="0.0.0.0",
+        help="Host to bind to (default: 0.0.0.0)"
+    )
+    args = parser.parse_args()
+
+    server_address = (args.host, args.port)
+    httpd = HTTPServer(server_address, MockVLLMHandler)
+
+    print(f"Mock vLLM Server")
+    print(f"================")
+    print(f"Listening on {args.host}:{args.port}")
+    print(f"")
+    print(f"Available endpoints:")
+    print(f"  GET  /health           - Health check")
+    print(f"  GET  /v1/models        - List models")
+    print(f"  POST /generate         - Generate endpoint")
+    print(f"  POST /v1/completions   - Completions endpoint")
+    print(f"  POST /v1/chat/completions - Chat completions endpoint")
+    print(f"  POST /*                - Any other path (transparent proxy test)")
+    print(f"")
+    print(f"Press Ctrl+C to stop")
+    print(f"")
+
+    try:
+        httpd.serve_forever()
+    except KeyboardInterrupt:
+        print("\nShutting down...")
+        httpd.shutdown()
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
When enabled, unmatched request paths are transparently proxied through the appropriate backend instead of returning 404. This allows custom endpoints to be forwarded through the router.

Changes:
- Add route_transparent() method to RouterTrait with default 404 impl
- Implement route_transparent() for VllmPDRouter to route through P/D
- Implement route_transparent() for regular Router with load balancing
- Implement route_transparent() for PDRouter (forwards to decode worker)
- Implement route_transparent() for RouterManager (delegates to router)
- Add transparent_proxy_handler in server.rs as fallback handler
- Modify build_app() to accept enable_transparent_proxy parameter
- Enable transparent proxy by default for all routing modes

<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
