### PR TITLE
fix(consistent-hash): pass HTTP headers to policy in PD disaggregation mode

### DIFF
--- a/src/routers/http/pd_router.rs
+++ b/src/routers/http/pd_router.rs
@@ -8,7 +8,7 @@ use crate::core::{
     WorkerFactory, WorkerLoadGuard, WorkerRegistry, WorkerType,
 };
 use crate::metrics::RouterMetrics;
-use crate::policies::{LoadBalancingPolicy, PolicyRegistry};
+use crate::policies::{LoadBalancingPolicy, PolicyRegistry, RequestHeaders};
 use crate::protocols::spec::{
     ChatCompletionRequest, ChatMessage, CompletionRequest, GenerateRequest, RerankRequest,
     ResponsesRequest, StringOrArray, UserMessageContent,
@@ -60,6 +60,20 @@ struct PDRequestContext<'a> {
     return_logprob: bool,
     request_text: Option<String>,
     model_id: Option<&'a str>,
+}
+
+/// Convert axum HeaderMap to policy RequestHeaders (HashMap<String, String>)
+fn headers_to_request_headers(headers: Option<&HeaderMap>) -> Option<RequestHeaders> {
+    headers.map(|h| {
+        h.iter()
+            .filter_map(|(name, value)| {
+                value
+                    .to_str()
+                    .ok()
+                    .map(|v| (name.as_str().to_lowercase(), v.to_string()))
+            })
+            .collect()
+    })
 }
 
 impl PDRouter {
@@ -838,7 +852,11 @@ impl PDRouter {
                     async move {
                         // Select workers fresh for each attempt
                         let (prefill, decode) = match self
-                            .select_pd_pair(context.request_text.as_deref(), context.model_id)
+                            .select_pd_pair(
+                                context.request_text.as_deref(),
+                                context.model_id,
+                                headers,
+                            )
                             .await
                         {
                             Ok(pair) => pair,
@@ -1245,6 +1263,7 @@ impl PDRouter {
         &self,
         request_text: Option<&str>,
         model_id: Option<&str>,
+        headers: Option<&HeaderMap>,
     ) -> Result<(Arc<dyn Worker>, Arc<dyn Worker>), String> {
         // Get workers from registry - filter by model if provided
         let prefill_workers = if let Some(model) = model_id {
@@ -1269,6 +1288,9 @@ impl PDRouter {
             self.worker_registry.get_decode_workers()
         };
 
+        // Convert headers for policies that need them (e.g., consistent_hash)
+        let request_headers = headers_to_request_headers(headers);
+
         // Select workers using helper function
         // Use separate policies for prefill and decode to avoid counter conflicts
         let prefill_policy = self.policy_registry.get_prefill_policy();
@@ -1278,6 +1300,7 @@ impl PDRouter {
             &prefill_workers,
             &*prefill_policy,
             request_text,
+            request_headers.as_ref(),
             "prefill",
         )?;
 
@@ -1285,6 +1308,7 @@ impl PDRouter {
             &decode_workers,
             &*decode_policy,
             request_text,
+            request_headers.as_ref(),
             "decode",
         )?;
 
@@ -1296,6 +1320,7 @@ impl PDRouter {
         workers: &[Arc<dyn Worker>],
         policy: &dyn LoadBalancingPolicy,
         request_text: Option<&str>,
+        headers: Option<&RequestHeaders>,
         worker_type: &str,
     ) -> Result<Arc<dyn Worker>, String> {
         // Check if we have any workers
@@ -1320,9 +1345,9 @@ impl PDRouter {
             ));
         }
 
-        // Let policy select from available workers (no conversion needed now!)
+        // Let policy select from available workers with headers for session affinity
         let selected_idx = policy
-            .select_worker(&available_workers, request_text)
+            .select_worker_with_headers(&available_workers, request_text, headers)
             .ok_or_else(|| {
                 format!(
                     "Policy {} failed to select a {} worker",
@@ -1830,7 +1855,7 @@ impl RouterTrait for PDRouter {
         // Note: This endpoint actually causes the model to generate tokens, so we only test one pair
 
         // Select a random worker pair using the policy
-        let (prefill, decode) = match self.select_pd_pair(None, None).await {
+        let (prefill, decode) = match self.select_pd_pair(None, None, None).await {
             Ok(pair) => pair,
             Err(e) => {
                 return (
@@ -2538,7 +2563,7 @@ mod tests {
         router.worker_registry.register(Arc::from(healthy_worker));
         router.worker_registry.register(Arc::from(decode_worker));
 
-        let result = router.select_pd_pair(None, None).await;
+        let result = router.select_pd_pair(None, None, None).await;
 
         assert!(result.is_ok());
         let (prefill, _decode) = result.unwrap();
@@ -2552,7 +2577,7 @@ mod tests {
     async fn test_empty_worker_lists() {
         let router = create_test_pd_router();
 
-        let result = router.select_pd_pair(None, None).await;
+        let result = router.select_pd_pair(None, None, None).await;
 
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("No prefill workers available"));

--- a/src/routers/http/vllm_pd_router.rs
+++ b/src/routers/http/vllm_pd_router.rs
@@ -7,7 +7,7 @@ use super::pd_router::PDRouter;
 use super::pd_types::PDRouterError;
 use super::vllm_service_discovery::{ServiceRegistry, ServiceType};
 use crate::core::{BasicWorker, Worker, WorkerType};
-use crate::policies::PolicyRegistry;
+use crate::policies::{PolicyRegistry, RequestHeaders};
 use crate::routers::{RouterTrait, WorkerManagement};
 use async_trait::async_trait;
 use axum::{
@@ -44,6 +44,20 @@ pub struct VllmPDRouter {
     profiling_tasks: Arc<Mutex<HashMap<String, tokio::task::AbortHandle>>>,
     /// Intra-node data parallel size for DP-aware routing (automatically enabled when > 1)
     intra_node_data_parallel_size: usize,
+}
+
+/// Convert axum HeaderMap to policy RequestHeaders (HashMap<String, String>)
+fn headers_to_request_headers(headers: Option<&HeaderMap>) -> Option<RequestHeaders> {
+    headers.map(|h| {
+        h.iter()
+            .filter_map(|(name, value)| {
+                value
+                    .to_str()
+                    .ok()
+                    .map(|v| (name.as_str().to_lowercase(), v.to_string()))
+            })
+            .collect()
+    })
 }
 
 impl VllmPDRouter {
@@ -181,6 +195,7 @@ impl VllmPDRouter {
         instances: &[(String, String)],
         is_prefill: bool,
         request_text: Option<&str>,
+        headers: Option<&RequestHeaders>,
     ) -> Option<usize> {
         if instances.is_empty() {
             return None;
@@ -196,8 +211,8 @@ impl VllmPDRouter {
             self.policy_registry.get_decode_policy()
         };
 
-        // Use policy to select worker
-        policy.select_worker(&workers, request_text)
+        // Use policy to select worker with headers for session affinity
+        policy.select_worker_with_headers(&workers, request_text, headers)
     }
 
     /// Process vLLM request using pure service discovery
@@ -239,20 +254,31 @@ impl VllmPDRouter {
         let request_text = serde_json::to_string(&request_json).ok();
         let request_str = request_text.as_deref();
 
-        let prefill_idx =
-            match self.select_worker_with_policy(&prefill_instances, true, request_str) {
-                Some(idx) => idx,
-                None => {
-                    return (
-                        axum::http::StatusCode::SERVICE_UNAVAILABLE,
-                        "Prefill policy failed to select a worker".to_string(),
-                    )
-                        .into_response();
-                }
-            };
+        // Convert headers for policies that need them (e.g., consistent_hash)
+        let request_headers = headers_to_request_headers(headers);
 
-        let decode_idx = match self.select_worker_with_policy(&decode_instances, false, request_str)
-        {
+        let prefill_idx = match self.select_worker_with_policy(
+            &prefill_instances,
+            true,
+            request_str,
+            request_headers.as_ref(),
+        ) {
+            Some(idx) => idx,
+            None => {
+                return (
+                    axum::http::StatusCode::SERVICE_UNAVAILABLE,
+                    "Prefill policy failed to select a worker".to_string(),
+                )
+                    .into_response();
+            }
+        };
+
+        let decode_idx = match self.select_worker_with_policy(
+            &decode_instances,
+            false,
+            request_str,
+            request_headers.as_ref(),
+        ) {
             Some(idx) => idx,
             None => {
                 return (
@@ -1194,10 +1220,17 @@ impl RouterTrait for VllmPDRouter {
             let request_text = serde_json::to_string(&request_json).ok();
             let request_str = request_text.as_deref();
 
+            // Convert headers for policies that need them (e.g., consistent_hash)
+            let request_headers = headers_to_request_headers(headers);
+
             let prefill_policy = self.policy_registry.get_prefill_policy();
             let decode_policy = self.policy_registry.get_decode_policy();
 
-            let prefill_idx = match prefill_policy.select_worker(&prefill_workers, request_str) {
+            let prefill_idx = match prefill_policy.select_worker_with_headers(
+                &prefill_workers,
+                request_str,
+                request_headers.as_ref(),
+            ) {
                 Some(idx) => idx,
                 None => {
                     return (
@@ -1208,7 +1241,11 @@ impl RouterTrait for VllmPDRouter {
                 }
             };
 
-            let decode_idx = match decode_policy.select_worker(&decode_workers, request_str) {
+            let decode_idx = match decode_policy.select_worker_with_headers(
+                &decode_workers,
+                request_str,
+                request_headers.as_ref(),
+            ) {
                 Some(idx) => idx,
                 None => {
                     return (
@@ -1344,10 +1381,17 @@ impl RouterTrait for VllmPDRouter {
             let request_text = serde_json::to_string(&request_json).ok();
             let request_str = request_text.as_deref();
 
+            // Convert headers for policies that need them (e.g., consistent_hash)
+            let request_headers = headers_to_request_headers(headers);
+
             let prefill_policy = self.policy_registry.get_prefill_policy();
             let decode_policy = self.policy_registry.get_decode_policy();
 
-            let prefill_idx = match prefill_policy.select_worker(&prefill_workers, request_str) {
+            let prefill_idx = match prefill_policy.select_worker_with_headers(
+                &prefill_workers,
+                request_str,
+                request_headers.as_ref(),
+            ) {
                 Some(idx) => idx,
                 None => {
                     return (
@@ -1358,7 +1402,11 @@ impl RouterTrait for VllmPDRouter {
                 }
             };
 
-            let decode_idx = match decode_policy.select_worker(&decode_workers, request_str) {
+            let decode_idx = match decode_policy.select_worker_with_headers(
+                &decode_workers,
+                request_str,
+                request_headers.as_ref(),
+            ) {
                 Some(idx) => idx,
                 None => {
                     return (
@@ -1515,10 +1563,17 @@ impl RouterTrait for VllmPDRouter {
             let request_text = serde_json::to_string(&request_json).ok();
             let request_str = request_text.as_deref();
 
+            // Convert headers for policies that need them (e.g., consistent_hash)
+            let request_headers = headers_to_request_headers(headers);
+
             let prefill_policy = self.policy_registry.get_prefill_policy();
             let decode_policy = self.policy_registry.get_decode_policy();
 
-            let prefill_idx = match prefill_policy.select_worker(&prefill_workers, request_str) {
+            let prefill_idx = match prefill_policy.select_worker_with_headers(
+                &prefill_workers,
+                request_str,
+                request_headers.as_ref(),
+            ) {
                 Some(idx) => idx,
                 None => {
                     return (
@@ -1529,7 +1584,11 @@ impl RouterTrait for VllmPDRouter {
                 }
             };
 
-            let decode_idx = match decode_policy.select_worker(&decode_workers, request_str) {
+            let decode_idx = match decode_policy.select_worker_with_headers(
+                &decode_workers,
+                request_str,
+                request_headers.as_ref(),
+            ) {
                 Some(idx) => idx,
                 None => {
                     return (

--- a/tests/test_consistent_hash_policy.rs
+++ b/tests/test_consistent_hash_policy.rs
@@ -715,4 +715,150 @@ mod consistent_hash_policy_tests {
             "ConsistentHashPolicy should report that it needs headers"
         );
     }
+
+    // =============================
+    // PD mode + HTTP Header routing tests
+    // =============================
+
+    #[test]
+    fn test_select_worker_pair_with_headers_pd_mode() {
+        let policy = ConsistentHashPolicy::new();
+        let prefill_workers = create_test_workers();
+        let decode_workers = create_test_workers();
+
+        let session_id = "pd-header-session-456";
+        let headers = create_headers(&[("x-session-id", session_id)]);
+
+        // Test PD mode worker pair selection with HTTP headers
+        if let Some((prefill_idx, decode_idx)) = policy.select_worker_pair_with_headers(
+            &prefill_workers,
+            &decode_workers,
+            Some(r#"{"prompt": "pd header test"}"#),
+            Some(&headers),
+        ) {
+            assert!(
+                prefill_idx < prefill_workers.len(),
+                "Prefill worker index should be valid"
+            );
+            assert!(
+                decode_idx < decode_workers.len(),
+                "Decode worker index should be valid"
+            );
+
+            // For the same session header, should get consistent results
+            if let Some((prefill_idx2, decode_idx2)) = policy.select_worker_pair_with_headers(
+                &prefill_workers,
+                &decode_workers,
+                Some(r#"{"prompt": "different prompt, same header"}"#),
+                Some(&headers),
+            ) {
+                assert_eq!(
+                    prefill_idx, prefill_idx2,
+                    "Prefill worker should be consistent for same X-Session-ID header"
+                );
+                assert_eq!(
+                    decode_idx, decode_idx2,
+                    "Decode worker should be consistent for same X-Session-ID header"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_pd_mode_header_takes_priority_over_body() {
+        let policy = ConsistentHashPolicy::new();
+        let prefill_workers = create_test_workers();
+        let decode_workers = create_test_workers();
+
+        let header_session = "header-wins-in-pd";
+        let body_session = "body-loses-in-pd";
+
+        let headers = create_headers(&[("x-session-id", header_session)]);
+        let body = format!(
+            r#"{{"session_params": {{"session_id": "{}"}}, "prompt": "test"}}"#,
+            body_session
+        );
+
+        // PD pair with header
+        let with_header = policy
+            .select_worker_pair_with_headers(
+                &prefill_workers,
+                &decode_workers,
+                Some(&body),
+                Some(&headers),
+            )
+            .expect("Should select pair with header");
+
+        // PD pair with header-only (no body session)
+        let header_only = policy
+            .select_worker_pair_with_headers(
+                &prefill_workers,
+                &decode_workers,
+                Some(r#"{"prompt": "no session in body"}"#),
+                Some(&headers),
+            )
+            .expect("Should select pair with header only");
+
+        // Header should take priority - both should route to same workers
+        assert_eq!(
+            with_header.0, header_only.0,
+            "Prefill: HTTP header should take priority over body session_params in PD mode"
+        );
+        assert_eq!(
+            with_header.1, header_only.1,
+            "Decode: HTTP header should take priority over body session_params in PD mode"
+        );
+    }
+
+    #[test]
+    fn test_pd_mode_without_headers_falls_back_to_body() {
+        let policy = ConsistentHashPolicy::new();
+        let prefill_workers = create_test_workers();
+        let decode_workers = create_test_workers();
+
+        let session_id = "body-session-in-pd";
+        let body = format!(
+            r#"{{"session_params": {{"session_id": "{}"}}, "prompt": "test"}}"#,
+            session_id
+        );
+
+        // PD pair without headers (None)
+        let without_headers = policy
+            .select_worker_pair_with_headers(&prefill_workers, &decode_workers, Some(&body), None)
+            .expect("Should select pair without headers");
+
+        // PD pair with empty headers
+        let empty_headers: RequestHeaders = HashMap::new();
+        let with_empty_headers = policy
+            .select_worker_pair_with_headers(
+                &prefill_workers,
+                &decode_workers,
+                Some(&body),
+                Some(&empty_headers),
+            )
+            .expect("Should select pair with empty headers");
+
+        // PD pair using old API (no headers)
+        let old_api = policy
+            .select_worker_pair(&prefill_workers, &decode_workers, Some(&body))
+            .expect("Should select pair with old API");
+
+        // All three should route to the same workers via body fallback
+        assert_eq!(
+            without_headers.0, with_empty_headers.0,
+            "Prefill: None headers and empty headers should route the same"
+        );
+        assert_eq!(
+            without_headers.1, with_empty_headers.1,
+            "Decode: None headers and empty headers should route the same"
+        );
+        assert_eq!(
+            without_headers.0, old_api.0,
+            "Prefill: Should be consistent with old API"
+        );
+        assert_eq!(
+            without_headers.1, old_api.1,
+            "Decode: Should be consistent with old API"
+        );
+    }
 }


### PR DESCRIPTION
## Purpose

In PD disaggregation mode (`--pd-disaggregation` and `--vllm-pd-disaggregation`), the `consistent_hash` policy's HTTP header-based session affinity (e.g., `X-Session-ID`) was silently broken. Headers were never passed to the policy because `PDRouter` and `VllmPDRouter` called `select_worker()` instead of `select_worker_with_headers()`.

The `LoadBalancingPolicy` trait already provides full header support via `select_worker_with_headers()`, and `ConsistentHashPolicy` correctly implements header extraction. The regular `Router` (non-PD mode) was already calling `select_worker_with_headers()` correctly — only the PD routers were missing this.

This is the same class of bug as #70 (cache_aware policy not properly wired in PD mode).

## Changes

- `PDRouter.pick_worker_by_policy_arc`: accept `RequestHeaders` and call `select_worker_with_headers` instead of `select_worker`
- `PDRouter.select_pd_pair`: accept `HeaderMap`, convert to `RequestHeaders`, and pass through
- `VllmPDRouter.select_worker_with_policy`: accept `RequestHeaders` and call `select_worker_with_headers`
- `VllmPDRouter` route_chat/route_completion/transparent_proxy: convert headers and pass to policy selection in all code paths
- Add 3 unit tests for PD mode header-based consistent hash routing

Other policies (`random`, `round_robin`, `power_of_two`, `cache_aware`) are unaffected as they ignore the headers parameter (`_headers`).

## Test Plan

- [x] Added unit tests: `test_select_worker_pair_with_headers_pd_mode`, `test_pd_mode_header_takes_priority_over_body`, `test_pd_mode_without_headers_falls_back_to_body`
- [x] Manual test: PD mode + `--policy consistent_hash` + `X-Session-ID` header routes consistently to same worker pair