### PR TITLE
fix: use endpoint_url() in transparent proxy to fix IPv6+DP URL corru…

### DIFF
--- a/src/core/worker.rs
+++ b/src/core/worker.rs
@@ -1688,6 +1688,38 @@ mod tests {
     }
 
     #[test]
+    fn test_dp_aware_endpoint_url_ipv6() {
+        let dp_worker = DPAwareWorker::new(
+            "https://[2a03:83e4:5006:0090:5f5a:f8c5:0400:0000]:20009".to_string(),
+            2,
+            4,
+            WorkerType::Regular,
+        );
+
+        // url() includes the @rank suffix (used for worker identification/registry)
+        assert_eq!(
+            dp_worker.url(),
+            "https://[2a03:83e4:5006:0090:5f5a:f8c5:0400:0000]:20009@2"
+        );
+
+        // base_url() strips the @rank suffix (used for actual HTTP requests)
+        assert_eq!(
+            dp_worker.base_url(),
+            "https://[2a03:83e4:5006:0090:5f5a:f8c5:0400:0000]:20009"
+        );
+
+        // endpoint_url() uses base_url, not url(), to construct request URLs
+        assert_eq!(
+            dp_worker.endpoint_url("/inference/v1/generate"),
+            "https://[2a03:83e4:5006:0090:5f5a:f8c5:0400:0000]:20009/inference/v1/generate"
+        );
+
+        assert_eq!(dp_worker.dp_rank(), Some(2));
+        assert_eq!(dp_worker.dp_size(), Some(4));
+        assert!(dp_worker.is_dp_aware());
+    }
+
+    #[test]
     fn test_dp_aware_worker_delegated_methods() {
         let dp_worker =
             DPAwareWorker::new("http://worker1:8080".to_string(), 0, 2, WorkerType::Regular);

--- a/src/routers/http/router.rs
+++ b/src/routers/http/router.rs
@@ -1602,7 +1602,7 @@ impl RouterTrait for Router {
         };
 
         let worker: &dyn Worker = workers[worker_idx].as_ref();
-        let url = format!("{}{}", worker.url(), path);
+        let url = worker.endpoint_url(path);
 
         debug!("Transparent proxy: forwarding to {}", url);
 
@@ -1622,6 +1622,9 @@ impl RouterTrait for Router {
                     .into_response();
             }
         };
+
+        // Add X-data-parallel-rank header for DP-aware routing
+        request_builder = dp_utils::add_dp_rank_header(request_builder, worker.dp_rank());
 
         // Propagate headers
         request_builder = header_utils::propagate_trace_headers(request_builder, headers);


### PR DESCRIPTION
## Purpose

When intra_node_data_parallel_size > 1, worker URLs include a @rank
suffix (e.g., https://[ipv6]:port@2). The transparent proxy handler
(route_transparent) was constructing request URLs using worker.url()
which includes this suffix. When reqwest parses the URL, the @ is
interpreted as a userinfo separator per RFC 3986, corrupting IPv6
addresses (e.g., https://0.0.0.2/ instead of the actual IPv6 address)
and causing 502 errors.

Fix: use worker.endpoint_url(path) which delegates to base_url()
(stripping the @rank suffix) and add the X-data-parallel-rank header
via dp_utils::add_dp_rank_header(). This matches how send_typed_request
already handles DP-aware routing.

Both Router and PDRouter transparent proxy paths are fixed.

## Test Plan

unit tested
e2e runs and see [ip]@0,1,2 being populated correctly

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
