### PR TITLE
fix: make prepare_prefill_request works for generate API

### DIFF
--- a/src/routers/http/vllm_pd_router.rs
+++ b/src/routers/http/vllm_pd_router.rs
@@ -140,6 +140,7 @@ impl VllmPDRouter {
     /// Modify request for prefill stage (set max_tokens=1)
     /// - For inference/v1/generate: patch sampling_params.max_tokens and sampling_params.min_tokens
     /// - For other endpoints (fallback): patch top-level max_tokens, max_completion_tokens, min_tokens
+    ///
     /// stream=false and stream_options removal are always applied at top level.
     fn prepare_prefill_request(mut request: Value, path: &str) -> Value {
         if path.contains("inference/v1/generate") {
@@ -148,8 +149,7 @@ impl VllmPDRouter {
                 sampling_params["max_tokens"] = json!(1);
                 // Also adjust min_tokens to ensure min_tokens <= max_tokens
                 // This is required because vLLM validates that min_tokens <= max_tokens
-                if let Some(min_tokens) =
-                    sampling_params.get("min_tokens").and_then(|v| v.as_u64())
+                if let Some(min_tokens) = sampling_params.get("min_tokens").and_then(|v| v.as_u64())
                 {
                     if min_tokens > 1 {
                         sampling_params["min_tokens"] = json!(1);
@@ -1745,8 +1745,7 @@ mod tests {
                 "temperature": 0.7
             }
         });
-        let result =
-            VllmPDRouter::prepare_prefill_request(request, "/inference/v1/generate");
+        let result = VllmPDRouter::prepare_prefill_request(request, "/inference/v1/generate");
         // sampling_params.max_tokens should be capped
         assert_eq!(result["sampling_params"]["max_tokens"], 1);
         // temperature should be preserved
@@ -1764,8 +1763,7 @@ mod tests {
                 "min_tokens": 50
             }
         });
-        let result =
-            VllmPDRouter::prepare_prefill_request(request, "/inference/v1/generate");
+        let result = VllmPDRouter::prepare_prefill_request(request, "/inference/v1/generate");
         assert_eq!(result["sampling_params"]["max_tokens"], 1);
         assert_eq!(result["sampling_params"]["min_tokens"], 1);
     }
@@ -1776,8 +1774,7 @@ mod tests {
         let request = json!({
             "token_ids": [123, 456],
         });
-        let result =
-            VllmPDRouter::prepare_prefill_request(request, "/inference/v1/generate");
+        let result = VllmPDRouter::prepare_prefill_request(request, "/inference/v1/generate");
         // stream should still be forced to false
         assert_eq!(result["stream"], false);
         // top-level max_tokens should NOT be set (generate path)
@@ -1795,8 +1792,7 @@ mod tests {
             "stream": true,
             "stream_options": {"include_usage": true}
         });
-        let result =
-            VllmPDRouter::prepare_prefill_request(request, "/inference/v1/generate");
+        let result = VllmPDRouter::prepare_prefill_request(request, "/inference/v1/generate");
         assert_eq!(result["stream"], false);
         assert!(result.get("stream_options").is_none());
     }


### PR DESCRIPTION
The generate API (inference/v1/generate) places max_tokens and min_tokens inside a nested sampling_params object, unlike OpenAI-style endpoints (chat/completions) which use top-level fields. Previously, prepare_prefill_request only patched top-level fields, which meant prefill requests to the generate API were not correctly capped at max_tokens=1.

This change adds a path parameter to prepare_prefill_request and uses it to select the correct patching strategy:
- For inference/v1/generate: patch sampling_params.max_tokens and sampling_params.min_tokens
- For other endpoints: patch top-level max_tokens, max_completion_tokens, and min_tokens (existing behavior)

Also deduplicates inline prefill request preparation in process_vllm_two_stage_request_discovered by reusing the shared prepare_prefill_request method.

<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
