### PR TITLE
fix: fix rustfmt and apply IPv6+DP URL fix to VllmPDRouter

### DIFF
--- a/src/routers/http/dp_utils.rs
+++ b/src/routers/http/dp_utils.rs
@@ -178,8 +178,7 @@ mod tests {
 
     #[test]
     fn test_extract_dp_rank_ipv6() {
-        let result =
-            extract_dp_rank("https://[2a03:83e4:5006:0090:5f5a:f8c5:0400:0000]:20009@2");
+        let result = extract_dp_rank("https://[2a03:83e4:5006:0090:5f5a:f8c5:0400:0000]:20009@2");
         assert!(result.is_ok());
         let (base, rank) = result.unwrap();
         assert_eq!(
@@ -191,8 +190,7 @@ mod tests {
 
     #[test]
     fn test_extract_dp_rank_ipv6_rank_zero() {
-        let result =
-            extract_dp_rank("https://[2a03:83e4:5006:0090:5f5a:f8c5:0400:0000]:20009@0");
+        let result = extract_dp_rank("https://[2a03:83e4:5006:0090:5f5a:f8c5:0400:0000]:20009@0");
         assert!(result.is_ok());
         let (base, rank) = result.unwrap();
         assert_eq!(
@@ -226,9 +224,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_dp_aware_workers_ipv6() {
-        let urls = vec![
-            "https://[2a03:83e4:5006:0090:5f5a:f8c5:0400:0000]:20009".to_string(),
-        ];
+        let urls = vec!["https://[2a03:83e4:5006:0090:5f5a:f8c5:0400:0000]:20009".to_string()];
         let result = get_dp_aware_workers(&urls, &None, 4).await.unwrap();
         assert_eq!(result.len(), 4);
         assert_eq!(

--- a/src/routers/http/vllm_pd_router.rs
+++ b/src/routers/http/vllm_pd_router.rs
@@ -696,25 +696,11 @@ impl VllmPDRouter {
 
         debug!("Added kv_transfer_params to prefill request for NixlConnector support");
 
-        // Extract base URL and dp_rank if intra_node_data_parallel_size > 1
-        let (prefill_base_url, prefill_dp_rank) = if self.intra_node_data_parallel_size > 1 {
-            match dp_utils::extract_dp_rank(prefill_worker.url()) {
-                Ok((base, rank)) => (base.to_string(), Some(rank)),
-                Err(e) => {
-                    return Err(PDRouterError::NetworkError {
-                        message: format!(
-                            "Failed to extract dp_rank from prefill worker URL {}: {}",
-                            prefill_worker.url(),
-                            e
-                        ),
-                    });
-                }
-            }
-        } else {
-            (prefill_worker.url().to_string(), None)
-        };
-
-        let prefill_url = format!("{}{}", prefill_base_url, path);
+        // Use endpoint_url() to get the base URL without @rank suffix,
+        // avoiding IPv6+DP URL corruption (same fix as Router and PDRouter)
+        let prefill_base_url = prefill_worker.base_url().to_string();
+        let prefill_dp_rank = prefill_worker.dp_rank();
+        let prefill_url = prefill_worker.endpoint_url(path);
 
         debug!(
             "🚀 vLLM Stage 1 - Prefill: {} with request_id: {}",
@@ -750,15 +736,11 @@ impl VllmPDRouter {
             )
             .header("X-Request-Id", &request_id);
 
-        // Propagate trace headers
+        // Propagate trace headers and add X-data-parallel-rank header using shared utilities
         prefill_request_builder =
             header_utils::propagate_trace_headers(prefill_request_builder, headers);
-
-        // Add X-data-parallel-rank header if intra_node_data_parallel_size > 1
-        if let Some(rank) = prefill_dp_rank {
-            prefill_request_builder =
-                prefill_request_builder.header("X-data-parallel-rank", rank.to_string());
-        }
+        prefill_request_builder =
+            dp_utils::add_dp_rank_header(prefill_request_builder, prefill_dp_rank);
 
         let prefill_response = match prefill_request_builder.json(&prefill_request).send().await {
             Ok(resp) => resp,
@@ -854,26 +836,11 @@ impl VllmPDRouter {
             debug!("Added kv_transfer_params to decode request");
         }
 
-        // Extract base URL and dp_rank if intra_node_data_parallel_size > 1
-        let (decode_base_url, decode_dp_rank) = if self.intra_node_data_parallel_size > 1 {
-            match dp_utils::extract_dp_rank(decode_worker.url()) {
-                Ok((base, rank)) => (base.to_string(), Some(rank)),
-                Err(e) => {
-                    decode_worker.decrement_load();
-                    return Err(PDRouterError::NetworkError {
-                        message: format!(
-                            "Failed to extract dp_rank from decode worker URL {}: {}",
-                            decode_worker.url(),
-                            e
-                        ),
-                    });
-                }
-            }
-        } else {
-            (decode_worker.url().to_string(), None)
-        };
-
-        let decode_url = format!("{}{}", decode_base_url, path);
+        // Use endpoint_url() to get the base URL without @rank suffix,
+        // avoiding IPv6+DP URL corruption (same fix as Router and PDRouter)
+        let decode_base_url = decode_worker.base_url().to_string();
+        let decode_dp_rank = decode_worker.dp_rank();
+        let decode_url = decode_worker.endpoint_url(path);
 
         debug!(
             "🚀 vLLM Stage 2 - Decode: {} with request_id: {}",
@@ -909,15 +876,11 @@ impl VllmPDRouter {
             )
             .header("X-Request-Id", &request_id);
 
-        // Propagate trace headers
+        // Propagate trace headers and add X-data-parallel-rank header using shared utilities
         decode_request_builder =
             header_utils::propagate_trace_headers(decode_request_builder, headers);
-
-        // Add X-data-parallel-rank header if intra_node_data_parallel_size > 1
-        if let Some(rank) = decode_dp_rank {
-            decode_request_builder =
-                decode_request_builder.header("X-data-parallel-rank", rank.to_string());
-        }
+        decode_request_builder =
+            dp_utils::add_dp_rank_header(decode_request_builder, decode_dp_rank);
 
         let decode_response = match decode_request_builder.json(&decode_request).send().await {
             Ok(resp) => resp,


### PR DESCRIPTION
Fix rustfmt formatting in dp_utils.rs tests to pass CI format check.

Apply the same endpoint_url() fix from #92 to VllmPDRouter's process_vllm_two_stage_request. Replace manual dp_utils::extract_dp_rank() with worker.endpoint_url(path), worker.base_url(), worker.dp_rank(), and dp_utils::add_dp_rank_header() to avoid IPv6+DP URL corruption when reqwest misinterprets @rank as a userinfo separator.

<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

## Test Plan
buildkite

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
