### PR TITLE
feat: add multi-prefill-pool support for modality-based routing

### DIFF
--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -1,7 +1,7 @@
 use super::ConfigResult;
 use crate::config::validation::ConfigValidator;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 /// Main router configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -281,8 +281,11 @@ pub struct DiscoveryConfig {
     pub check_interval_secs: u64,
     /// Regular mode selector
     pub selector: HashMap<String, String>,
-    /// PD mode prefill selector
-    pub prefill_selector: HashMap<String, String>,
+    /// PD mode prefill selectors (pool_name -> label selector)
+    /// Supports multiple prefill pools for modality-based routing.
+    /// Uses BTreeMap for deterministic iteration order (sorted by pool name),
+    /// ensuring consistent pool assignment when selectors overlap.
+    pub prefill_selectors: BTreeMap<String, HashMap<String, String>>,
     /// PD mode decode selector
     pub decode_selector: HashMap<String, String>,
     /// Bootstrap port annotation key
@@ -297,7 +300,7 @@ impl Default for DiscoveryConfig {
             port: 8000,
             check_interval_secs: 120,
             selector: HashMap::new(),
-            prefill_selector: HashMap::new(),
+            prefill_selectors: BTreeMap::new(),
             decode_selector: HashMap::new(),
             bootstrap_port_annotation: "vllm.ai/bootstrap-port".to_string(),
         }
@@ -763,7 +766,7 @@ mod tests {
         assert_eq!(config.port, 8000);
         assert_eq!(config.check_interval_secs, 120);
         assert!(config.selector.is_empty());
-        assert!(config.prefill_selector.is_empty());
+        assert!(config.prefill_selectors.is_empty());
         assert!(config.decode_selector.is_empty());
         assert_eq!(config.bootstrap_port_annotation, "vllm.ai/bootstrap-port");
     }
@@ -774,13 +777,16 @@ mod tests {
         selector.insert("app".to_string(), "vllm".to_string());
         selector.insert("role".to_string(), "worker".to_string());
 
+        let mut prefill_selectors = BTreeMap::new();
+        prefill_selectors.insert("default".to_string(), selector.clone());
+
         let config = DiscoveryConfig {
             enabled: true,
             namespace: Some("default".to_string()),
             port: 9000,
             check_interval_secs: 30,
             selector: selector.clone(),
-            prefill_selector: selector.clone(),
+            prefill_selectors,
             decode_selector: selector.clone(),
             bootstrap_port_annotation: "custom.io/port".to_string(),
         };
@@ -1117,7 +1123,11 @@ mod tests {
                 port: 8443,
                 check_interval_secs: 120,
                 selector: selectors.clone(),
-                prefill_selector: selectors.clone(),
+                prefill_selectors: {
+                    let mut m = BTreeMap::new();
+                    m.insert("default".to_string(), selectors.clone());
+                    m
+                },
                 decode_selector: selectors,
                 bootstrap_port_annotation: "mycompany.io/bootstrap".to_string(),
             }),

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -321,14 +321,16 @@ impl ConfigValidator {
                 }
             }
             RoutingMode::PrefillDecode { .. } => {
-                if discovery.prefill_selector.is_empty() && discovery.decode_selector.is_empty() {
+                let has_valid_prefill = discovery.prefill_selectors.values().any(|s| !s.is_empty());
+                if !has_valid_prefill && discovery.decode_selector.is_empty() {
                     return Err(ConfigError::ValidationFailed {
                         reason: "PD mode with service discovery requires at least one non-empty selector (prefill or decode)".to_string(),
                     });
                 }
             }
             RoutingMode::VllmPrefillDecode { .. } => {
-                if discovery.prefill_selector.is_empty() && discovery.decode_selector.is_empty() {
+                let has_valid_prefill = discovery.prefill_selectors.values().any(|s| !s.is_empty());
+                if !has_valid_prefill && discovery.decode_selector.is_empty() {
                     return Err(ConfigError::ValidationFailed {
                         reason: "vLLM PD mode with service discovery requires at least one non-empty selector (prefill or decode)".to_string(),
                     });

--- a/src/core/worker.rs
+++ b/src/core/worker.rs
@@ -367,6 +367,11 @@ impl BasicWorker {
         self
     }
 
+    pub fn with_label(mut self, key: String, value: String) -> Self {
+        self.metadata.labels.insert(key, value);
+        self
+    }
+
     pub fn with_health_config(mut self, config: HealthConfig) -> Self {
         self.metadata.health_config = config;
         self
@@ -1906,6 +1911,73 @@ mod tests {
         assert_eq!(
             dp_worker.circuit_breaker().state(),
             crate::core::CircuitState::Open
+        );
+    }
+
+    // ===== with_label tests =====
+
+    #[test]
+    fn test_with_label_adds_single_label() {
+        let worker = BasicWorker::new("http://worker:8080".to_string(), WorkerType::Regular)
+            .with_label("pool".to_string(), "text".to_string());
+
+        assert_eq!(
+            worker.metadata().labels.get("pool"),
+            Some(&"text".to_string())
+        );
+    }
+
+    #[test]
+    fn test_with_label_adds_multiple_labels() {
+        let worker = BasicWorker::new(
+            "http://worker:8080".to_string(),
+            WorkerType::Prefill {
+                bootstrap_port: None,
+            },
+        )
+        .with_label("prefill_pool".to_string(), "perception".to_string())
+        .with_label("region".to_string(), "us-east".to_string());
+
+        assert_eq!(
+            worker.metadata().labels.get("prefill_pool"),
+            Some(&"perception".to_string())
+        );
+        assert_eq!(
+            worker.metadata().labels.get("region"),
+            Some(&"us-east".to_string())
+        );
+        assert_eq!(worker.metadata().labels.len(), 2);
+    }
+
+    #[test]
+    fn test_with_label_overwrites_existing() {
+        let worker = BasicWorker::new("http://worker:8080".to_string(), WorkerType::Regular)
+            .with_label("pool".to_string(), "text".to_string())
+            .with_label("pool".to_string(), "perception".to_string());
+
+        assert_eq!(
+            worker.metadata().labels.get("pool"),
+            Some(&"perception".to_string())
+        );
+        assert_eq!(worker.metadata().labels.len(), 1);
+    }
+
+    #[test]
+    fn test_with_label_combined_with_with_labels() {
+        let mut labels = std::collections::HashMap::new();
+        labels.insert("env".to_string(), "prod".to_string());
+
+        let worker = BasicWorker::new("http://worker:8080".to_string(), WorkerType::Regular)
+            .with_labels(labels)
+            .with_label("prefill_pool".to_string(), "text".to_string());
+
+        assert_eq!(
+            worker.metadata().labels.get("env"),
+            Some(&"prod".to_string())
+        );
+        assert_eq!(
+            worker.metadata().labels.get("prefill_pool"),
+            Some(&"text".to_string())
         );
     }
 

--- a/src/core/worker_registry.rs
+++ b/src/core/worker_registry.rs
@@ -219,6 +219,52 @@ impl WorkerRegistry {
             .collect()
     }
 
+    /// Get prefill workers filtered by pool name.
+    /// Falls back to the "default" pool if the requested pool has no workers,
+    /// ensuring backward compatibility with single-pool configs that use unnamed
+    /// `--prefill-selector` (which creates pool "default").
+    pub fn get_prefill_workers_by_pool(&self, pool_name: &str) -> Vec<Arc<dyn Worker>> {
+        let workers = self.get_prefill_workers_for_pool(pool_name);
+        if workers.is_empty() && pool_name != "default" {
+            let default_workers = self.get_prefill_workers_for_pool("default");
+            if !default_workers.is_empty() {
+                tracing::info!(
+                    "No prefill workers in pool '{}', falling back to 'default' pool ({} workers)",
+                    pool_name,
+                    default_workers.len()
+                );
+                return default_workers;
+            }
+        }
+        workers
+    }
+
+    /// Get prefill workers for a specific pool without fallback.
+    fn get_prefill_workers_for_pool(&self, pool_name: &str) -> Vec<Arc<dyn Worker>> {
+        self.workers
+            .iter()
+            .filter_map(|entry| {
+                let worker = entry.value();
+                match worker.worker_type() {
+                    WorkerType::Prefill { .. } => {
+                        let worker_pool = worker
+                            .metadata()
+                            .labels
+                            .get("prefill_pool")
+                            .map(|s| s.as_str())
+                            .unwrap_or("default");
+                        if worker_pool == pool_name {
+                            Some(worker.clone())
+                        } else {
+                            None
+                        }
+                    }
+                    _ => None,
+                }
+            })
+            .collect()
+    }
+
     /// Get all decode workers
     pub fn get_decode_workers(&self) -> Vec<Arc<dyn Worker>> {
         self.get_by_type(&WorkerType::Decode)
@@ -522,5 +568,256 @@ mod tests {
         let llama_workers_after = registry.get_by_model_fast("llama-3");
         assert_eq!(llama_workers_after.len(), 1);
         assert_eq!(llama_workers_after[0].url(), "http://worker2:8080");
+    }
+
+    // ===== get_prefill_workers_by_pool tests =====
+
+    #[test]
+    fn test_get_prefill_workers_by_pool_filters_correctly() {
+        let registry = WorkerRegistry::new();
+
+        // Create prefill workers in different pools
+        let text_worker = crate::core::BasicWorker::new(
+            "http://text-prefill:8080".to_string(),
+            crate::core::WorkerType::Prefill {
+                bootstrap_port: None,
+            },
+        )
+        .with_label("prefill_pool".to_string(), "text".to_string());
+
+        let perception_worker = crate::core::BasicWorker::new(
+            "http://perception-prefill:8080".to_string(),
+            crate::core::WorkerType::Prefill {
+                bootstrap_port: None,
+            },
+        )
+        .with_label("prefill_pool".to_string(), "perception".to_string());
+
+        let decode_worker = crate::core::BasicWorker::new(
+            "http://decode:8080".to_string(),
+            crate::core::WorkerType::Decode,
+        );
+
+        registry.register(Arc::new(text_worker));
+        registry.register(Arc::new(perception_worker));
+        registry.register(Arc::new(decode_worker));
+
+        // Filter by "text" pool
+        let text_workers = registry.get_prefill_workers_by_pool("text");
+        assert_eq!(text_workers.len(), 1);
+        assert_eq!(text_workers[0].url(), "http://text-prefill:8080");
+
+        // Filter by "perception" pool
+        let perception_workers = registry.get_prefill_workers_by_pool("perception");
+        assert_eq!(perception_workers.len(), 1);
+        assert_eq!(
+            perception_workers[0].url(),
+            "http://perception-prefill:8080"
+        );
+
+        // Decode workers should not appear in any pool
+        let empty = registry.get_prefill_workers_by_pool("decode");
+        assert!(empty.is_empty());
+    }
+
+    #[test]
+    fn test_get_prefill_workers_by_pool_default_pool() {
+        let registry = WorkerRegistry::new();
+
+        // Worker without prefill_pool label defaults to "default"
+        let worker_no_label = crate::core::BasicWorker::new(
+            "http://prefill-no-label:8080".to_string(),
+            crate::core::WorkerType::Prefill {
+                bootstrap_port: None,
+            },
+        );
+
+        let worker_explicit_default = crate::core::BasicWorker::new(
+            "http://prefill-default:8080".to_string(),
+            crate::core::WorkerType::Prefill {
+                bootstrap_port: None,
+            },
+        )
+        .with_label("prefill_pool".to_string(), "default".to_string());
+
+        let worker_text = crate::core::BasicWorker::new(
+            "http://prefill-text:8080".to_string(),
+            crate::core::WorkerType::Prefill {
+                bootstrap_port: None,
+            },
+        )
+        .with_label("prefill_pool".to_string(), "text".to_string());
+
+        registry.register(Arc::new(worker_no_label));
+        registry.register(Arc::new(worker_explicit_default));
+        registry.register(Arc::new(worker_text));
+
+        // "default" pool should include both the no-label and explicit-default workers
+        let default_workers = registry.get_prefill_workers_by_pool("default");
+        assert_eq!(default_workers.len(), 2);
+        let urls: Vec<String> = default_workers
+            .iter()
+            .map(|w| w.url().to_string())
+            .collect();
+        assert!(urls.contains(&"http://prefill-no-label:8080".to_string()));
+        assert!(urls.contains(&"http://prefill-default:8080".to_string()));
+
+        // "text" pool should only have the text worker
+        let text_workers = registry.get_prefill_workers_by_pool("text");
+        assert_eq!(text_workers.len(), 1);
+        assert_eq!(text_workers[0].url(), "http://prefill-text:8080");
+    }
+
+    #[test]
+    fn test_get_prefill_workers_by_pool_empty_pool() {
+        let registry = WorkerRegistry::new();
+
+        let worker = crate::core::BasicWorker::new(
+            "http://prefill:8080".to_string(),
+            crate::core::WorkerType::Prefill {
+                bootstrap_port: None,
+            },
+        )
+        .with_label("prefill_pool".to_string(), "text".to_string());
+
+        registry.register(Arc::new(worker));
+
+        // Non-existent pool with no "default" pool returns empty
+        let workers = registry.get_prefill_workers_by_pool("nonexistent");
+        assert!(workers.is_empty());
+    }
+
+    #[test]
+    fn test_get_prefill_workers_by_pool_fallback_to_default() {
+        let registry = WorkerRegistry::new();
+
+        // Register a worker in the "default" pool (simulates legacy --prefill-selector app=my-prefill)
+        let default_worker = crate::core::BasicWorker::new(
+            "http://default-prefill:8080".to_string(),
+            crate::core::WorkerType::Prefill {
+                bootstrap_port: None,
+            },
+        );
+        // No prefill_pool label → defaults to "default"
+
+        registry.register(Arc::new(default_worker));
+
+        // Requesting "text" pool (from detect_prefill_pool) should fall back to "default"
+        let workers = registry.get_prefill_workers_by_pool("text");
+        assert_eq!(workers.len(), 1);
+        assert_eq!(workers[0].url(), "http://default-prefill:8080");
+
+        // Requesting "default" directly also works
+        let workers = registry.get_prefill_workers_by_pool("default");
+        assert_eq!(workers.len(), 1);
+    }
+
+    #[test]
+    fn test_get_prefill_workers_by_pool_no_fallback_when_pool_exists() {
+        let registry = WorkerRegistry::new();
+
+        // Register workers in both "text" and "default" pools
+        let text_worker = crate::core::BasicWorker::new(
+            "http://text-prefill:8080".to_string(),
+            crate::core::WorkerType::Prefill {
+                bootstrap_port: None,
+            },
+        )
+        .with_label("prefill_pool".to_string(), "text".to_string());
+
+        let default_worker = crate::core::BasicWorker::new(
+            "http://default-prefill:8080".to_string(),
+            crate::core::WorkerType::Prefill {
+                bootstrap_port: None,
+            },
+        );
+
+        registry.register(Arc::new(text_worker));
+        registry.register(Arc::new(default_worker));
+
+        // Requesting "text" should NOT fall back — it has its own workers
+        let workers = registry.get_prefill_workers_by_pool("text");
+        assert_eq!(workers.len(), 1);
+        assert_eq!(workers[0].url(), "http://text-prefill:8080");
+    }
+
+    #[test]
+    fn test_get_prefill_workers_by_pool_ignores_decode_workers() {
+        let registry = WorkerRegistry::new();
+
+        // Even if a decode worker has a prefill_pool label, it should not be returned
+        let decode_worker = crate::core::BasicWorker::new(
+            "http://decode:8080".to_string(),
+            crate::core::WorkerType::Decode,
+        )
+        .with_label("prefill_pool".to_string(), "text".to_string());
+
+        let regular_worker = crate::core::BasicWorker::new(
+            "http://regular:8080".to_string(),
+            crate::core::WorkerType::Regular,
+        )
+        .with_label("prefill_pool".to_string(), "text".to_string());
+
+        registry.register(Arc::new(decode_worker));
+        registry.register(Arc::new(regular_worker));
+
+        let text_workers = registry.get_prefill_workers_by_pool("text");
+        assert!(text_workers.is_empty());
+    }
+
+    #[test]
+    fn test_get_prefill_workers_by_pool_multiple_in_same_pool() {
+        let registry = WorkerRegistry::new();
+
+        for i in 0..3 {
+            let worker = crate::core::BasicWorker::new(
+                format!("http://text-prefill-{}:8080", i),
+                crate::core::WorkerType::Prefill {
+                    bootstrap_port: None,
+                },
+            )
+            .with_label("prefill_pool".to_string(), "text".to_string());
+            registry.register(Arc::new(worker));
+        }
+
+        let text_workers = registry.get_prefill_workers_by_pool("text");
+        assert_eq!(text_workers.len(), 3);
+    }
+
+    #[test]
+    fn test_get_prefill_workers_unchanged() {
+        // Verify get_prefill_workers() still returns ALL prefill workers regardless of pool
+        let registry = WorkerRegistry::new();
+
+        let text_worker = crate::core::BasicWorker::new(
+            "http://text-prefill:8080".to_string(),
+            crate::core::WorkerType::Prefill {
+                bootstrap_port: None,
+            },
+        )
+        .with_label("prefill_pool".to_string(), "text".to_string());
+
+        let perception_worker = crate::core::BasicWorker::new(
+            "http://perception-prefill:8080".to_string(),
+            crate::core::WorkerType::Prefill {
+                bootstrap_port: None,
+            },
+        )
+        .with_label("prefill_pool".to_string(), "perception".to_string());
+
+        let no_label_worker = crate::core::BasicWorker::new(
+            "http://unlabeled-prefill:8080".to_string(),
+            crate::core::WorkerType::Prefill {
+                bootstrap_port: None,
+            },
+        );
+
+        registry.register(Arc::new(text_worker));
+        registry.register(Arc::new(perception_worker));
+        registry.register(Arc::new(no_label_worker));
+
+        // get_prefill_workers() should return all 3
+        let all_prefill = registry.get_prefill_workers();
+        assert_eq!(all_prefill.len(), 3);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 use pyo3::prelude::*;
 pub mod config;
 pub mod logging;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 pub mod core;
 pub mod data_connector;
@@ -113,6 +113,16 @@ impl Router {
         config::ConnectionMode::Http
     }
 
+    /// Convert a single prefill selector to a BTreeMap with pool "default".
+    /// Returns empty map if the selector is empty.
+    fn prefill_selector_as_pools(&self) -> BTreeMap<String, HashMap<String, String>> {
+        if self.prefill_selector.is_empty() {
+            BTreeMap::new()
+        } else {
+            BTreeMap::from([("default".to_string(), self.prefill_selector.clone())])
+        }
+    }
+
     /// Convert PyO3 Router to RouterConfig
     pub fn to_router_config(&self) -> config::ConfigResult<config::RouterConfig> {
         use config::{
@@ -178,7 +188,7 @@ impl Router {
                 port: self.service_discovery_port,
                 check_interval_secs: 60,
                 selector: self.selector.clone(),
-                prefill_selector: self.prefill_selector.clone(),
+                prefill_selectors: self.prefill_selector_as_pools(),
                 decode_selector: self.decode_selector.clone(),
                 bootstrap_port_annotation: self.bootstrap_port_annotation.clone(),
             })
@@ -483,7 +493,7 @@ impl Router {
                 namespace: self.service_discovery_namespace.clone(),
                 // Enable PD mode for both --pd-disaggregation and --vllm-pd-disaggregation
                 pd_mode: self.pd_disaggregation || self.vllm_pd_disaggregation,
-                prefill_selector: self.prefill_selector.clone(),
+                prefill_selectors: self.prefill_selector_as_pools(),
                 decode_selector: self.decode_selector.clone(),
                 bootstrap_port_annotation: self.bootstrap_port_annotation.clone(),
             })

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use clap::{ArgAction, Parser, ValueEnum};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use vllm_router_rs::config::{
     CircuitBreakerConfig, ConfigError, ConfigResult, ConnectionMode, DiscoveryConfig,
     HealthCheckConfig, HistoryBackend, MetricsConfig, PolicyConfig, RetryConfig, RouterConfig,
@@ -42,6 +42,80 @@ fn parse_prefill_args() -> Vec<(String, Option<u16>)> {
     }
 
     prefill_entries
+}
+
+/// Parse prefill selectors with optional pool name prefix.
+///
+/// Supports:
+/// - `--prefill-selector app=my-prefill` → pool "default" (backward compat)
+/// - `--prefill-selector text:app=text-prefill` → pool "text"
+/// - `--prefill-selector perception:app=mm-prefill` → pool "perception"
+///
+/// Parsing: split on first `:` — if the left side contains no `=`, it's a pool name;
+/// otherwise treat whole string as `key=value` for pool "default".
+fn parse_prefill_selectors(selector_list: &[String]) -> BTreeMap<String, HashMap<String, String>> {
+    let mut pools: BTreeMap<String, HashMap<String, String>> = BTreeMap::new();
+
+    for item in selector_list {
+        let item = item.trim();
+        if item.is_empty() {
+            continue;
+        }
+
+        // Split on first ':'
+        let (pool_name, kv_str) = if let Some(colon_pos) = item.find(':') {
+            let left = item[..colon_pos].trim();
+            if left.contains('=') {
+                ("default", item)
+            } else {
+                (left, item[colon_pos + 1..].trim())
+            }
+        } else {
+            ("default", item)
+        };
+
+        // Validate pool name is not empty
+        let pool_name = if pool_name.is_empty() {
+            eprintln!(
+                "WARNING: Empty pool name in --prefill-selector '{}', using 'default'",
+                item
+            );
+            "default"
+        } else {
+            pool_name
+        };
+
+        // Parse key=value pairs from kv_str
+        let map = pools.entry(pool_name.to_string()).or_default();
+        for kv in kv_str.split(',') {
+            let kv = kv.trim();
+            if kv.is_empty() {
+                continue;
+            }
+            if let Some(eq_pos) = kv.find('=') {
+                let key = kv[..eq_pos].trim().to_string();
+                let value = kv[eq_pos + 1..].trim().to_string();
+                if !key.is_empty() {
+                    map.insert(key, value);
+                }
+            }
+        }
+    }
+
+    // Remove pools with empty selectors (e.g., from "--prefill-selector text:")
+    pools.retain(|name, sel| {
+        if sel.is_empty() {
+            eprintln!(
+                "WARNING: Prefill pool '{}' has no label selectors and will never match any pods. Ignoring.",
+                name
+            );
+            false
+        } else {
+            true
+        }
+    });
+
+    pools
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, ValueEnum)]
@@ -511,7 +585,7 @@ impl CliArgs {
                 port: self.service_discovery_port,
                 check_interval_secs: 60,
                 selector: Self::parse_selector(&self.selector),
-                prefill_selector: Self::parse_selector(&self.prefill_selector),
+                prefill_selectors: parse_prefill_selectors(&self.prefill_selector),
                 decode_selector: Self::parse_selector(&self.decode_selector),
                 bootstrap_port_annotation: "vllm.ai/bootstrap-port".to_string(),
             })
@@ -646,7 +720,7 @@ impl CliArgs {
                 namespace: self.service_discovery_namespace.clone(),
                 // Enable PD mode for both --pd-disaggregation and --vllm-pd-disaggregation
                 pd_mode: self.pd_disaggregation || self.vllm_pd_disaggregation,
-                prefill_selector: Self::parse_selector(&self.prefill_selector),
+                prefill_selectors: parse_prefill_selectors(&self.prefill_selector),
                 decode_selector: Self::parse_selector(&self.decode_selector),
                 bootstrap_port_annotation: "vllm.ai/bootstrap-port".to_string(),
             })
@@ -793,4 +867,113 @@ Provide --worker-urls or PD flags as usual.",
     runtime.block_on(async move { server::startup(server_config).await })?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_prefill_selectors_unnamed() {
+        let selectors = vec!["app=my-prefill".to_string()];
+        let result = parse_prefill_selectors(&selectors);
+        assert_eq!(result.len(), 1);
+        assert_eq!(
+            result.get("default").unwrap().get("app").unwrap(),
+            "my-prefill"
+        );
+    }
+
+    #[test]
+    fn test_parse_prefill_selectors_named() {
+        let selectors = vec![
+            "text:app=text-prefill".to_string(),
+            "perception:app=mm-prefill".to_string(),
+        ];
+        let result = parse_prefill_selectors(&selectors);
+        assert_eq!(result.len(), 2);
+        assert_eq!(
+            result.get("text").unwrap().get("app").unwrap(),
+            "text-prefill"
+        );
+        assert_eq!(
+            result.get("perception").unwrap().get("app").unwrap(),
+            "mm-prefill"
+        );
+    }
+
+    #[test]
+    fn test_parse_prefill_selectors_mixed() {
+        let selectors = vec![
+            "app=default-prefill".to_string(),
+            "text:app=text-prefill".to_string(),
+        ];
+        let result = parse_prefill_selectors(&selectors);
+        assert_eq!(result.len(), 2);
+        assert_eq!(
+            result.get("default").unwrap().get("app").unwrap(),
+            "default-prefill"
+        );
+        assert_eq!(
+            result.get("text").unwrap().get("app").unwrap(),
+            "text-prefill"
+        );
+    }
+
+    #[test]
+    fn test_parse_prefill_selectors_multi_label() {
+        let selectors = vec!["text:app=prefill,component=text".to_string()];
+        let result = parse_prefill_selectors(&selectors);
+        let text_pool = result.get("text").unwrap();
+        assert_eq!(text_pool.get("app").unwrap(), "prefill");
+        assert_eq!(text_pool.get("component").unwrap(), "text");
+    }
+
+    #[test]
+    fn test_parse_prefill_selectors_empty() {
+        let selectors: Vec<String> = vec![];
+        let result = parse_prefill_selectors(&selectors);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_parse_prefill_selectors_empty_pool_name() {
+        let selectors = vec![":app=my-prefill".to_string()];
+        let result = parse_prefill_selectors(&selectors);
+        // Empty pool name should default to "default"
+        assert!(result.contains_key("default"));
+        assert_eq!(
+            result.get("default").unwrap().get("app").unwrap(),
+            "my-prefill"
+        );
+    }
+
+    #[test]
+    fn test_parse_prefill_selectors_empty_value() {
+        let selectors = vec!["text:".to_string()];
+        let result = parse_prefill_selectors(&selectors);
+        // Empty selector map is filtered out
+        assert!(!result.contains_key("text"));
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_parse_prefill_selectors_duplicate_keys() {
+        let selectors = vec!["text:app=val1,app=val2".to_string()];
+        let result = parse_prefill_selectors(&selectors);
+        // Last value wins for duplicate keys
+        assert_eq!(result.get("text").unwrap().get("app").unwrap(), "val2");
+    }
+
+    #[test]
+    fn test_parse_prefill_selectors_whitespace() {
+        let selectors = vec!["  text : app = prefill , role = worker  ".to_string()];
+        let result = parse_prefill_selectors(&selectors);
+        assert_eq!(result.len(), 1);
+        let text_pool = result
+            .get("text")
+            .expect("pool name should be trimmed to 'text'");
+        assert_eq!(text_pool.get("app").unwrap(), "prefill");
+        assert_eq!(text_pool.get("role").unwrap(), "worker");
+    }
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -238,6 +238,12 @@ pub fn init_metrics() {
         "Time per streaming decode step"
     );
 
+    // Multi-prefill-pool metrics
+    describe_counter!(
+        "vllm_router_prefill_pool_routed_total",
+        "Total requests routed to each prefill pool"
+    );
+
     // Factory metrics
     describe_counter!(
         "vllm_tokenizer_factory_loads_total",
@@ -404,6 +410,14 @@ impl RouterMetrics {
     pub fn record_pd_prefill_request(worker: &str) {
         counter!("vllm_router_pd_prefill_requests_total",
             "worker" => worker.to_string()
+        )
+        .increment(1);
+    }
+
+    /// Record a prefill pool routing event (which pool was selected for a request)
+    pub fn record_prefill_pool_routed(pool: &str) {
+        counter!("vllm_router_prefill_pool_routed_total",
+            "pool" => pool.to_string()
         )
         .increment(1);
     }

--- a/src/protocols/spec.rs
+++ b/src/protocols/spec.rs
@@ -2364,10 +2364,54 @@ pub enum LoRAPath {
     Batch(Vec<Option<String>>),
 }
 
+// ============= Prefill Pool Detection =============
+
+/// Detect which prefill pool should handle a chat completion request based on modality.
+/// Returns "perception" if any user message contains a non-text content part
+/// (e.g., image_url, audio_url, video), otherwise returns "text".
+pub fn detect_prefill_pool(request: &ChatCompletionRequest) -> &'static str {
+    let has_non_text = request.messages.iter().any(|msg| {
+        matches!(msg, ChatMessage::User { content: UserMessageContent::Parts(parts), .. }
+            if parts.iter().any(|p| !matches!(p, ContentPart::Text { .. })))
+    });
+    if has_non_text {
+        "perception"
+    } else {
+        "text"
+    }
+}
+
+/// Detect which prefill pool should handle a request from a raw JSON value.
+/// Same logic as detect_prefill_pool but operates on serde_json::Value.
+/// Returns "perception" if any user message contains a non-text content part
+/// (e.g., image_url, audio_url, video), otherwise returns "text".
+/// Note: Any content part with a "type" field that is not "text" (including
+/// unknown or misspelled types) is treated as non-text and routed to "perception".
+/// This errs on the side of multimodal processing for unrecognized types.
+pub fn detect_prefill_pool_from_json(json: &serde_json::Value) -> &'static str {
+    let has_non_text = json
+        .get("messages")
+        .and_then(|m| m.as_array())
+        .into_iter()
+        .flatten()
+        .filter(|msg| msg.get("role").and_then(|r| r.as_str()) == Some("user"))
+        .filter_map(|msg| msg.get("content").and_then(|c| c.as_array()))
+        .flatten()
+        .any(|part| {
+            let part_type = part.get("type").and_then(|t| t.as_str());
+            part_type.is_some() && part_type != Some("text")
+        });
+    if has_non_text {
+        "perception"
+    } else {
+        "text"
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serde_json;
+    use serde_json::{self, json};
 
     // ==================================================================
     // =            RERANK REQUEST TESTS                                =
@@ -3666,5 +3710,110 @@ mod tests {
             }
             _ => panic!("Expected Assistant message"),
         }
+    }
+
+    // ============= Prefill Pool Detection Tests =============
+
+    #[test]
+    fn test_detect_prefill_pool_text_only() {
+        let request = serde_json::from_value::<ChatCompletionRequest>(json!({
+            "messages": [
+                {"role": "user", "content": "Hello, how are you?"}
+            ]
+        }))
+        .unwrap();
+        assert_eq!(detect_prefill_pool(&request), "text");
+    }
+
+    #[test]
+    fn test_detect_prefill_pool_with_image() {
+        let request = serde_json::from_value::<ChatCompletionRequest>(json!({
+            "messages": [
+                {"role": "user", "content": [
+                    {"type": "text", "text": "What's in this image?"},
+                    {"type": "image_url", "image_url": {"url": "https://example.com/image.png"}}
+                ]}
+            ]
+        }))
+        .unwrap();
+        assert_eq!(detect_prefill_pool(&request), "perception");
+    }
+
+    #[test]
+    fn test_detect_prefill_pool_mixed_messages() {
+        let request = serde_json::from_value::<ChatCompletionRequest>(json!({
+            "messages": [
+                {"role": "system", "content": "You are a helpful assistant."},
+                {"role": "user", "content": "Hello!"},
+                {"role": "assistant", "content": "Hi there!"},
+                {"role": "user", "content": [
+                    {"type": "text", "text": "Describe this"},
+                    {"type": "image_url", "image_url": {"url": "https://example.com/img.jpg"}}
+                ]}
+            ]
+        }))
+        .unwrap();
+        assert_eq!(detect_prefill_pool(&request), "perception");
+    }
+
+    #[test]
+    fn test_detect_prefill_pool_text_parts_only() {
+        let request = serde_json::from_value::<ChatCompletionRequest>(json!({
+            "messages": [
+                {"role": "user", "content": [
+                    {"type": "text", "text": "Part 1"},
+                    {"type": "text", "text": "Part 2"}
+                ]}
+            ]
+        }))
+        .unwrap();
+        assert_eq!(detect_prefill_pool(&request), "text");
+    }
+
+    #[test]
+    fn test_detect_prefill_pool_from_json_text() {
+        let json = json!({
+            "messages": [
+                {"role": "user", "content": "Simple text"}
+            ]
+        });
+        assert_eq!(detect_prefill_pool_from_json(&json), "text");
+    }
+
+    #[test]
+    fn test_detect_prefill_pool_from_json_image() {
+        let json = json!({
+            "messages": [
+                {"role": "user", "content": [
+                    {"type": "text", "text": "What's this?"},
+                    {"type": "image_url", "image_url": {"url": "https://example.com/img.png"}}
+                ]}
+            ]
+        });
+        assert_eq!(detect_prefill_pool_from_json(&json), "perception");
+    }
+
+    #[test]
+    fn test_detect_prefill_pool_from_json_no_messages() {
+        let json = json!({"prompt": "Hello"});
+        assert_eq!(detect_prefill_pool_from_json(&json), "text");
+    }
+
+    #[test]
+    fn test_detect_prefill_pool_from_json_audio() {
+        let json = json!({"messages": [{"role": "user", "content": [{"type": "audio_url", "audio_url": {"url": "http://example.com/audio.mp3"}}]}]});
+        assert_eq!(detect_prefill_pool_from_json(&json), "perception");
+    }
+
+    #[test]
+    fn test_detect_prefill_pool_from_json_video() {
+        let json = json!({"messages": [{"role": "user", "content": [{"type": "video", "video": {"url": "http://example.com/video.mp4"}}]}]});
+        assert_eq!(detect_prefill_pool_from_json(&json), "perception");
+    }
+
+    #[test]
+    fn test_detect_prefill_pool_from_json_unknown_type() {
+        let json = json!({"messages": [{"role": "user", "content": [{"type": "custom_modality", "data": "something"}]}]});
+        assert_eq!(detect_prefill_pool_from_json(&json), "perception");
     }
 }

--- a/src/routers/http/pd_router.rs
+++ b/src/routers/http/pd_router.rs
@@ -262,6 +262,17 @@ impl PDRouter {
         url: String,
         bootstrap_port: Option<u16>,
     ) -> Result<String, PDRouterError> {
+        self.add_prefill_server_with_pool("default", url, bootstrap_port)
+            .await
+    }
+
+    /// Add a prefill server with a pool label for multi-pool routing
+    pub async fn add_prefill_server_with_pool(
+        &self,
+        pool: &str,
+        url: String,
+        bootstrap_port: Option<u16>,
+    ) -> Result<String, PDRouterError> {
         // Wait for the new server to be healthy
         self.wait_for_server_health(&url).await?;
 
@@ -270,15 +281,12 @@ impl PDRouter {
             return Err(PDRouterError::WorkerAlreadyExists { url: url.clone() });
         }
 
-        // Create Worker for the new prefill server with circuit breaker configuration
-        // TODO: In IGW mode, fetch model_id from worker's /get_model_info endpoint
-        let worker = WorkerFactory::create_prefill_with_config(
-            url.clone(),
-            bootstrap_port,
-            self.circuit_breaker_config.clone(),
-        );
+        // Create Worker for the new prefill server with circuit breaker and pool label
+        let worker = BasicWorker::new(url.clone(), WorkerType::Prefill { bootstrap_port })
+            .with_circuit_breaker_config(self.circuit_breaker_config.clone())
+            .with_label("prefill_pool".to_string(), pool.to_string());
 
-        let worker_arc: Arc<dyn Worker> = Arc::from(worker);
+        let worker_arc: Arc<dyn Worker> = Arc::new(worker);
 
         // Register the worker in the registry
         self.worker_registry.register(worker_arc.clone());
@@ -298,8 +306,11 @@ impl PDRouter {
             }
         }
 
-        info!("Added prefill server: {}", url);
-        Ok(format!("Successfully added prefill server: {}", url))
+        info!("Added prefill server: {} (pool: {})", url, pool);
+        Ok(format!(
+            "Successfully added prefill server: {} (pool: {})",
+            url, pool
+        ))
     }
 
     pub async fn add_decode_server(&self, url: String) -> Result<String, PDRouterError> {

--- a/src/routers/http/vllm_pd_router.rs
+++ b/src/routers/http/vllm_pd_router.rs
@@ -225,26 +225,29 @@ impl VllmPDRouter {
         policy.select_worker(&workers, request_text)
     }
 
-    /// Process vLLM request using pure service discovery
-    async fn process_vllm_request(
+    /// Process vLLM request using pool-aware service discovery
+    async fn process_vllm_request_with_pool(
         &self,
         request_json: Value,
         path: &str,
         headers: Option<&HeaderMap>,
+        pool_name: &str,
     ) -> Response {
-        debug!("Processing vLLM request for path: {}", path);
         debug!(
-            "Request JSON: {}",
-            serde_json::to_string_pretty(&request_json).unwrap_or_default()
+            "Processing vLLM request for path: {} (pool: {})",
+            path, pool_name
         );
 
-        // Get available instances from service discovery
-        let prefill_instances = self.service_registry.get_prefill_instances();
+        // Get pool-filtered prefill instances and all decode instances
+        let prefill_instances = self
+            .service_registry
+            .get_prefill_instances_by_pool(pool_name);
         let decode_instances = self.service_registry.get_decode_instances();
 
         debug!(
-            "Found {} prefill instances, {} decode instances from service discovery",
+            "Found {} prefill instances (pool: {}), {} decode instances from service discovery",
             prefill_instances.len(),
+            pool_name,
             decode_instances.len()
         );
 
@@ -253,32 +256,59 @@ impl VllmPDRouter {
             return (
                 axum::http::StatusCode::SERVICE_UNAVAILABLE,
                 format!(
-                    "No workers available via service discovery: {} prefill, {} decode",
+                    "No workers available via service discovery: {} prefill (pool: {}), {} decode",
                     prefill_instances.len(),
+                    pool_name,
                     decode_instances.len()
                 ),
             )
                 .into_response();
         }
 
+        // Delegate to the non-pool-aware method for the rest of the logic
+        // (the instances are already filtered)
+        self.process_vllm_request_with_instances(
+            request_json,
+            path,
+            headers,
+            &prefill_instances,
+            &decode_instances,
+        )
+        .await
+    }
+
+    /// Shared helper: process a vLLM request given pre-filtered prefill/decode instances
+    async fn process_vllm_request_with_instances(
+        &self,
+        request_json: Value,
+        path: &str,
+        headers: Option<&HeaderMap>,
+        prefill_instances: &[(String, String)],
+        decode_instances: &[(String, String)],
+    ) -> Response {
+        debug!(
+            "Request JSON: {}",
+            serde_json::to_string_pretty(&request_json).unwrap_or_default()
+        );
+
         // Use policy-based load balancing to select prefill and decode workers
         let request_text = serde_json::to_string(&request_json).ok();
         let request_str = request_text.as_deref();
 
-        let prefill_idx =
-            match self.select_worker_with_policy(&prefill_instances, true, request_str) {
-                Some(idx) => idx,
-                None => {
-                    RouterMetrics::record_pd_error("server_selection");
-                    return (
-                        axum::http::StatusCode::SERVICE_UNAVAILABLE,
-                        "Prefill policy failed to select a worker".to_string(),
-                    )
-                        .into_response();
-                }
-            };
+        let prefill_idx = match self.select_worker_with_policy(prefill_instances, true, request_str)
+        {
+            Some(idx) => idx,
+            None => {
+                RouterMetrics::record_pd_error("server_selection");
+                return (
+                    axum::http::StatusCode::SERVICE_UNAVAILABLE,
+                    "Prefill policy failed to select a worker".to_string(),
+                )
+                    .into_response();
+            }
+        };
 
-        let decode_idx = match self.select_worker_with_policy(&decode_instances, false, request_str)
+        let decode_idx = match self.select_worker_with_policy(decode_instances, false, request_str)
         {
             Some(idx) => idx,
             None => {
@@ -320,6 +350,135 @@ impl VllmPDRouter {
         {
             Ok(response) => {
                 debug!("Two-stage processing completed successfully");
+                response
+            }
+            Err(e) => {
+                error!("Two-stage processing failed: {}", e);
+                (
+                    axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("Request processing failed: {}", e),
+                )
+                    .into_response()
+            }
+        }
+    }
+
+    /// Direct URL mode: select prefill/decode workers by pool, then execute two-stage dispatch.
+    /// Shared by route_chat, route_completion, and route_transparent.
+    async fn route_direct_url(
+        &self,
+        request_json: Value,
+        path: &str,
+        headers: Option<&HeaderMap>,
+        pool_name: &str,
+    ) -> Response {
+        let all_prefill = self
+            .pd_router
+            .worker_registry
+            .get_prefill_workers_by_pool(pool_name);
+        let prefill_workers: Vec<Arc<dyn Worker>> = all_prefill
+            .into_iter()
+            .filter(|w| w.is_available())
+            .collect();
+        let all_decode = self.pd_router.worker_registry.get_decode_workers();
+        let decode_workers: Vec<Arc<dyn Worker>> = all_decode
+            .into_iter()
+            .filter(|w| w.is_available())
+            .collect();
+
+        info!(
+            "Found {} prefill workers (pool: {}), {} decode workers from worker_registry",
+            prefill_workers.len(),
+            pool_name,
+            decode_workers.len()
+        );
+
+        if prefill_workers.is_empty() || decode_workers.is_empty() {
+            RouterMetrics::record_pd_error("server_selection");
+            return (
+                axum::http::StatusCode::SERVICE_UNAVAILABLE,
+                format!(
+                    "No workers available: {} prefill (pool: {}), {} decode. Check that prefill pods with matching labels are running and that --prefill-selector pool names match request modalities.",
+                    prefill_workers.len(),
+                    pool_name,
+                    decode_workers.len()
+                ),
+            )
+                .into_response();
+        }
+
+        let request_text = serde_json::to_string(&request_json).ok();
+        let request_str = request_text.as_deref();
+        let request_headers: Option<HashMap<String, String>> = headers.map(|h| {
+            h.iter()
+                .filter_map(|(name, value)| {
+                    value
+                        .to_str()
+                        .ok()
+                        .map(|v| (name.as_str().to_lowercase(), v.to_string()))
+                })
+                .collect()
+        });
+
+        let prefill_policy = self.policy_registry.get_prefill_policy();
+        let decode_policy = self.policy_registry.get_decode_policy();
+
+        let prefill_idx = match prefill_policy.select_worker_with_headers(
+            &prefill_workers,
+            request_str,
+            request_headers.as_ref(),
+        ) {
+            Some(idx) => idx,
+            None => {
+                RouterMetrics::record_pd_error("server_selection");
+                return (
+                    axum::http::StatusCode::SERVICE_UNAVAILABLE,
+                    "Prefill policy failed to select a worker".to_string(),
+                )
+                    .into_response();
+            }
+        };
+
+        let decode_idx = match decode_policy.select_worker_with_headers(
+            &decode_workers,
+            request_str,
+            request_headers.as_ref(),
+        ) {
+            Some(idx) => idx,
+            None => {
+                RouterMetrics::record_pd_error("server_selection");
+                return (
+                    axum::http::StatusCode::SERVICE_UNAVAILABLE,
+                    "Decode policy failed to select a worker".to_string(),
+                )
+                    .into_response();
+            }
+        };
+
+        let prefill_worker = &prefill_workers[prefill_idx];
+        let decode_worker = &decode_workers[decode_idx];
+
+        info!(
+            "Selected prefill={} [policy:{}], decode={} [policy:{}] for {}",
+            prefill_worker.url(),
+            prefill_policy.name(),
+            decode_worker.url(),
+            decode_policy.name(),
+            path
+        );
+
+        match self
+            .process_vllm_two_stage_request(
+                request_json,
+                prefill_worker.clone(),
+                decode_worker.clone(),
+                path,
+                headers,
+            )
+            .await
+        {
+            Ok(response) => {
+                info!("Two-stage processing completed successfully");
                 response
             }
             Err(e) => {
@@ -1101,6 +1260,19 @@ impl VllmPDRouter {
         self.pd_router.add_prefill_server(url, bootstrap_port).await
     }
 
+    /// Add a prefill server with a pool label for multi-pool routing
+    /// Delegates to the underlying PDRouter
+    pub async fn add_prefill_server_with_pool(
+        &self,
+        pool: &str,
+        url: String,
+        bootstrap_port: Option<u16>,
+    ) -> Result<String, PDRouterError> {
+        self.pd_router
+            .add_prefill_server_with_pool(pool, url, bootstrap_port)
+            .await
+    }
+
     /// Add a decode server to the router
     /// Delegates to the underlying PDRouter
     pub async fn add_decode_server(&self, url: String) -> Result<String, PDRouterError> {
@@ -1170,9 +1342,12 @@ impl RouterTrait for VllmPDRouter {
         body: &crate::protocols::spec::ChatCompletionRequest,
         _model_id: Option<&str>,
     ) -> Response {
+        // Detect prefill pool based on request modality
+        let pool_name = crate::protocols::spec::detect_prefill_pool(body);
+        RouterMetrics::record_prefill_pool_routed(pool_name);
         info!(
-            "vLLM route_chat called, use_discovery={}",
-            self.use_discovery
+            "vLLM route_chat called, use_discovery={}, prefill_pool={}",
+            self.use_discovery, pool_name
         );
 
         if self.use_discovery {
@@ -1197,22 +1372,18 @@ impl RouterTrait for VllmPDRouter {
                 }
             };
 
-            // Process vLLM two-stage request with service discovery
-            self.process_vllm_request(request_json, "/v1/chat/completions", headers)
-                .await
+            // Process vLLM two-stage request with service discovery (pool-aware)
+            self.process_vllm_request_with_pool(
+                request_json,
+                "/v1/chat/completions",
+                headers,
+                pool_name,
+            )
+            .await
         } else {
-            // Direct URL mode - implement routing logic here (not delegating to PDRouter)
-            info!("Using direct URL mode with VllmPDRouter's own routing logic");
-
-            // Convert request to JSON
+            // Direct URL mode
             let request_json = match serde_json::to_value(body) {
-                Ok(json) => {
-                    debug!(
-                        "Serialized chat request: {}",
-                        serde_json::to_string_pretty(&json).unwrap_or_default()
-                    );
-                    json
-                }
+                Ok(json) => json,
                 Err(e) => {
                     return (
                         axum::http::StatusCode::INTERNAL_SERVER_ERROR,
@@ -1221,117 +1392,8 @@ impl RouterTrait for VllmPDRouter {
                         .into_response()
                 }
             };
-
-            // Get prefill and decode workers from worker_registry
-            let prefill_workers = self.pd_router.worker_registry.get_prefill_workers();
-            let decode_workers = self.pd_router.worker_registry.get_decode_workers();
-
-            info!(
-                "Found {} prefill workers, {} decode workers from worker_registry",
-                prefill_workers.len(),
-                decode_workers.len()
-            );
-
-            if prefill_workers.is_empty() || decode_workers.is_empty() {
-                RouterMetrics::record_pd_error("server_selection");
-                return (
-                    axum::http::StatusCode::SERVICE_UNAVAILABLE,
-                    format!(
-                        "No workers available: {} prefill, {} decode",
-                        prefill_workers.len(),
-                        decode_workers.len()
-                    ),
-                )
-                    .into_response();
-            }
-
-            // Select workers using policy with headers for consistent hash
-            let request_text = serde_json::to_string(&request_json).ok();
-            let request_str = request_text.as_deref();
-            let request_headers: Option<HashMap<String, String>> = headers.map(|h| {
-                h.iter()
-                    .filter_map(|(name, value)| {
-                        value
-                            .to_str()
-                            .ok()
-                            .map(|v| (name.as_str().to_lowercase(), v.to_string()))
-                    })
-                    .collect()
-            });
-
-            let prefill_policy = self.policy_registry.get_prefill_policy();
-            let decode_policy = self.policy_registry.get_decode_policy();
-
-            let prefill_idx = match prefill_policy.select_worker_with_headers(
-                &prefill_workers,
-                request_str,
-                request_headers.as_ref(),
-            ) {
-                Some(idx) => idx,
-                None => {
-                    RouterMetrics::record_pd_error("server_selection");
-                    return (
-                        axum::http::StatusCode::SERVICE_UNAVAILABLE,
-                        "Prefill policy failed to select a worker".to_string(),
-                    )
-                        .into_response();
-                }
-            };
-
-            let decode_idx = match decode_policy.select_worker_with_headers(
-                &decode_workers,
-                request_str,
-                request_headers.as_ref(),
-            ) {
-                Some(idx) => idx,
-                None => {
-                    RouterMetrics::record_pd_error("server_selection");
-                    return (
-                        axum::http::StatusCode::SERVICE_UNAVAILABLE,
-                        "Decode policy failed to select a worker".to_string(),
-                    )
-                        .into_response();
-                }
-            };
-
-            let prefill_worker = &prefill_workers[prefill_idx];
-            let decode_worker = &decode_workers[decode_idx];
-            // Load tracking is handled inside process_vllm_two_stage_request for fine-grained
-            // tracking: prefill load only during prefill phase, decode load only during decode phase.
-
-            info!(
-                "Chat: Selected prefill={} [policy:{}], decode={} [policy:{}]",
-                prefill_worker.url(),
-                prefill_policy.name(),
-                decode_worker.url(),
-                decode_policy.name()
-            );
-
-            // Execute dual dispatch with vLLM two-stage processing
-            let resp = match self
-                .process_vllm_two_stage_request(
-                    request_json,
-                    prefill_worker.clone(),
-                    decode_worker.clone(),
-                    "/v1/chat/completions",
-                    headers,
-                )
+            self.route_direct_url(request_json, "/v1/chat/completions", headers, pool_name)
                 .await
-            {
-                Ok(response) => {
-                    info!("Two-stage processing completed successfully");
-                    response
-                }
-                Err(e) => {
-                    error!("Two-stage processing failed: {}", e);
-                    (
-                        axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                        format!("Request processing failed: {}", e),
-                    )
-                        .into_response()
-                }
-            };
-            resp
         }
     }
 
@@ -1341,9 +1403,14 @@ impl RouterTrait for VllmPDRouter {
         body: &crate::protocols::spec::CompletionRequest,
         _model_id: Option<&str>,
     ) -> Response {
+        // Completion requests always route to the "text" pool.
+        // The /v1/completions API uses a plain text `prompt` field, not structured
+        // `messages` with content parts, so modality detection is not applicable.
+        let pool_name = "text";
+        RouterMetrics::record_prefill_pool_routed(pool_name);
         info!(
-            "vLLM route_completion called, use_discovery={}",
-            self.use_discovery
+            "vLLM route_completion called, use_discovery={}, prefill_pool={}",
+            self.use_discovery, pool_name
         );
 
         if self.use_discovery {
@@ -1368,22 +1435,13 @@ impl RouterTrait for VllmPDRouter {
                 }
             };
 
-            // Process vLLM two-stage request with service discovery
-            self.process_vllm_request(request_json, "/v1/completions", headers)
+            // Process vLLM two-stage request with service discovery (pool-aware)
+            self.process_vllm_request_with_pool(request_json, "/v1/completions", headers, pool_name)
                 .await
         } else {
-            // Direct URL mode - implement routing logic here (not delegating to PDRouter)
-            info!("Using direct URL mode with VllmPDRouter's own routing logic");
-
-            // Convert request to JSON
+            // Direct URL mode
             let request_json = match serde_json::to_value(body) {
-                Ok(json) => {
-                    debug!(
-                        "Serialized completion request: {}",
-                        serde_json::to_string_pretty(&json).unwrap_or_default()
-                    );
-                    json
-                }
+                Ok(json) => json,
                 Err(e) => {
                     return (
                         axum::http::StatusCode::INTERNAL_SERVER_ERROR,
@@ -1392,117 +1450,8 @@ impl RouterTrait for VllmPDRouter {
                         .into_response()
                 }
             };
-
-            // Get prefill and decode workers from worker_registry
-            let prefill_workers = self.pd_router.worker_registry.get_prefill_workers();
-            let decode_workers = self.pd_router.worker_registry.get_decode_workers();
-
-            info!(
-                "Found {} prefill workers, {} decode workers from worker_registry",
-                prefill_workers.len(),
-                decode_workers.len()
-            );
-
-            if prefill_workers.is_empty() || decode_workers.is_empty() {
-                RouterMetrics::record_pd_error("server_selection");
-                return (
-                    axum::http::StatusCode::SERVICE_UNAVAILABLE,
-                    format!(
-                        "No workers available: {} prefill, {} decode",
-                        prefill_workers.len(),
-                        decode_workers.len()
-                    ),
-                )
-                    .into_response();
-            }
-
-            // Select workers using policy with headers for consistent hash
-            let request_text = serde_json::to_string(&request_json).ok();
-            let request_str = request_text.as_deref();
-            let request_headers: Option<HashMap<String, String>> = headers.map(|h| {
-                h.iter()
-                    .filter_map(|(name, value)| {
-                        value
-                            .to_str()
-                            .ok()
-                            .map(|v| (name.as_str().to_lowercase(), v.to_string()))
-                    })
-                    .collect()
-            });
-
-            let prefill_policy = self.policy_registry.get_prefill_policy();
-            let decode_policy = self.policy_registry.get_decode_policy();
-
-            let prefill_idx = match prefill_policy.select_worker_with_headers(
-                &prefill_workers,
-                request_str,
-                request_headers.as_ref(),
-            ) {
-                Some(idx) => idx,
-                None => {
-                    RouterMetrics::record_pd_error("server_selection");
-                    return (
-                        axum::http::StatusCode::SERVICE_UNAVAILABLE,
-                        "Prefill policy failed to select a worker".to_string(),
-                    )
-                        .into_response();
-                }
-            };
-
-            let decode_idx = match decode_policy.select_worker_with_headers(
-                &decode_workers,
-                request_str,
-                request_headers.as_ref(),
-            ) {
-                Some(idx) => idx,
-                None => {
-                    RouterMetrics::record_pd_error("server_selection");
-                    return (
-                        axum::http::StatusCode::SERVICE_UNAVAILABLE,
-                        "Decode policy failed to select a worker".to_string(),
-                    )
-                        .into_response();
-                }
-            };
-
-            let prefill_worker = &prefill_workers[prefill_idx];
-            let decode_worker = &decode_workers[decode_idx];
-            // Load tracking is handled inside process_vllm_two_stage_request for fine-grained
-            // tracking: prefill load only during prefill phase, decode load only during decode phase.
-
-            info!(
-                "Completion: Selected prefill={} [policy:{}], decode={} [policy:{}]",
-                prefill_worker.url(),
-                prefill_policy.name(),
-                decode_worker.url(),
-                decode_policy.name()
-            );
-
-            // Execute dual dispatch with vLLM two-stage processing
-            let resp = match self
-                .process_vllm_two_stage_request(
-                    request_json,
-                    prefill_worker.clone(),
-                    decode_worker.clone(),
-                    "/v1/completions",
-                    headers,
-                )
+            self.route_direct_url(request_json, "/v1/completions", headers, pool_name)
                 .await
-            {
-                Ok(response) => {
-                    info!("Two-stage processing completed successfully");
-                    response
-                }
-                Err(e) => {
-                    error!("Two-stage processing failed: {}", e);
-                    (
-                        axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                        format!("Request processing failed: {}", e),
-                    )
-                        .into_response()
-                }
-            };
-            resp
         }
     }
 
@@ -1587,121 +1536,18 @@ impl RouterTrait for VllmPDRouter {
         // Body is already a serde_json::Value, use it directly
         let request_json = body;
 
+        // Detect prefill pool from request body for transparent proxy
+        let pool_name = crate::protocols::spec::detect_prefill_pool_from_json(&request_json);
+        RouterMetrics::record_prefill_pool_routed(pool_name);
+
         if self.use_discovery {
-            // Discovery mode - use vLLM-specific two-stage processing
-            self.process_vllm_request(request_json, path, headers).await
-        } else {
-            // Direct URL mode - use worker registry, filtered by availability
-            let all_prefill = self.pd_router.worker_registry.get_prefill_workers();
-            let prefill_workers: Vec<Arc<dyn Worker>> = all_prefill
-                .iter()
-                .filter(|w| w.is_available())
-                .cloned()
-                .collect();
-            let all_decode = self.pd_router.worker_registry.get_decode_workers();
-            let decode_workers: Vec<Arc<dyn Worker>> = all_decode
-                .iter()
-                .filter(|w| w.is_available())
-                .cloned()
-                .collect();
-
-            if prefill_workers.is_empty() || decode_workers.is_empty() {
-                RouterMetrics::record_pd_error("server_selection");
-                return (
-                    StatusCode::SERVICE_UNAVAILABLE,
-                    format!(
-                        "No available workers: {} prefill, {} decode",
-                        prefill_workers.len(),
-                        decode_workers.len()
-                    ),
-                )
-                    .into_response();
-            }
-
-            // Select workers using policy with headers for consistent hash
-            let request_text = serde_json::to_string(&request_json).ok();
-            let request_str = request_text.as_deref();
-            let request_headers: Option<HashMap<String, String>> = headers.map(|h| {
-                h.iter()
-                    .filter_map(|(name, value)| {
-                        value
-                            .to_str()
-                            .ok()
-                            .map(|v| (name.as_str().to_lowercase(), v.to_string()))
-                    })
-                    .collect()
-            });
-
-            let prefill_policy = self.policy_registry.get_prefill_policy();
-            let decode_policy = self.policy_registry.get_decode_policy();
-
-            let prefill_idx = match prefill_policy.select_worker_with_headers(
-                &prefill_workers,
-                request_str,
-                request_headers.as_ref(),
-            ) {
-                Some(idx) => idx,
-                None => {
-                    RouterMetrics::record_pd_error("server_selection");
-                    return (
-                        StatusCode::SERVICE_UNAVAILABLE,
-                        "Prefill policy failed to select a worker".to_string(),
-                    )
-                        .into_response();
-                }
-            };
-
-            let decode_idx = match decode_policy.select_worker_with_headers(
-                &decode_workers,
-                request_str,
-                request_headers.as_ref(),
-            ) {
-                Some(idx) => idx,
-                None => {
-                    RouterMetrics::record_pd_error("server_selection");
-                    return (
-                        StatusCode::SERVICE_UNAVAILABLE,
-                        "Decode policy failed to select a worker".to_string(),
-                    )
-                        .into_response();
-                }
-            };
-
-            let prefill_worker = &prefill_workers[prefill_idx];
-            let decode_worker = &decode_workers[decode_idx];
-
-            debug!(
-                "Transparent proxy: prefill={}, decode={}",
-                prefill_worker.url(),
-                decode_worker.url()
-            );
-
-            // Execute two-stage processing
-            match self
-                .process_vllm_two_stage_request(
-                    request_json,
-                    prefill_worker.clone(),
-                    decode_worker.clone(),
-                    path,
-                    headers,
-                )
+            // Discovery mode - use vLLM-specific two-stage processing (pool-aware)
+            self.process_vllm_request_with_pool(request_json, path, headers, pool_name)
                 .await
-            {
-                Ok(response) => response,
-                Err(e) => {
-                    error!(
-                        "Transparent proxy request failed: prefill={}, decode={}, error={}",
-                        prefill_worker.url(),
-                        decode_worker.url(),
-                        e
-                    );
-                    (
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        format!("Transparent proxy request failed: {}", e),
-                    )
-                        .into_response()
-                }
-            }
+        } else {
+            // Direct URL mode
+            self.route_direct_url(request_json, path, headers, pool_name)
+                .await
         }
     }
 }

--- a/src/routers/http/vllm_service_discovery.rs
+++ b/src/routers/http/vllm_service_discovery.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::sync::broadcast;
-use tracing::{debug, info, warn};
+use tracing::{debug, error, info, warn};
 
 /// Default ping timeout in seconds
 const DEFAULT_PING_SECONDS: u64 = 5;
@@ -308,6 +308,29 @@ impl ServiceRegistry {
             .map(|instance| instance.zmq_address.clone())
     }
 
+    /// Get prefill instances filtered by pool name.
+    ///
+    /// ZMQ discovery does not support multi-pool routing because workers do not
+    /// advertise pool metadata. When the requested pool is "default" or "text"
+    /// (the implicit single-pool case), all prefill instances are returned.
+    /// Any other pool name means multi-pool routing was configured, which is
+    /// incompatible with ZMQ discovery — this returns an empty vec so the
+    /// caller surfaces a clear SERVICE_UNAVAILABLE error.
+    ///
+    /// Use K8s service discovery (--service-discovery) for multi-pool support.
+    pub fn get_prefill_instances_by_pool(&self, pool: &str) -> Vec<(String, String)> {
+        if pool != "default" && pool != "text" {
+            error!(
+                "Multi-pool prefill routing is NOT supported in ZMQ discovery mode. \
+                 Pool '{}' requested but ZMQ workers have no pool metadata. \
+                 Use --service-discovery (K8s) for multi-pool support.",
+                pool
+            );
+            return Vec::new();
+        }
+        self.get_prefill_instances()
+    }
+
     /// Get all available prefill instances
     pub fn get_prefill_instances(&self) -> Vec<(String, String)> {
         let guard = self.prefill_instances.lock().unwrap();
@@ -344,5 +367,86 @@ impl ServiceRegistry {
 impl Drop for ServiceRegistry {
     fn drop(&mut self) {
         self.shutdown();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_prefill_instances_by_pool_returns_all_for_default_pools() {
+        let registry = ServiceRegistry::new();
+
+        // Register two prefill instances
+        registry.register_service(
+            "http://10.0.0.1:8000".to_string(),
+            "tcp://10.0.0.1:5555".to_string(),
+            ServiceType::Prefill,
+        );
+        registry.register_service(
+            "http://10.0.0.2:8000".to_string(),
+            "tcp://10.0.0.2:5555".to_string(),
+            ServiceType::Prefill,
+        );
+
+        // "text" and "default" are allowed in ZMQ mode — returns all prefill instances
+        let text_instances = registry.get_prefill_instances_by_pool("text");
+        let default_instances = registry.get_prefill_instances_by_pool("default");
+        let all_instances = registry.get_prefill_instances();
+
+        assert_eq!(text_instances.len(), 2);
+        assert_eq!(default_instances.len(), 2);
+        assert_eq!(text_instances, all_instances);
+        assert_eq!(default_instances, all_instances);
+    }
+
+    #[test]
+    fn test_get_prefill_instances_by_pool_fails_for_non_default_pool() {
+        let registry = ServiceRegistry::new();
+
+        registry.register_service(
+            "http://10.0.0.1:8000".to_string(),
+            "tcp://10.0.0.1:5555".to_string(),
+            ServiceType::Prefill,
+        );
+
+        // "perception" is a multi-pool name — not supported in ZMQ mode
+        let perception_instances = registry.get_prefill_instances_by_pool("perception");
+        assert!(
+            perception_instances.is_empty(),
+            "Non-default pool should return empty in ZMQ mode"
+        );
+    }
+
+    #[test]
+    fn test_get_prefill_instances_by_pool_empty() {
+        let registry = ServiceRegistry::new();
+
+        // No instances registered — pool query should return empty
+        let instances = registry.get_prefill_instances_by_pool("text");
+        assert!(instances.is_empty());
+    }
+
+    #[test]
+    fn test_get_prefill_instances_by_pool_excludes_decode() {
+        let registry = ServiceRegistry::new();
+
+        // Register one prefill and one decode
+        registry.register_service(
+            "http://10.0.0.1:8000".to_string(),
+            "tcp://10.0.0.1:5555".to_string(),
+            ServiceType::Prefill,
+        );
+        registry.register_service(
+            "http://10.0.0.2:8000".to_string(),
+            "tcp://10.0.0.2:5555".to_string(),
+            ServiceType::Decode,
+        );
+
+        // Should only return prefill instances, not decode
+        let instances = registry.get_prefill_instances_by_pool("text");
+        assert_eq!(instances.len(), 1);
+        assert_eq!(instances[0].0, "http://10.0.0.1:8000");
     }
 }

--- a/src/service_discovery.rs
+++ b/src/service_discovery.rs
@@ -8,7 +8,7 @@ use kube::{
     runtime::WatchStreamExt,
     Client,
 };
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::net::{IpAddr, SocketAddr};
 
 use rustls;
@@ -28,7 +28,13 @@ pub struct ServiceDiscoveryConfig {
     pub namespace: Option<String>,
     // PD mode specific configuration
     pub pd_mode: bool,
-    pub prefill_selector: HashMap<String, String>,
+    /// Prefill pool selectors, keyed by pool name.
+    /// When a pod matches multiple pool selectors, the most specific selector
+    /// (most label key-value pairs) wins. If two selectors have the same
+    /// specificity, BTreeMap alphabetical order breaks the tie.
+    /// For best results, ensure selectors are mutually exclusive so that each
+    /// pod matches at most one pool.
+    pub prefill_selectors: BTreeMap<String, HashMap<String, String>>,
     pub decode_selector: HashMap<String, String>,
     // Bootstrap port annotation specific to mooncake implementation
     pub bootstrap_port_annotation: String,
@@ -43,7 +49,7 @@ impl Default for ServiceDiscoveryConfig {
             port: 8000,      // Standard port for modern services
             namespace: None, // None means watch all namespaces
             pd_mode: false,
-            prefill_selector: HashMap::new(),
+            prefill_selectors: BTreeMap::new(),
             decode_selector: HashMap::new(),
             bootstrap_port_annotation: "vllm.ai/bootstrap-port".to_string(),
         }
@@ -53,7 +59,7 @@ impl Default for ServiceDiscoveryConfig {
 /// Pod type for PD mode service discovery
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum PodType {
-    Prefill,
+    Prefill { pool: String },
     Decode,
     Regular,
 }
@@ -86,12 +92,15 @@ impl PodInfo {
     pub fn should_include(pod: &Pod, config: &ServiceDiscoveryConfig) -> bool {
         if config.pd_mode {
             // In PD mode, at least one selector must be non-empty
-            if config.prefill_selector.is_empty() && config.decode_selector.is_empty() {
-                warn!("PD mode enabled but both prefill_selector and decode_selector are empty");
+            if config.prefill_selectors.is_empty() && config.decode_selector.is_empty() {
+                warn!("PD mode enabled but both prefill_selectors and decode_selector are empty");
                 return false;
             }
-            // In PD mode, pod must match either prefill or decode selector
-            Self::matches_selector(pod, &config.prefill_selector)
+            // In PD mode, pod must match any prefill pool selector or decode selector
+            config
+                .prefill_selectors
+                .values()
+                .any(|sel| Self::matches_selector(pod, sel))
                 || Self::matches_selector(pod, &config.decode_selector)
         } else {
             // In regular mode, pod must match the general selector
@@ -122,9 +131,19 @@ impl PodInfo {
         // Determine pod type based on labels if config is provided and in PD mode
         let pod_type = if let Some(config) = config {
             if config.pd_mode {
-                // Use simplified helper methods for cleaner logic
-                if Self::matches_selector(pod, &config.prefill_selector) {
-                    Some(PodType::Prefill)
+                // Check each prefill pool selector to find which pool this pod belongs to.
+                // When multiple selectors match, pick the most specific one (most labels).
+                // This ensures a selector with app=vllm,pool=perception beats app=vllm alone,
+                // regardless of pool name ordering.
+                let prefill_pool = config
+                    .prefill_selectors
+                    .iter()
+                    .filter(|(_, sel)| Self::matches_selector(pod, sel))
+                    .max_by_key(|(_, sel)| sel.len())
+                    .map(|(pool_name, _)| pool_name.clone());
+
+                if let Some(pool) = prefill_pool {
+                    Some(PodType::Prefill { pool })
                 } else if Self::matches_selector(pod, &config.decode_selector) {
                     Some(PodType::Decode)
                 } else {
@@ -139,7 +158,7 @@ impl PodInfo {
         };
 
         // Extract bootstrap port from annotations for prefill pods
-        let bootstrap_port = if matches!(pod_type, Some(PodType::Prefill)) {
+        let bootstrap_port = if matches!(pod_type, Some(PodType::Prefill { .. })) {
             if let Some(config) = config {
                 pod.metadata
                     .annotations
@@ -196,12 +215,18 @@ pub async fn start_service_discovery(
 
     // Log the appropriate selectors based on mode
     if config.pd_mode {
-        let prefill_selector = config
-            .prefill_selector
+        let prefill_selectors_str: Vec<String> = config
+            .prefill_selectors
             .iter()
-            .map(|(k, v)| format!("{}={}", k, v))
-            .collect::<Vec<_>>()
-            .join(",");
+            .map(|(pool, sel)| {
+                let labels = sel
+                    .iter()
+                    .map(|(k, v)| format!("{}={}", k, v))
+                    .collect::<Vec<_>>()
+                    .join(",");
+                format!("{}:{}", pool, labels)
+            })
+            .collect();
 
         let decode_selector = config
             .decode_selector
@@ -211,8 +236,9 @@ pub async fn start_service_discovery(
             .join(",");
 
         info!(
-            "Starting K8s service discovery | PD mode | prefill: '{}' | decode: '{}'",
-            prefill_selector, decode_selector
+            "Starting K8s service discovery | PD mode | prefill pools: [{}] | decode: '{}'",
+            prefill_selectors_str.join(", "),
+            decode_selector
         );
     } else {
         let label_selector = config
@@ -390,8 +416,12 @@ async fn handle_pod_event(
                 // Try to downcast to PDRouter first, then VllmPDRouter
                 if let Some(pd_router) = router.as_any().downcast_ref::<PDRouter>() {
                     match &pod_info.pod_type {
-                        Some(PodType::Prefill) => pd_router
-                            .add_prefill_server(worker_url.clone(), pod_info.bootstrap_port)
+                        Some(PodType::Prefill { ref pool }) => pd_router
+                            .add_prefill_server_with_pool(
+                                pool,
+                                worker_url.clone(),
+                                pod_info.bootstrap_port,
+                            )
                             .await
                             .map_err(|e| e.to_string()),
                         Some(PodType::Decode) => pd_router
@@ -407,8 +437,12 @@ async fn handle_pod_event(
                 {
                     // Support --vllm-pd-disaggregation mode with K8s service discovery
                     match &pod_info.pod_type {
-                        Some(PodType::Prefill) => vllm_pd_router
-                            .add_prefill_server(worker_url.clone(), pod_info.bootstrap_port)
+                        Some(PodType::Prefill { ref pool }) => vllm_pd_router
+                            .add_prefill_server_with_pool(
+                                pool,
+                                worker_url.clone(),
+                                pod_info.bootstrap_port,
+                            )
                             .await
                             .map_err(|e| e.to_string()),
                         Some(PodType::Decode) => vllm_pd_router
@@ -479,7 +513,7 @@ async fn handle_pod_deletion(
             // Try to downcast to PDRouter first, then VllmPDRouter
             if let Some(pd_router) = router.as_any().downcast_ref::<PDRouter>() {
                 match &pod_info.pod_type {
-                    Some(PodType::Prefill) => {
+                    Some(PodType::Prefill { .. }) => {
                         if let Err(e) = pd_router.remove_prefill_server(&worker_url).await {
                             error!("Failed to remove prefill server {}: {}", worker_url, e);
                         }
@@ -497,7 +531,7 @@ async fn handle_pod_deletion(
             } else if let Some(vllm_pd_router) = router.as_any().downcast_ref::<VllmPDRouter>() {
                 // Support --vllm-pd-disaggregation mode with K8s service discovery
                 match &pod_info.pod_type {
-                    Some(PodType::Prefill) => {
+                    Some(PodType::Prefill { .. }) => {
                         if let Err(e) = vllm_pd_router.remove_prefill_server(&worker_url).await {
                             error!("Failed to remove vllm prefill server {}: {}", worker_url, e);
                         }
@@ -655,6 +689,9 @@ mod tests {
         prefill_selector.insert("app".to_string(), "vllm".to_string());
         prefill_selector.insert("component".to_string(), "prefill".to_string());
 
+        let mut prefill_selectors = BTreeMap::new();
+        prefill_selectors.insert("default".to_string(), prefill_selector);
+
         let mut decode_selector = HashMap::new();
         decode_selector.insert("app".to_string(), "vllm".to_string());
         decode_selector.insert("component".to_string(), "decode".to_string());
@@ -666,7 +703,7 @@ mod tests {
             port: 8080,
             namespace: None,
             pd_mode: true,
-            prefill_selector,
+            prefill_selectors,
             decode_selector,
             bootstrap_port_annotation: "vllm.ai/bootstrap-port".to_string(),
         }
@@ -708,7 +745,7 @@ mod tests {
         assert_eq!(config.port, 8000);
         assert!(config.namespace.is_none());
         assert!(!config.pd_mode);
-        assert!(config.prefill_selector.is_empty());
+        assert!(config.prefill_selectors.is_empty());
         assert!(config.decode_selector.is_empty());
         assert_eq!(config.bootstrap_port_annotation, "vllm.ai/bootstrap-port");
     }
@@ -716,11 +753,13 @@ mod tests {
     #[test]
     fn test_pod_type_enum() {
         // Test that PodType enum has expected variants
-        let prefill = PodType::Prefill;
+        let prefill = PodType::Prefill {
+            pool: "default".to_string(),
+        };
         let decode = PodType::Decode;
         let regular = PodType::Regular;
 
-        assert_eq!(format!("{:?}", prefill), "Prefill");
+        assert!(format!("{:?}", prefill).contains("Prefill"));
         assert_eq!(format!("{:?}", decode), "Decode");
         assert_eq!(format!("{:?}", regular), "Regular");
     }
@@ -753,7 +792,12 @@ mod tests {
         assert_eq!(pod_info.ip, "10.0.0.1".parse::<IpAddr>().unwrap());
         assert_eq!(pod_info.status, "Running");
         assert!(pod_info.is_ready);
-        assert_eq!(pod_info.pod_type, Some(PodType::Prefill));
+        assert_eq!(
+            pod_info.pod_type,
+            Some(PodType::Prefill {
+                pool: "default".to_string()
+            })
+        );
         assert_eq!(pod_info.bootstrap_port, Some(8081));
     }
 
@@ -812,7 +856,12 @@ mod tests {
         let config = create_pd_config();
 
         let pod_info = PodInfo::from_pod(&pod, Some(&config)).unwrap();
-        assert_eq!(pod_info.pod_type, Some(PodType::Prefill));
+        assert_eq!(
+            pod_info.pod_type,
+            Some(PodType::Prefill {
+                pool: "default".to_string()
+            })
+        );
         assert!(pod_info.bootstrap_port.is_none()); // Should be None for invalid port
     }
 
@@ -937,7 +986,9 @@ mod tests {
             ip: "1.2.3.4".parse().unwrap(),
             status: "Running".into(),
             is_ready: true,
-            pod_type: Some(PodType::Prefill),
+            pod_type: Some(PodType::Prefill {
+                pool: "default".to_string(),
+            }),
             bootstrap_port: Some(8081),
         };
 
@@ -946,7 +997,9 @@ mod tests {
             ip: "1.2.3.4".parse().unwrap(),
             status: "Running".into(),
             is_ready: true,
-            pod_type: Some(PodType::Prefill),
+            pod_type: Some(PodType::Prefill {
+                pool: "default".to_string(),
+            }),
             bootstrap_port: Some(8081),
         };
 
@@ -1028,7 +1081,9 @@ mod tests {
             ip: "1.2.3.4".parse().unwrap(),
             status: "Running".into(),
             is_ready: true,
-            pod_type: Some(PodType::Prefill),
+            pod_type: Some(PodType::Prefill {
+                pool: "default".to_string(),
+            }),
             bootstrap_port: Some(8081),
         };
         let port = 8080u16;
@@ -1084,7 +1139,9 @@ mod tests {
             ip: "1.2.3.4".parse().unwrap(),
             status: "Running".into(),
             is_ready: true,
-            pod_type: Some(PodType::Prefill),
+            pod_type: Some(PodType::Prefill {
+                pool: "default".to_string(),
+            }),
             bootstrap_port: Some(8081),
         };
 
@@ -1175,7 +1232,9 @@ mod tests {
             ip: "1.2.3.4".parse().unwrap(),
             status: "Running".into(),
             is_ready: true,
-            pod_type: Some(PodType::Prefill),
+            pod_type: Some(PodType::Prefill {
+                pool: "default".to_string(),
+            }),
             bootstrap_port: Some(8081),
         };
         let port = 8080u16;
@@ -1192,6 +1251,276 @@ mod tests {
 
         // Pod should not be tracked since router.add_pd_worker will fail for regular router
         assert!(!tracked_pods.lock().unwrap().contains(&pod_info));
+    }
+
+    // Helper to create a multi-pool PD config with "text" and "perception" prefill pools
+    fn create_multi_pool_pd_config() -> ServiceDiscoveryConfig {
+        let mut text_selector = HashMap::new();
+        text_selector.insert("app".to_string(), "vllm".to_string());
+        text_selector.insert("pool".to_string(), "text-prefill".to_string());
+
+        let mut perception_selector = HashMap::new();
+        perception_selector.insert("app".to_string(), "vllm".to_string());
+        perception_selector.insert("pool".to_string(), "perception-prefill".to_string());
+
+        let mut prefill_selectors = BTreeMap::new();
+        prefill_selectors.insert("text".to_string(), text_selector);
+        prefill_selectors.insert("perception".to_string(), perception_selector);
+
+        let mut decode_selector = HashMap::new();
+        decode_selector.insert("app".to_string(), "vllm".to_string());
+        decode_selector.insert("pool".to_string(), "decode".to_string());
+
+        ServiceDiscoveryConfig {
+            enabled: true,
+            selector: HashMap::new(),
+            check_interval: Duration::from_secs(60),
+            port: 8080,
+            namespace: None,
+            pd_mode: true,
+            prefill_selectors,
+            decode_selector,
+            bootstrap_port_annotation: "vllm.ai/bootstrap-port".to_string(),
+        }
+    }
+
+    // Helper to create a pod with arbitrary labels
+    fn create_labeled_pod(
+        name: &str,
+        ip: &str,
+        labels: Vec<(&str, &str)>,
+        bootstrap_port: Option<u16>,
+    ) -> Pod {
+        let mut label_map = std::collections::BTreeMap::new();
+        for (k, v) in labels {
+            label_map.insert(k.to_string(), v.to_string());
+        }
+
+        let mut annotations = std::collections::BTreeMap::new();
+        if let Some(port) = bootstrap_port {
+            annotations.insert("vllm.ai/bootstrap-port".to_string(), port.to_string());
+        }
+
+        Pod {
+            metadata: ObjectMeta {
+                name: Some(name.to_string()),
+                labels: Some(label_map),
+                annotations: Some(annotations),
+                ..Default::default()
+            },
+            spec: Some(PodSpec::default()),
+            status: Some(PodStatus {
+                pod_ip: Some(ip.to_string()),
+                phase: Some("Running".to_string()),
+                conditions: Some(vec![PodCondition {
+                    type_: "Ready".to_string(),
+                    status: "True".to_string(),
+                    last_probe_time: None,
+                    last_transition_time: None,
+                    message: None,
+                    reason: None,
+                    observed_generation: None,
+                }]),
+                ..Default::default()
+            }),
+        }
+    }
+
+    #[test]
+    fn test_from_pod_multi_pool_text_prefill() {
+        let config = create_multi_pool_pd_config();
+        let pod = create_labeled_pod(
+            "text-prefill-0",
+            "10.0.1.1",
+            vec![("app", "vllm"), ("pool", "text-prefill")],
+            Some(9001),
+        );
+
+        let pod_info = PodInfo::from_pod(&pod, Some(&config)).unwrap();
+        assert_eq!(pod_info.name, "text-prefill-0");
+        assert_eq!(
+            pod_info.pod_type,
+            Some(PodType::Prefill {
+                pool: "text".to_string()
+            })
+        );
+        assert_eq!(pod_info.bootstrap_port, Some(9001));
+    }
+
+    #[test]
+    fn test_from_pod_multi_pool_perception_prefill() {
+        let config = create_multi_pool_pd_config();
+        let pod = create_labeled_pod(
+            "perception-prefill-0",
+            "10.0.2.1",
+            vec![("app", "vllm"), ("pool", "perception-prefill")],
+            Some(9002),
+        );
+
+        let pod_info = PodInfo::from_pod(&pod, Some(&config)).unwrap();
+        assert_eq!(pod_info.name, "perception-prefill-0");
+        assert_eq!(
+            pod_info.pod_type,
+            Some(PodType::Prefill {
+                pool: "perception".to_string()
+            })
+        );
+        assert_eq!(pod_info.bootstrap_port, Some(9002));
+    }
+
+    #[test]
+    fn test_from_pod_multi_pool_decode() {
+        let config = create_multi_pool_pd_config();
+        let pod = create_labeled_pod(
+            "decode-0",
+            "10.0.3.1",
+            vec![("app", "vllm"), ("pool", "decode")],
+            None,
+        );
+
+        let pod_info = PodInfo::from_pod(&pod, Some(&config)).unwrap();
+        assert_eq!(pod_info.name, "decode-0");
+        assert_eq!(pod_info.pod_type, Some(PodType::Decode));
+        assert!(pod_info.bootstrap_port.is_none());
+    }
+
+    #[test]
+    fn test_from_pod_multi_pool_unmatched_falls_to_regular() {
+        let config = create_multi_pool_pd_config();
+        let pod = create_labeled_pod(
+            "other-0",
+            "10.0.4.1",
+            vec![("app", "vllm"), ("pool", "unknown-pool")],
+            None,
+        );
+
+        let pod_info = PodInfo::from_pod(&pod, Some(&config)).unwrap();
+        assert_eq!(pod_info.pod_type, Some(PodType::Regular));
+        assert!(pod_info.bootstrap_port.is_none());
+    }
+
+    #[test]
+    fn test_should_include_multi_pool_text_prefill() {
+        let config = create_multi_pool_pd_config();
+        let pod = create_labeled_pod(
+            "text-prefill-0",
+            "10.0.1.1",
+            vec![("app", "vllm"), ("pool", "text-prefill")],
+            Some(9001),
+        );
+        assert!(PodInfo::should_include(&pod, &config));
+    }
+
+    #[test]
+    fn test_should_include_multi_pool_perception_prefill() {
+        let config = create_multi_pool_pd_config();
+        let pod = create_labeled_pod(
+            "perception-prefill-0",
+            "10.0.2.1",
+            vec![("app", "vllm"), ("pool", "perception-prefill")],
+            Some(9002),
+        );
+        assert!(PodInfo::should_include(&pod, &config));
+    }
+
+    #[test]
+    fn test_should_include_multi_pool_decode() {
+        let config = create_multi_pool_pd_config();
+        let pod = create_labeled_pod(
+            "decode-0",
+            "10.0.3.1",
+            vec![("app", "vllm"), ("pool", "decode")],
+            None,
+        );
+        assert!(PodInfo::should_include(&pod, &config));
+    }
+
+    #[test]
+    fn test_should_include_multi_pool_rejects_unmatched() {
+        let config = create_multi_pool_pd_config();
+        let pod = create_labeled_pod(
+            "other-0",
+            "10.0.4.1",
+            vec![("app", "other-app"), ("pool", "text-prefill")],
+            None,
+        );
+        assert!(!PodInfo::should_include(&pod, &config));
+    }
+
+    #[test]
+    fn test_pod_type_equality_different_pools() {
+        let text_pool = PodType::Prefill {
+            pool: "text".to_string(),
+        };
+        let perception_pool = PodType::Prefill {
+            pool: "perception".to_string(),
+        };
+        let default_pool = PodType::Prefill {
+            pool: "default".to_string(),
+        };
+
+        assert_ne!(text_pool, perception_pool);
+        assert_ne!(text_pool, default_pool);
+        assert_ne!(perception_pool, default_pool);
+
+        let text_pool2 = PodType::Prefill {
+            pool: "text".to_string(),
+        };
+        assert_eq!(text_pool, text_pool2);
+    }
+
+    #[test]
+    fn test_overlapping_selectors_most_specific_wins() {
+        // Both pools match on app=vllm, but "perception" also requires pool=perception.
+        // A pod with app=vllm,pool=perception matches both selectors.
+        // The most specific selector (most labels) wins, so "perception" (2 labels)
+        // beats "text" (1 label) regardless of pool name ordering.
+        let mut broad_selector = HashMap::new();
+        broad_selector.insert("app".to_string(), "vllm".to_string());
+
+        let mut specific_selector = HashMap::new();
+        specific_selector.insert("app".to_string(), "vllm".to_string());
+        specific_selector.insert("pool".to_string(), "perception".to_string());
+
+        let mut prefill_selectors = BTreeMap::new();
+        // "text" pool has a broad selector (just app=vllm)
+        prefill_selectors.insert("text".to_string(), broad_selector);
+        // "perception" pool has a more specific selector (app=vllm,pool=perception)
+        prefill_selectors.insert("perception".to_string(), specific_selector);
+
+        let config = ServiceDiscoveryConfig {
+            enabled: true,
+            selector: HashMap::new(),
+            check_interval: Duration::from_secs(60),
+            port: 8080,
+            namespace: None,
+            pd_mode: true,
+            prefill_selectors,
+            decode_selector: HashMap::new(),
+            bootstrap_port_annotation: "vllm.ai/bootstrap-port".to_string(),
+        };
+
+        // Pod matches both selectors
+        let pod = create_labeled_pod(
+            "overlap-pod",
+            "10.0.1.1",
+            vec![("app", "vllm"), ("pool", "perception")],
+            None,
+        );
+
+        // Run multiple times to verify determinism
+        for _ in 0..10 {
+            let pod_info = PodInfo::from_pod(&pod, Some(&config)).unwrap();
+            // "perception" selector has 2 labels vs "text" with 1 label,
+            // so most-specific-wins picks "perception"
+            assert_eq!(
+                pod_info.pod_type,
+                Some(PodType::Prefill {
+                    pool: "perception".to_string()
+                }),
+                "Most specific selector (most labels) should win with overlapping selectors"
+            );
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

Enable independent scaling of text and perception (multimodal) prefill pods while sharing a single decode pool. Requests are auto-routed to the correct prefill pool based on modality detection (image_url content parts → perception, otherwise → text).

Key changes:
- Add detect_prefill_pool() / detect_prefill_pool_from_json() in spec.rs
- Add parse_prefill_selectors() for named pool CLI selectors (e.g. --prefill-selector=text:app=text-prefill)
- Change DiscoveryConfig.prefill_selector to prefill_selectors map
- Add WorkerRegistry.get_prefill_workers_by_pool() with label filtering
- Update K8s service discovery PodType::Prefill to carry pool name
- Add pool-aware routing in VllmPDRouter (route_chat, route_completion, route_transparent)
- Add prefill_pool_routed_total Prometheus metric with pool label
- Add 33 unit tests covering all new functionality
- Backward compatible: no pool prefix defaults to "default" pool

## Test Plan

Tested by deploying multi-prefill on k8s. 

## Test Result

Both text and perception evals passed, and we verified routing worked correctly.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
