### PR TITLE
fix: use parse_worker_url() to strip @rank before reqwest dispatch in VllmPDRouter

### DIFF
--- a/src/routers/http/dp_utils.rs
+++ b/src/routers/http/dp_utils.rs
@@ -254,4 +254,123 @@ mod tests {
             assert_eq!(rank, i);
         }
     }
+    // ============================================================
+    // Verify parse_worker_url handles ALL URL formats correctly
+    // These tests cover both the #98 regression (hostname:port)
+    // and the original #92 concern (IPv6)
+    // ============================================================
+
+    #[test]
+    fn test_parse_worker_url_hostname_port_dp() {
+        let (base, rank) = parse_worker_url("http://node1:8087@3");
+        assert_eq!(base, "http://node1:8087");
+        assert_eq!(rank, Some(3));
+        // Verify the URL we'd send to reqwest is clean
+        let request_url = format!("{}/v1/completions", base);
+        assert!(
+            !request_url.contains('@'),
+            "request URL must not contain @rank"
+        );
+        assert_eq!(request_url, "http://node1:8087/v1/completions");
+    }
+
+    #[test]
+    fn test_parse_worker_url_hostname_port_no_dp() {
+        let (base, rank) = parse_worker_url("http://node1:8087");
+        assert_eq!(base, "http://node1:8087");
+        assert_eq!(rank, None);
+    }
+
+    // ============================================================
+    // Critical: prove that reqwest would parse @rank as userinfo
+    // This is the actual bug that #98 introduced
+    // ============================================================
+
+    #[test]
+    fn test_reqwest_userinfo_proof() {
+        // Demonstrate WHY @rank must be stripped before reqwest:
+        // reqwest/url parses "http://host:port@rank" as userinfo
+
+        // BAD: raw URL with @rank — reqwest sees wrong host
+        let bad_url = url::Url::parse("http://node1:8087@3/v1/completions").unwrap();
+        assert_eq!(
+            bad_url.host_str(),
+            Some("0.0.0.3"),
+            "proves @rank corrupts host"
+        );
+        assert_eq!(bad_url.username(), "node1", "host becomes username");
+
+        // GOOD: stripped URL — reqwest sees correct host
+        let (base, rank) = parse_worker_url("http://node1:8087@3");
+        let good_url_str = format!("{}/v1/completions", base);
+        let good_url = url::Url::parse(&good_url_str).unwrap();
+        assert_eq!(
+            good_url.host_str(),
+            Some("node1"),
+            "host is correct after stripping"
+        );
+        assert_eq!(good_url.port(), Some(8087));
+        assert_eq!(rank, Some(3));
+    }
+
+    #[test]
+    fn test_reqwest_userinfo_proof_ipv6() {
+        // Same proof for IPv6 — verify our fix works for both formats
+        let (base, rank) =
+            parse_worker_url("https://[2a03:83e4:5006:0090:5f5a:f8c5:0400:0000]:20009@2");
+        let url_str = format!("{}/v1/completions", base);
+        let parsed = url::Url::parse(&url_str).unwrap();
+        assert_eq!(
+            parsed.host_str(),
+            Some("[2a03:83e4:5006:90:5f5a:f8c5:400:0]")
+        );
+        assert_eq!(parsed.port(), Some(20009));
+        assert_eq!(rank, Some(2));
+        assert!(parsed.username().is_empty(), "no userinfo pollution");
+    }
+
+    // ============================================================
+    // End-to-end: expand → parse → build URL round-trip
+    // ============================================================
+
+    #[tokio::test]
+    async fn test_dp_expand_roundtrip_hostname() {
+        let urls = vec!["http://node1:8087".to_string()];
+        let expanded = get_dp_aware_workers(&urls, &None, 4).await.unwrap();
+
+        for (i, worker_url) in expanded.iter().enumerate() {
+            // Simulate what our fixed vllm_pd_router does:
+            let (base, rank) = parse_worker_url(worker_url);
+            let request_url = format!("{}/v1/completions", base);
+
+            // Verify rank is correct
+            assert_eq!(rank, Some(i));
+
+            // Verify URL is clean for reqwest
+            assert!(!request_url.contains('@'));
+            let parsed = url::Url::parse(&request_url).unwrap();
+            assert_eq!(parsed.host_str(), Some("node1"));
+            assert_eq!(parsed.port(), Some(8087));
+        }
+    }
+
+    #[tokio::test]
+    async fn test_dp_expand_roundtrip_ipv6() {
+        let urls = vec!["https://[2a03:83e4:5006:0090:5f5a:f8c5:0400:0000]:20009".to_string()];
+        let expanded = get_dp_aware_workers(&urls, &None, 4).await.unwrap();
+
+        for (i, worker_url) in expanded.iter().enumerate() {
+            let (base, rank) = parse_worker_url(worker_url);
+            let request_url = format!("{}/v1/completions", base);
+
+            assert_eq!(rank, Some(i));
+            assert!(!request_url.contains('@'));
+            let parsed = url::Url::parse(&request_url).unwrap();
+            assert_eq!(
+                parsed.host_str(),
+                Some("[2a03:83e4:5006:90:5f5a:f8c5:400:0]")
+            );
+            assert_eq!(parsed.port(), Some(20009));
+        }
+    }
 }

--- a/src/routers/http/vllm_pd_router.rs
+++ b/src/routers/http/vllm_pd_router.rs
@@ -696,11 +696,12 @@ impl VllmPDRouter {
 
         debug!("Added kv_transfer_params to prefill request for NixlConnector support");
 
-        // Use endpoint_url() to get the base URL without @rank suffix,
-        // avoiding IPv6+DP URL corruption (same fix as Router and PDRouter)
-        let prefill_base_url = prefill_worker.base_url().to_string();
-        let prefill_dp_rank = prefill_worker.dp_rank();
-        let prefill_url = prefill_worker.endpoint_url(path);
+        // Use parse_worker_url to safely strip @rank suffix before sending to reqwest.
+        // BasicWorker stores the full URL including @rank, and its default trait
+        // base_url()/endpoint_url() do not strip it, causing reqwest to misparse
+        // "http://host:port@rank" as HTTP userinfo (user:pass@host).
+        let (prefill_base_url, prefill_dp_rank) = dp_utils::parse_worker_url(prefill_worker.url());
+        let prefill_url = format!("{}{}", prefill_base_url, path);
 
         debug!(
             "🚀 vLLM Stage 1 - Prefill: {} with request_id: {}",
@@ -836,11 +837,10 @@ impl VllmPDRouter {
             debug!("Added kv_transfer_params to decode request");
         }
 
-        // Use endpoint_url() to get the base URL without @rank suffix,
-        // avoiding IPv6+DP URL corruption (same fix as Router and PDRouter)
-        let decode_base_url = decode_worker.base_url().to_string();
-        let decode_dp_rank = decode_worker.dp_rank();
-        let decode_url = decode_worker.endpoint_url(path);
+        // Use parse_worker_url to safely strip @rank suffix before sending to reqwest.
+        // Same fix as prefill path above - see comment there for details.
+        let (decode_base_url, decode_dp_rank) = dp_utils::parse_worker_url(decode_worker.url());
+        let decode_url = format!("{}{}", decode_base_url, path);
 
         debug!(
             "🚀 vLLM Stage 2 - Decode: {} with request_id: {}",


### PR DESCRIPTION
## Purpose

Fixes #100 — regression from #98 where hostname:port URLs with
`--intra-node-data-parallel-size > 1` fail because `@rank` suffix
is not stripped before passing to reqwest.

## Root Cause

PDRouter stores DP-expanded URLs (e.g. `http://node1:8087@3`) as
`BasicWorker`. `BasicWorker`'s default `base_url()` returns the raw
URL including `@rank`. #98 replaced manual `extract_dp_rank()` stripping
with `endpoint_url()`, which relies on `base_url()` — but `BasicWorker`
does not override it to strip `@rank`.

When reqwest receives `http://node1:8087@3`, it parses as HTTP userinfo:
- user=`node1`, pass=`8087`, host=`3` → `0.0.0.3`

The old code already handled this correctly via `extract_dp_rank()`.
#98 inadvertently removed that working logic.

## Fix

Replace `prefill_worker.endpoint_url(path)` / `decode_worker.endpoint_url(path)`
with `dp_utils::parse_worker_url(worker.url())` + `format!("{}{}", base, path)`
to explicitly strip `@rank` before constructing request URLs.

## Test Plan

Added unit tests for hostname:port format in dp_utils:
- `test_parse_worker_url_hostname_port_dp`
- `test_parse_worker_url_hostname_port_no_dp`
- `test_reqwest_userinfo_proof` — proves `@rank` causes host corruption
- `test_reqwest_userinfo_proof_ipv6` — proves IPv6 also works correctly
- `test_dp_expand_roundtrip_hostname` — end-to-end hostname:port
- `test_dp_expand_roundtrip_ipv6` — end-to-end IPv6

cargo test -- dp_utils

`15 passed; 0 failed`
<img width="665" height="318" alt="Screenshot 2026-03-05 at 4 58 04 PM" src="https://github.com/user-attachments/assets/b12bf702-109d-4dbe-ac0c-2afa80d8843d" />

**After (this PR):** Requests route correctly to actual worker hostnames.