### PR TITLE
Change content type in Tool message to Value

### DIFF
--- a/src/protocols/spec.rs
+++ b/src/protocols/spec.rs
@@ -90,7 +90,7 @@ pub enum ChatMessage {
     },
     Tool {
         role: String, // "tool"
-        content: String,
+        content: Value,
         tool_call_id: String,
     },
     Function {
@@ -191,9 +191,8 @@ impl<'de> Deserialize<'de> for ChatMessage {
                 role: role.to_string(),
                 content: value
                     .get("content")
-                    .and_then(|c| c.as_str())
-                    .unwrap_or("")
-                    .to_string(),
+                    .cloned()
+                    .unwrap_or_else(|| Value::String(String::new())),
                 tool_call_id: value
                     .get("tool_call_id")
                     .and_then(|t| t.as_str())
@@ -3615,8 +3614,34 @@ mod tests {
                 tool_call_id,
                 ..
             } => {
-                assert_eq!(content, "Tool result here");
+                assert_eq!(content, Value::String("Tool result here".to_string()));
                 assert_eq!(tool_call_id, "call_123");
+            }
+            _ => panic!("Expected Tool message"),
+        }
+    }
+
+    #[test]
+    fn test_chat_message_tool_preserves_array_content() {
+        let json = r#"{
+            "role": "tool",
+            "content": [{"type": "text", "text": "1 files found: ['wi_example.docx']"}],
+            "tool_call_id": "call_456"
+        }"#;
+
+        let message: ChatMessage = serde_json::from_str(json).unwrap();
+
+        match message {
+            ChatMessage::Tool {
+                content,
+                tool_call_id,
+                ..
+            } => {
+                let expected = serde_json::json!([
+                    {"type": "text", "text": "1 files found: ['wi_example.docx']"}
+                ]);
+                assert_eq!(content, expected);
+                assert_eq!(tool_call_id, "call_456");
             }
             _ => panic!("Expected Tool message"),
         }


### PR DESCRIPTION
## Purpose

Fixes #107 

Fixes an issue where `tool` message content was dropped when the router forwarded requests to the worker.

Previously, when a request contained a tool response like:

```json
{
  "role": "tool",
  "tool_call_id": "chatcmpl-tool-a9717cdb2bb2f299",
  "content": [
    { "type": "text", "text": "1 files found: ['wi_example.docx']" }
  ]
}
```

the router could forward it as:

```json
{
  "role": "tool",
  "tool_call_id": "chatcmpl-tool-a9717cdb2bb2f299",
  "content": ""
}
```

Root cause:
`ChatMessage::Tool.content` was deserialized as `String` in `specs`, so non-string content (for example array-based/multimodal tool output) was coerced to an empty string.

Impact:
The model received an empty tool response and could hallucinate instead of using the real tool output.

This PR updates the `specs` message model/deserialization logic to preserve tool content as JSON and forward it unchanged to the worker.

---

## Test Plan

1. Start router and worker.
2. Send a chat completion request containing:
- a tool call
- a tool response message with array-based content
3. Inspect router logs and forwarded worker payload (`vllm_router_rs::backend_payload`).

Example `messages`:

```json
[
  {"role":"user","content":"Ok donne la liste des fichiers"},
  {
    "role":"assistant",
    "tool_calls":[
      {
        "type":"function",
        "id":"chatcmpl-tool-test",
        "function":{"name":"get-list-file","arguments":"{}"}
      }
    ]
  },
  {
    "role":"tool",
    "tool_call_id":"chatcmpl-tool-test",
    "content":[{"type":"text","text":"1 files found: ['wi_example.docx']"}]
  }
]
```

---

## Test Result

### Before

Forwarded payload:

```json
{
  "role":"tool",
  "tool_call_id":"chatcmpl-tool-test",
  "content":""
}
```

Tool content was lost.

### After

Forwarded payload:

```json
{
  "role":"tool",
  "tool_call_id":"chatcmpl-tool-test",
  "content":[{"type":"text","text":"1 files found: ['wi_example.docx']"}]
}
```

Tool content is preserved and available to the model.
