### PR TITLE
fix: set DefaultBodyLimit to match max_payload_size for axum extractors

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -21,7 +21,7 @@ use crate::{
     tokenizer::{factory as tokenizer_factory, traits::Tokenizer},
 };
 use axum::{
-    extract::{Path, Query, Request, State},
+    extract::{DefaultBodyLimit, Path, Query, Request, State},
     http::StatusCode,
     response::{IntoResponse, Response},
     routing::{delete, get, post},
@@ -760,6 +760,7 @@ pub fn build_app(
         .merge(admin_routes)
         .merge(worker_routes)
         // Request body size limiting
+        .layer(DefaultBodyLimit::max(max_payload_size))
         .layer(tower_http::limit::RequestBodyLimitLayer::new(
             max_payload_size,
         ))


### PR DESCRIPTION
Axum's Json<T> extractor enforces a default 2MB body limit (DefaultBodyLimit), independent of the tower-http RequestBodyLimitLayer. Multimodal requests with base64-encoded images easily exceed 2MB, causing 413 Payload Too Large errors. Add DefaultBodyLimit::max() layer so Json extractors respect the configured --max-payload-size (512MB).

<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

## Test Plan
Built Docker image and used for MMMU eval against P/D disagg using the response API (on top of https://github.com/vllm-project/router/pull/99)

Before: a lot of 413 errors due to payload too large
After: MMMU eval passed

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
