### PR TITLE
fix: CVEs in docker image

### DIFF
--- a/Dockerfile.router
+++ b/Dockerfile.router
@@ -21,12 +21,14 @@ COPY build.rs ./
 RUN cargo build --release
 
 # Python stage with Rust binary
-FROM python:3.11-slim-bullseye
+FROM python:3.12-slim-bullseye
 
 # Install system dependencies
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt upgrade -y && apt-get install -y \
     curl \
     && rm -rf /var/lib/apt/lists/*
+
+RUN pip3 install --upgrade pip
 
 # Create app directory
 WORKDIR /app


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

This PR fixes following 36 CVEs when building router docker image:
```
â”‚ gpgv               â”‚ CVE-2025-68973 â”‚ HIGH     â”‚        â”‚ 2.2.27-2+deb11u2  â”‚ 2.2.27-2+deb11u3         â”‚ GnuPG: GnuPG: Information disclosure and potential arbitrary â”‚
â”‚ libgnutls30        â”‚ CVE-2025-32988 â”‚          â”‚        â”‚ 3.7.1-5+deb11u7   â”‚ 3.7.1-5+deb11u8          â”‚ gnutls: Vulnerability in GnuTLS otherName SAN export         â”‚
â”‚                    â”‚ CVE-2025-32990 â”‚          â”‚        â”‚                   â”‚                          â”‚ gnutls: Vulnerability in GnuTLS certtool template parsing    â”‚
â”‚                    â”‚ CVE-2025-14831 â”‚ MEDIUM   â”‚        â”‚                   â”‚ 3.7.1-5+deb11u9          â”‚ gnutls: GnuTLS: Denial of Service via excessive resource     â”‚
â”‚                    â”‚ CVE-2025-6395  â”‚          â”‚        â”‚                   â”‚ 3.7.1-5+deb11u8          â”‚ gnutls: NULL pointer dereference in                          â”‚
â”‚                    â”‚ CVE-2025-9820  â”‚          â”‚        â”‚                   â”‚ 3.7.1-5+deb11u9          â”‚ gnutls: Stack-based Buffer Overflow in                       â”‚
â”‚ libpam-modules     â”‚ CVE-2025-6020  â”‚ HIGH     â”‚        â”‚ 1.4.0-9+deb11u1   â”‚ 1.4.0-9+deb11u2          â”‚ linux-pam: Linux-pam directory Traversal                     â”‚
â”‚                    â”‚ CVE-2024-22365 â”‚ MEDIUM   â”‚        â”‚                   â”‚                          â”‚ pam: allowing unprivileged user to block another user        â”‚
â”‚ libpam-modules-bin â”‚ CVE-2025-6020  â”‚ HIGH     â”‚        â”‚                   â”‚                          â”‚ linux-pam: Linux-pam directory Traversal                     â”‚
â”‚                    â”‚ CVE-2024-22365 â”‚ MEDIUM   â”‚        â”‚                   â”‚                          â”‚ pam: allowing unprivileged user to block another user        â”‚
â”‚ libpam-runtime     â”‚ CVE-2025-6020  â”‚ HIGH     â”‚        â”‚                   â”‚                          â”‚ linux-pam: Linux-pam directory Traversal                     â”‚
â”‚                    â”‚ CVE-2024-22365 â”‚ MEDIUM   â”‚        â”‚                   â”‚                          â”‚ pam: allowing unprivileged user to block another user        â”‚
â”‚ libpam0g           â”‚ CVE-2025-6020  â”‚ HIGH     â”‚        â”‚                   â”‚                          â”‚ linux-pam: Linux-pam directory Traversal                     â”‚
â”‚                    â”‚ CVE-2024-22365 â”‚ MEDIUM   â”‚        â”‚                   â”‚                          â”‚ pam: allowing unprivileged user to block another user        â”‚
â”‚ libssl1.1          â”‚ CVE-2025-69419 â”‚ HIGH     â”‚        â”‚ 1.1.1w-0+deb11u3  â”‚ 1.1.1w-0+deb11u5         â”‚ openssl: OpenSSL: Arbitrary code execution due to            â”‚
â”‚                    â”‚ CVE-2025-69421 â”‚          â”‚        â”‚                   â”‚                          â”‚ openssl: OpenSSL: Denial of Service via malformed PKCS#12    â”‚
â”‚                    â”‚ CVE-2025-68160 â”‚ MEDIUM   â”‚        â”‚                   â”‚                          â”‚ openssl: OpenSSL: Denial of Service due to out-of-bounds     â”‚
â”‚                    â”‚ CVE-2025-69418 â”‚          â”‚        â”‚                   â”‚                          â”‚ openssl: OpenSSL: Information disclosure and data tampering  â”‚
â”‚                    â”‚ CVE-2025-69420 â”‚          â”‚        â”‚                   â”‚                          â”‚ openssl: OpenSSL: Denial of Service via malformed TimeStamp  â”‚
â”‚                    â”‚ CVE-2025-9230  â”‚          â”‚        â”‚                   â”‚ 1.1.1w-0+deb11u4         â”‚ openssl: Out-of-bounds read & write in RFC 3211 KEK Unwrap   â”‚
â”‚                    â”‚ CVE-2026-22795 â”‚          â”‚        â”‚                   â”‚ 1.1.1w-0+deb11u5         â”‚ openssl: OpenSSL: Denial of Service due to type confusion in â”‚
â”‚                    â”‚ CVE-2026-22796 â”‚          â”‚        â”‚                   â”‚                          â”‚ openssl: OpenSSL: Denial of Service via type confusion in    â”‚
â”‚ libsystemd0        â”‚ CVE-2025-4598  â”‚          â”‚        â”‚ 247.3-7+deb11u6   â”‚ 247.3-7+deb11u7          â”‚ systemd-coredump: race condition that allows a local         â”‚
â”‚ openssl            â”‚ CVE-2025-69419 â”‚ HIGH     â”‚        â”‚ 1.1.1w-0+deb11u3  â”‚ 1.1.1w-0+deb11u5         â”‚ openssl: OpenSSL: Arbitrary code execution due to            â”‚
â”‚                    â”‚ CVE-2025-69421 â”‚          â”‚        â”‚                   â”‚                          â”‚ openssl: OpenSSL: Denial of Service via malformed PKCS#12    â”‚
â”‚                    â”‚ CVE-2025-68160 â”‚ MEDIUM   â”‚        â”‚                   â”‚                          â”‚ openssl: OpenSSL: Denial of Service due to out-of-bounds     â”‚
â”‚                    â”‚ CVE-2025-69418 â”‚          â”‚        â”‚                   â”‚                          â”‚ openssl: OpenSSL: Information disclosure and data tampering  â”‚
â”‚                    â”‚ CVE-2025-69420 â”‚          â”‚        â”‚                   â”‚                          â”‚ openssl: OpenSSL: Denial of Service via malformed TimeStamp  â”‚
â”‚                    â”‚ CVE-2025-9230  â”‚          â”‚        â”‚                   â”‚ 1.1.1w-0+deb11u4         â”‚ openssl: Out-of-bounds read & write in RFC 3211 KEK Unwrap   â”‚
â”‚                    â”‚ CVE-2026-22795 â”‚          â”‚        â”‚                   â”‚ 1.1.1w-0+deb11u5         â”‚ openssl: OpenSSL: Denial of Service due to type confusion in â”‚
â”‚                    â”‚ CVE-2026-22796 â”‚          â”‚        â”‚                   â”‚                          â”‚ openssl: OpenSSL: Denial of Service via type confusion in    â”‚
â”‚ pip (METADATA)        â”‚ CVE-2025-8869  â”‚ MEDIUM   â”‚ fixed  â”‚ 24.0              â”‚ 25.3          â”‚ pip: pip missing checks on symbolic link extraction      â”‚
â”‚                       â”‚ CVE-2026-1703  â”‚ LOW      â”‚        â”‚                   â”‚ 26.0          â”‚ pip: pip: Information disclosure via path traversal when â”‚
â”‚ setuptools (METADATA) â”‚ CVE-2024-6345  â”‚ HIGH     â”‚        â”‚ 65.5.1            â”‚ 70.0.0        â”‚ pypa/setuptools: Remote code execution via download      â”‚
â”‚                       â”‚ CVE-2025-47273 â”‚          â”‚        â”‚                   â”‚ 78.1.1        â”‚ setuptools: Path Traversal Vulnerability in setuptools   â”‚
â”‚ wheel (METADATA)      â”‚ CVE-2026-24049 â”‚          â”‚        â”‚ 0.45.1            â”‚ 0.46.2        â”‚ wheel: wheel: Privilege Escalation or Arbitrary Code     â”‚
```

## Test Plan

## Test Result

 - I have verified that the new image `andyzhangx/router:v0.1.12` works well:
```
# k logs vllm-router-pd-84ff7d867c-7q695
DEBUG: Main function started
DEBUG: Parsing prefill arguments
DEBUG: Prefill URLs parsed: [("http://qwen306b-0.qwen306b-headless.default.svc.cluster.local:5000", None)]
DEBUG: Filtering CLI arguments
DEBUG: Raw args: ["vllm-router", "--pd-disaggregation", "--prefill", "http://qwen306b-0.qwen306b-headless.default.svc.cluster.local:5000", "--decode", "http://qwen306b-1.qwen306b-headless.default.svc.cluster.local:5000", "--host", "0.0.0.0", "--port", "10001", "--log-level", "info"]
DEBUG: Parsing CLI arguments with clap
DEBUG: Filtered args: ["vllm-router", "--pd-disaggregation", "--decode", "http://qwen306b-1.qwen306b-headless.default.svc.cluster.local:5000", "--host", "0.0.0.0", "--port", "10001", "--log-level", "info"]
DEBUG: CLI args parsed successfully
DEBUG: pd_disaggregation: true
DEBUG: vllm_pd_disaggregation: false
VLLM Router starting...
Host: 0.0.0.0:10001
Mode: PD Disaggregated
Policy: cache_aware
Prefill nodes: [("http://qwen306b-0.qwen306b-headless.default.svc.cluster.local:5000", None)]
Decode nodes: ["http://qwen306b-1.qwen306b-headless.default.svc.cluster.local:5000"]
DEBUG: Converting to RouterConfig
DEBUG: RouterConfig created successfully
DEBUG: Validating configuration
DEBUG: Configuration validated successfully
DEBUG: Creating ServerConfig
DEBUG: CLI host: 0.0.0.0, port: 10001
DEBUG: ServerConfig created successfully - host: 0.0.0.0, port: 10001
DEBUG: Creating Tokio runtime
DEBUG: Tokio runtime created successfully
DEBUG: Starting server startup function
DEBUG: Server startup function called
DEBUG: Initializing logging
DEBUG: Logging initialized
DEBUG: Initializing Prometheus metrics
DEBUG: Prometheus metrics initialized
2026-03-10 03:24:08  INFO vllm_router_rs::server: src/server.rs:819: Starting router on 0.0.0.0:10001 | mode: PrefillDecode { prefill_urls: [("http://qwen306b-0.qwen306b-headless.default.svc.cluster.local:5000", None)], decode_urls: ["http://qwen306b-1.qwen306b-headless.default.svc.cluster.local:5000"], prefill_policy: None, decode_policy: None } | policy: CacheAware { cache_threshold: 0.3, balance_abs_threshold: 64, balance_rel_threshold: 1.5, eviction_interval_secs: 120, max_tree_size: 67108864 } | max_payload: 512MB
DEBUG: Creating HTTP client
DEBUG: HTTP client created
DEBUG: Creating AppContext
DEBUG: AppContext created
2026-03-10 03:24:08  INFO vllm_router_rs::server: src/server.rs:917: Single router mode (enable_igw=false)
2026-03-10 03:24:08  INFO vllm_router_rs::routers::factory: src/routers/factory.rs:69: Creating regular PDRouter with prefill_urls: [("http://qwen306b-0.qwen306b-headless.default.svc.cluster.local:5000", None)], decode_urls: ["http://qwen306b-1.qwen306b-headless.default.svc.cluster.local:5000"]
2026-03-10 03:24:08  INFO vllm_router_rs::routers::http::pd_router: src/routers/http/pd_router.rs:497: DP-aware mode disabled, using original worker URLs
2026-03-10 03:24:08  INFO vllm_router_rs::routers::http::router: src/routers/http/router.rs:250: Waiting for 1 unique hosts (representing 1 workers) to become healthy (timeout: 600s)
2026-03-10 03:24:08  INFO vllm_router_rs::routers::http::router: src/routers/http/router.rs:320: 1 out of 1 unique hosts are healthy (representing 1 workers)
2026-03-10 03:24:08  INFO vllm_router_rs::routers::http::router: src/routers/http/router.rs:250: Waiting for 1 unique hosts (representing 1 workers) to become healthy (timeout: 600s)
2026-03-10 03:24:08  INFO vllm_router_rs::routers::http::router: src/routers/http/router.rs:320: 1 out of 1 unique hosts are healthy (representing 1 workers)
2026-03-10 03:24:08  INFO vllm_router_rs::server: src/server.rs:929: Started health checker for workers with 60s interval
2026-03-10 03:24:08  INFO vllm_router_rs::server: src/server.rs:944: Started request queue with size: 100, timeout: 60s
2026-03-10 03:24:08  INFO vllm_router_rs::routers::http::pd_router: src/routers/http/pd_router.rs:635: Prefill drain coordinator started
2026-03-10 03:24:08  INFO vllm_router_rs::server: src/server.rs:980: Router ready | workers: ["http://qwen306b-0.qwen306b-headless.default.svc.cluster.local:5000", "http://qwen306b-1.qwen306b-headless.default.svc.cluster.local:5000"]
2026-03-10 03:24:08  INFO vllm_router_rs::middleware: src/middleware.rs:335: Starting concurrency queue processor
2026-03-10 03:24:08  INFO vllm_router_rs::server: src/server.rs:1008: Starting server on 0.0.0.0:10001
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
