### PR TITLE
fix: revert nightly Docker build queue to cpu_queue_postmerge

### DIFF
--- a/.buildkite/release-pipeline.yml
+++ b/.buildkite/release-pipeline.yml
@@ -168,7 +168,7 @@ steps:
         depends_on: ~
         id: build-nightly-docker-x86
         agents:
-          queue: cpu_queue_premerge_us_east_1
+          queue: cpu_queue_postmerge
         commands:
           - "DOCKER_BUILDKIT=1 docker build --tag vllm/vllm-router:nightly-x86_64 --progress plain -f Dockerfile.router ."
           - "docker push vllm/vllm-router:nightly-x86_64"


### PR DESCRIPTION
The nightly Docker build was changed to use cpu_queue_premerge_us_east_1 but should use cpu_queue_postmerge instead.

<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

## Test Plan
check buildkite/release results

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
