### PR TITLE
feat: add OpenTelemetry distributed tracing support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,10 @@ tracing-subscriber = { version = "0.3", features = [
 ] }
 tracing-log = "0.2"
 tracing-appender = "0.2.3"
+opentelemetry = "0.27"
+opentelemetry_sdk = { version = "0.27", features = ["trace", "rt-tokio"] }
+opentelemetry-otlp = { version = "0.27", features = ["trace", "grpc-tonic"] }
+tracing-opentelemetry = "0.28"
 chrono = "0.4"
 kube = { version = "1.1.0", features = ["runtime", "derive"] }
 k8s-openapi = { version = "0.25.0", features = ["v1_33"] }

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -406,6 +406,24 @@ impl Default for MetricsConfig {
     }
 }
 
+/// OpenTelemetry tracing configuration
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TraceConfig {
+    /// Whether to enable OpenTelemetry tracing
+    pub enable_trace: bool,
+    /// OTLP collector endpoint (format: host:port)
+    pub otlp_traces_endpoint: String,
+}
+
+impl Default for TraceConfig {
+    fn default() -> Self {
+        Self {
+            enable_trace: false,
+            otlp_traces_endpoint: "localhost:4317".to_string(),
+        }
+    }
+}
+
 impl Default for RouterConfig {
     fn default() -> Self {
         Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ pub mod server;
 pub mod service_discovery;
 pub mod tokenizer;
 pub mod tree;
+pub mod otel_trace;
 use crate::metrics::PrometheusConfig;
 
 #[pyclass(eq)]

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -8,6 +8,9 @@ use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::{EnvFilter, Layer};
 
+use crate::config::TraceConfig;
+use crate::otel_trace::get_otel_layer;
+
 /// Configuration for the logging system
 #[derive(Debug, Clone)]
 pub struct LoggingConfig {
@@ -57,7 +60,7 @@ pub struct LogGuard {
 ///
 /// # Panics
 /// Will not panic, as initialization errors are handled gracefully
-pub fn init_logging(config: LoggingConfig) -> LogGuard {
+pub fn init_logging(config: LoggingConfig, otel_layer_config: Option<TraceConfig>) -> LogGuard {
     // Forward logs to tracing - ignore errors to allow for multiple initialization
     let _ = LogTracer::init();
 
@@ -147,6 +150,19 @@ pub fn init_logging(config: LoggingConfig) -> LogGuard {
         };
 
         layers.push(file_layer);
+    }
+
+    if let Some(otel_layer_config) = &otel_layer_config {
+        if otel_layer_config.enable_trace {
+            match get_otel_layer() {
+                Ok(otel_layer) => {
+                    layers.push(otel_layer);
+                }
+                Err(e) => {
+                    eprintln!("Failed to initialize OpenTelemetry layer: {e}");
+                }
+            }
+        }
     }
 
     // Initialize the subscriber with all layers

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use vllm_router_rs::config::{
     CircuitBreakerConfig, ConfigError, ConfigResult, ConnectionMode, DiscoveryConfig,
     HealthCheckConfig, HistoryBackend, MetricsConfig, PolicyConfig, RetryConfig, RouterConfig,
-    RoutingMode,
+    RoutingMode, TraceConfig,
 };
 use vllm_router_rs::metrics::PrometheusConfig;
 use vllm_router_rs::server::{self, ServerConfig};
@@ -206,6 +206,14 @@ struct CliArgs {
     /// Set the logging level
     #[arg(long, default_value = "info", value_parser = ["debug", "info", "warn", "error"])]
     log_level: String,
+
+    /// Enable OpenTelemetry tracing
+    #[arg(long, default_value_t = false, help_heading = "Tracing (OpenTelemetry)")]
+    enable_trace: bool,
+
+    /// OTLP collector endpoint (format: host:port)
+    #[arg(long, default_value = "localhost:4317", help_heading = "Tracing (OpenTelemetry)")]
+    otlp_traces_endpoint: String,
 
     /// Enable Kubernetes service discovery
     #[arg(long, default_value_t = false)]
@@ -675,6 +683,14 @@ impl CliArgs {
             } else {
                 Some(self.request_id_headers.clone())
             },
+            trace_config: if self.enable_trace {
+                Some(TraceConfig {
+                    enable_trace: true,
+                    otlp_traces_endpoint: self.otlp_traces_endpoint.clone(),
+                })
+            } else {
+                None
+            },
         }
     }
 }
@@ -791,6 +807,10 @@ Provide --worker-urls or PD flags as usual.",
     // Block on the async startup function
     println!("DEBUG: Starting server startup function");
     runtime.block_on(async move { server::startup(server_config).await })?;
+
+    if vllm_router_rs::otel_trace::is_otel_enabled() {
+        vllm_router_rs::otel_trace::shutdown_otel();
+    }
 
     Ok(())
 }

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -145,6 +145,7 @@ impl<B> MakeSpan<B> for RequestSpan {
         // Don't try to extract request ID here - it won't be available yet
         // The RequestIdLayer runs after TraceLayer creates the span
         info_span!(
+            target: "vllm_router_rs::otel-trace",
             "http_request",
             method = %request.method(),
             uri = %request.uri(),

--- a/src/otel_trace.rs
+++ b/src/otel_trace.rs
@@ -1,0 +1,220 @@
+//! OpenTelemetry tracing integration.
+
+use std::{
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        OnceLock,
+    },
+    time::Duration,
+};
+
+use anyhow::Result;
+use axum::http::{HeaderMap, HeaderName, HeaderValue};
+use opentelemetry::{global, trace::TracerProvider as _, KeyValue};
+use opentelemetry_otlp::WithExportConfig;
+use opentelemetry_sdk::{
+    propagation::TraceContextPropagator,
+    runtime,
+    trace::{BatchConfigBuilder, BatchSpanProcessor, Tracer as SdkTracer, TracerProvider},
+    Resource,
+};
+use tokio::task::spawn_blocking;
+use tracing::{Metadata, Subscriber};
+use tracing_opentelemetry::OpenTelemetrySpanExt;
+use tracing_subscriber::{
+    layer::{Context, Filter},
+    Layer,
+};
+
+/// Whether OpenTelemetry tracing is enabled.
+///
+/// This flag guards access to TRACER and PROVIDER. We use Release/Acquire
+/// ordering to ensure proper synchronization: writes to TRACER/PROVIDER
+/// happen-before the Release store, and Acquire loads happen-before reads.
+static ENABLED: AtomicBool = AtomicBool::new(false);
+static TRACER: OnceLock<SdkTracer> = OnceLock::new();
+static PROVIDER: OnceLock<TracerProvider> = OnceLock::new();
+
+const OTEL_SPAN_TARGET: &str = "vllm_router_rs::otel-trace";
+
+/// Filter that only allows specific module targets to be exported to OTEL.
+#[derive(Clone, Copy, Default)]
+pub(crate) struct CustomOtelFilter;
+
+impl CustomOtelFilter {
+    #[inline]
+    pub const fn new() -> Self {
+        Self
+    }
+
+    #[inline]
+    fn is_allowed(target: &str) -> bool {
+        target.starts_with(OTEL_SPAN_TARGET)
+    }
+}
+
+impl<S> Filter<S> for CustomOtelFilter
+where
+    S: Subscriber,
+{
+    #[inline]
+    fn enabled(&self, meta: &Metadata<'_>, _cx: &Context<'_, S>) -> bool {
+        Self::is_allowed(meta.target())
+    }
+
+    #[inline]
+    fn callsite_enabled(&self, meta: &'static Metadata<'static>) -> tracing::subscriber::Interest {
+        if Self::is_allowed(meta.target()) {
+            tracing::subscriber::Interest::always()
+        } else {
+            tracing::subscriber::Interest::never()
+        }
+    }
+}
+
+pub fn otel_tracing_init(enable: bool, otlp_endpoint: Option<&str>) -> Result<()> {
+    if !enable {
+        ENABLED.store(false, Ordering::Release);
+        return Ok(());
+    }
+
+    let endpoint = otlp_endpoint.unwrap_or("localhost:4317");
+    let endpoint = if !endpoint.starts_with("http://") && !endpoint.starts_with("https://") {
+        format!("http://{endpoint}")
+    } else {
+        endpoint.to_string()
+    };
+
+    global::set_text_map_propagator(TraceContextPropagator::new());
+
+    let exporter = opentelemetry_otlp::SpanExporter::builder()
+        .with_tonic()
+        .with_endpoint(&endpoint)
+        .with_protocol(opentelemetry_otlp::Protocol::Grpc)
+        .build()
+        .map_err(|e| {
+            eprintln!("[tracing] Failed to create OTLP exporter: {e}");
+            anyhow::anyhow!("Failed to create OTLP exporter: {e}")
+        })?;
+
+    let batch_config = BatchConfigBuilder::default()
+        .with_scheduled_delay(Duration::from_millis(500))
+        .with_max_export_batch_size(64)
+        .build();
+
+    let span_processor = BatchSpanProcessor::builder(exporter, runtime::Tokio)
+        .with_batch_config(batch_config)
+        .build();
+
+    let resource = Resource::default().merge(&Resource::new(vec![KeyValue::new(
+        "service.name",
+        "vllm-router",
+    )]));
+
+    let provider = TracerProvider::builder()
+        .with_span_processor(span_processor)
+        .with_resource(resource)
+        .build();
+
+    PROVIDER
+        .set(provider.clone())
+        .map_err(|_| anyhow::anyhow!("Provider already initialized"))?;
+
+    let tracer = provider.tracer("vllm-router");
+
+    TRACER
+        .set(tracer)
+        .map_err(|_| anyhow::anyhow!("Tracer already initialized"))?;
+
+    let _ = global::set_tracer_provider(provider);
+
+    ENABLED.store(true, Ordering::Release);
+
+    eprintln!("[tracing] OpenTelemetry initialized successfully");
+    Ok(())
+}
+
+/// Get the OpenTelemetry tracing layer. Must be called after `otel_tracing_init`.
+pub fn get_otel_layer<S>() -> Result<Box<dyn Layer<S> + Send + Sync + 'static>>
+where
+    S: Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a> + Send + Sync,
+{
+    if !is_otel_enabled() {
+        anyhow::bail!("OpenTelemetry is not enabled");
+    }
+
+    let tracer = TRACER
+        .get()
+        .ok_or_else(|| anyhow::anyhow!("Tracer not initialized. Call otel_tracing_init first."))?
+        .clone();
+
+    let layer = tracing_opentelemetry::layer()
+        .with_tracer(tracer)
+        .with_filter(CustomOtelFilter::new());
+
+    Ok(Box::new(layer))
+}
+
+/// Check if OpenTelemetry tracing is enabled.
+#[inline]
+pub fn is_otel_enabled() -> bool {
+    ENABLED.load(Ordering::Acquire)
+}
+
+pub async fn flush_spans_async() -> Result<()> {
+    if !is_otel_enabled() {
+        return Ok(());
+    }
+
+    let provider = PROVIDER
+        .get()
+        .ok_or_else(|| anyhow::anyhow!("Provider not initialized"))?
+        .clone();
+
+    spawn_blocking(move || provider.force_flush())
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to flush spans: {e}"))?;
+
+    Ok(())
+}
+
+pub fn shutdown_otel() {
+    if ENABLED.load(Ordering::Acquire) {
+        global::shutdown_tracer_provider();
+        ENABLED.store(false, Ordering::Release);
+        eprintln!("[tracing] OpenTelemetry shut down");
+    }
+}
+
+/// Inject W3C trace context headers into an HTTP request's HeaderMap.
+///
+/// When OTel is enabled, this injects the current span's trace context
+/// (traceparent, tracestate) into outgoing requests, making the router's
+/// span the parent of backend spans.
+///
+/// When OTel is disabled, this is a no-op.
+#[inline]
+pub fn inject_trace_context_http(headers: &mut HeaderMap) {
+    if !is_otel_enabled() {
+        return;
+    }
+
+    let context = tracing::Span::current().context();
+
+    struct HeaderInjector<'a>(&'a mut HeaderMap);
+
+    impl opentelemetry::propagation::Injector for HeaderInjector<'_> {
+        #[inline]
+        fn set(&mut self, key: &str, value: String) {
+            if let Ok(header_name) = HeaderName::from_bytes(key.as_bytes()) {
+                if let Ok(header_value) = HeaderValue::from_str(&value) {
+                    self.0.insert(header_name, header_value);
+                }
+            }
+        }
+    }
+
+    global::get_text_map_propagator(|propagator| {
+        propagator.inject_context(&context, &mut HeaderInjector(headers));
+    });
+}

--- a/src/routers/header_utils.rs
+++ b/src/routers/header_utils.rs
@@ -57,13 +57,27 @@ pub const TRACE_HEADER_NAMES: &[&str] = &["traceparent", "tracestate", "baggage"
 
 /// Propagate OpenTelemetry trace headers to a reqwest RequestBuilder
 ///
-/// This enables distributed tracing across service boundaries by forwarding
-/// W3C Trace Context headers from incoming requests to outgoing backend requests.
+/// When OTel is enabled: actively injects the current span's trace context,
+/// making the router's span the parent of the backend request's span.
+/// When OTel is disabled: passively forwards existing trace headers from
+/// the incoming request.
 pub fn propagate_trace_headers(
     request: reqwest::RequestBuilder,
     headers: Option<&HeaderMap>,
 ) -> reqwest::RequestBuilder {
-    propagate_headers(request, headers, TRACE_HEADER_NAMES)
+    if crate::otel_trace::is_otel_enabled() {
+        // Active injection: use the current span's context
+        let mut trace_headers = HeaderMap::new();
+        crate::otel_trace::inject_trace_context_http(&mut trace_headers);
+        let mut req = request;
+        for (k, v) in trace_headers.iter() {
+            req = req.header(k, v);
+        }
+        req
+    } else {
+        // Passive forwarding: copy existing trace headers from incoming request
+        propagate_headers(request, headers, TRACE_HEADER_NAMES)
+    }
 }
 
 /// Propagate specific headers from incoming request to outgoing reqwest RequestBuilder

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,5 +1,6 @@
+use crate::otel_trace;
 use crate::{
-    config::{ConnectionMode, HistoryBackend, RouterConfig},
+    config::{ConnectionMode, HistoryBackend, RouterConfig, TraceConfig},
     core::{WorkerRegistry, WorkerType},
     data_connector::{MemoryResponseStorage, NoOpResponseStorage, SharedResponseStorage},
     logging::{self, LoggingConfig},
@@ -696,6 +697,7 @@ pub struct ServerConfig {
     pub prometheus_config: Option<PrometheusConfig>,
     pub request_timeout_secs: u64,
     pub request_id_headers: Option<Vec<String>>,
+    pub trace_config: Option<TraceConfig>,
 }
 
 /// Build the Axum application with all routes and middleware
@@ -784,6 +786,15 @@ pub async fn startup(config: ServerConfig) -> Result<(), Box<dyn std::error::Err
     // Only initialize logging if not already done (for Python bindings support)
     static LOGGING_INITIALIZED: AtomicBool = AtomicBool::new(false);
 
+    if let Some(trace_config) = &config.trace_config {
+        if let Err(e) = otel_trace::otel_tracing_init(
+            trace_config.enable_trace,
+            Some(&trace_config.otlp_traces_endpoint),
+        ) {
+            eprintln!("Failed to initialize OpenTelemetry: {e}");
+        }
+    }
+
     println!("DEBUG: Initializing logging");
     let _log_guard = if !LOGGING_INITIALIZED.swap(true, Ordering::SeqCst) {
         Some(logging::init_logging(LoggingConfig {
@@ -803,7 +814,7 @@ pub async fn startup(config: ServerConfig) -> Result<(), Box<dyn std::error::Err
             colorize: true,
             log_file_name: "vllm-router".to_string(),
             log_targets: None,
-        }))
+        }, config.trace_config.clone()))
     } else {
         None
     };


### PR DESCRIPTION
Add opt-in OTel tracing so the router emits its own spans in distributed trace waterfalls. When enabled via --enable-trace, the router's HTTP request span becomes visible between client and backend spans, and trace context is actively injected (not just passively forwarded) to establish proper parent-child span relationships.

Before                                                                                                                                                                                           
                                                            
  Client span ──────────────────────────────────>                                                                                                                                                  
                    (router is invisible)                                                                                                                                                          
           Backend span ────────────────────────>

  - Router passively forwards traceparent/tracestate headers from client to backend
  - No OTel spans emitted — router processing time is a blind spot in distributed traces
  - Trace context passes through but router never appears in the trace waterfall

After

  Client span ──────────────────────────────────>
    Router span ────────────────────────────────>
      Backend span ─────────────────────────────>

  - Router emits its own OTel span (http_request) with method, uri, status_code, latency, request_id
  - Active W3C TraceContext injection — router's span becomes the parent of backend spans
  - Opt-in via --enable-trace — zero overhead when disabled
  - Custom filter exports only tagged spans, no noise from internal tracing

New CLI flags:
  --enable-trace              Enable OpenTelemetry tracing
  --otlp-traces-endpoint      OTLP collector endpoint [default: localhost:4317]

Key changes:
- New src/otel_trace.rs module (init, filter, layer, context injection, shutdown)
- TraceConfig added to config types and ServerConfig
- OTel layer conditionally added to tracing subscriber in logging.rs
- Middleware http_request span tagged with OTel target for export filtering
- propagate_trace_headers() uses active context injection when OTel enabled
- Graceful OTel shutdown on process exit

<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
