### PR TITLE
Migrate /v1/chat/completions from typed struct to JSON pass-through

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ target
 
 .tokenizer_cache/*
 
+# VS Code
+.vscode/
+
 # RustRover
 #  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore

--- a/src/routers/grpc/pd_router.rs
+++ b/src/routers/grpc/pd_router.rs
@@ -264,7 +264,7 @@ impl RouterTrait for GrpcPDRouter {
     async fn route_chat(
         &self,
         _headers: Option<&HeaderMap>,
-        _body: &crate::protocols::spec::ChatCompletionRequest,
+        _body: &serde_json::Value,
         _model_id: Option<&str>,
     ) -> Response {
         (StatusCode::NOT_IMPLEMENTED).into_response()

--- a/src/routers/grpc/router.rs
+++ b/src/routers/grpc/router.rs
@@ -197,7 +197,7 @@ impl RouterTrait for GrpcRouter {
     async fn route_chat(
         &self,
         _headers: Option<&HeaderMap>,
-        _body: &crate::protocols::spec::ChatCompletionRequest,
+        _body: &serde_json::Value,
         _model_id: Option<&str>,
     ) -> Response {
         (StatusCode::NOT_IMPLEMENTED).into_response()

--- a/src/routers/http/openai_router.rs
+++ b/src/routers/http/openai_router.rs
@@ -2,9 +2,7 @@
 
 use crate::config::CircuitBreakerConfig;
 use crate::core::{CircuitBreaker, CircuitBreakerConfig as CoreCircuitBreakerConfig};
-use crate::protocols::spec::{
-    ChatCompletionRequest, CompletionRequest, GenerateRequest, RerankRequest,
-};
+use crate::protocols::spec::{CompletionRequest, GenerateRequest, RerankRequest};
 use async_trait::async_trait;
 use axum::{
     body::Body,
@@ -199,24 +197,20 @@ impl super::super::RouterTrait for OpenAIRouter {
     async fn route_chat(
         &self,
         headers: Option<&HeaderMap>,
-        body: &ChatCompletionRequest,
+        body: &serde_json::Value,
         _model_id: Option<&str>,
     ) -> Response {
         if !self.circuit_breaker.can_execute() {
             return (StatusCode::SERVICE_UNAVAILABLE, "Circuit breaker open").into_response();
         }
 
-        // Serialize request body, removing VLLM-only fields
-        let mut payload = match serde_json::to_value(body) {
-            Ok(v) => v,
-            Err(e) => {
-                return (
-                    StatusCode::BAD_REQUEST,
-                    format!("Failed to serialize request: {}", e),
-                )
-                    .into_response();
-            }
-        };
+        let is_stream = body
+            .get("stream")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+
+        // Clone and remove VLLM-only fields before sending to OpenAI backend
+        let mut payload = body.clone();
         if let Some(obj) = payload.as_object_mut() {
             for key in [
                 "top_k",
@@ -252,7 +246,7 @@ impl super::super::RouterTrait for OpenAIRouter {
         }
 
         // Accept SSE when stream=true
-        if body.stream {
+        if is_stream {
             req = req.header("Accept", "text/event-stream");
         }
 
@@ -271,7 +265,7 @@ impl super::super::RouterTrait for OpenAIRouter {
         let status = StatusCode::from_u16(resp.status().as_u16())
             .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
 
-        if !body.stream {
+        if !is_stream {
             // Capture Content-Type before consuming response body
             let content_type = resp.headers().get(CONTENT_TYPE).cloned();
             match resp.bytes().await {

--- a/src/routers/http/pd_router.rs
+++ b/src/routers/http/pd_router.rs
@@ -11,8 +11,7 @@ use crate::core::{
 use crate::metrics::RouterMetrics;
 use crate::policies::{LoadBalancingPolicy, PolicyRegistry};
 use crate::protocols::spec::{
-    ChatCompletionRequest, ChatMessage, CompletionRequest, GenerateRequest, RerankRequest,
-    ResponsesRequest, StringOrArray, UserMessageContent,
+    CompletionRequest, GenerateRequest, RerankRequest, ResponsesRequest, StringOrArray,
 };
 use crate::routers::header_utils;
 use crate::routers::{RouterTrait, WorkerManagement};
@@ -745,17 +744,6 @@ impl PDRouter {
             if text.contains("[") && text.contains("]") {
                 // This is a simplified check - in reality we'd need to parse JSON
                 return None; // For now, fall back to non-batch
-            }
-        }
-        None
-    }
-
-    // Helper to determine batch size from a ChatCompletionRequest
-    fn get_chat_batch_size(req: &ChatCompletionRequest) -> Option<usize> {
-        // Check 'n' parameter for multiple responses
-        if let Some(n) = req.n {
-            if n > 1 {
-                return Some(n as usize);
             }
         }
         None
@@ -2013,29 +2001,46 @@ impl RouterTrait for PDRouter {
     async fn route_chat(
         &self,
         headers: Option<&HeaderMap>,
-        body: &ChatCompletionRequest,
+        body: &serde_json::Value,
         model_id: Option<&str>,
     ) -> Response {
-        // Extract parameters
-        let is_stream = body.stream;
-        let return_logprob = body.logprobs;
+        // Extract parameters from JSON
+        let is_stream = body
+            .get("stream")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        let return_logprob = body
+            .get("logprobs")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
 
-        // Extract text for cache-aware routing
+        // Extract text for cache-aware routing from first message
         let request_text = if self.policies_need_request_text() {
-            body.messages.first().and_then(|msg| match msg {
-                ChatMessage::User { content, .. } => match content {
-                    UserMessageContent::Text(text) => Some(text.clone()),
-                    UserMessageContent::Parts(_) => None,
-                },
-                ChatMessage::System { content, .. } => Some(content.clone()),
-                _ => None,
-            })
+            body.get("messages")
+                .and_then(|msgs| msgs.as_array())
+                .and_then(|msgs| msgs.first())
+                .and_then(|msg| {
+                    let role = msg.get("role").and_then(|r| r.as_str()).unwrap_or("");
+                    match role {
+                        "user" | "system" => msg
+                            .get("content")
+                            .and_then(|c| c.as_str())
+                            .map(|s| s.to_string()),
+                        _ => None,
+                    }
+                })
         } else {
             None
         };
 
-        // Calculate batch size
-        let batch_size = Self::get_chat_batch_size(body);
+        // Calculate batch size from 'n' parameter
+        let batch_size = body.get("n").and_then(|v| v.as_u64()).and_then(|n| {
+            if n > 1 {
+                Some(n as usize)
+            } else {
+                None
+            }
+        });
 
         // Create context
         let context = PDRequestContext {

--- a/src/routers/http/router.rs
+++ b/src/routers/http/router.rs
@@ -6,8 +6,8 @@ use crate::core::{
 use crate::metrics::RouterMetrics;
 use crate::policies::{LoadBalancingPolicy, PolicyRegistry};
 use crate::protocols::spec::{
-    ChatCompletionRequest, CompletionRequest, EmbeddingRequest, GenerateRequest, GenerationRequest,
-    RerankRequest, RerankResponse, RerankResult, ResponsesRequest,
+    CompletionRequest, EmbeddingRequest, GenerateRequest, GenerationRequest, RerankRequest,
+    RerankResponse, RerankResult, ResponsesRequest,
 };
 use crate::routers::header_utils;
 use crate::routers::http::dp_utils;
@@ -586,6 +586,114 @@ impl Router {
 
                 // For retryable failures, we need to decrement load since send_typed_request
                 // won't have done it (it only decrements on success or non-retryable failures)
+                if is_retryable_status(response.status()) && load_incremented {
+                    if let Some(cleanup_worker) = worker_for_cleanup {
+                        cleanup_worker.decrement_load();
+                        RouterMetrics::set_running_requests(
+                            cleanup_worker.url(),
+                            cleanup_worker.load(),
+                        );
+                    }
+                }
+
+                response
+            },
+            // should_retry predicate
+            |res, _attempt| is_retryable_status(res.status()),
+            // on_backoff hook
+            |delay, attempt| {
+                RouterMetrics::record_retry(route);
+                RouterMetrics::record_retry_backoff_duration(delay, attempt);
+            },
+            // on_exhausted hook
+            || RouterMetrics::record_retries_exhausted(route),
+        )
+        .await;
+
+        if response.status().is_success() {
+            let duration = start.elapsed();
+            RouterMetrics::record_request(route);
+            RouterMetrics::record_generate_duration(duration);
+        } else if !is_retryable_status(response.status()) {
+            RouterMetrics::record_request_error(route, "non_retryable_error");
+        }
+
+        response
+    }
+
+    /// Route a request using a raw JSON Value instead of a typed struct.
+    /// This preserves all unknown fields through the proxy (no struct round-trip).
+    /// Provides the same features as route_typed_request: retry, circuit breaker,
+    /// load tracking, metrics, and streaming SSE handling.
+    pub async fn route_value_request(
+        &self,
+        headers: Option<&HeaderMap>,
+        body: &serde_json::Value,
+        route: &str,
+        model_id: Option<&str>,
+    ) -> Response {
+        let start = Instant::now();
+        let is_stream = body
+            .get("stream")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        let text = body
+            .get("session_params")
+            .and_then(|sp| sp.get("session_id"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+
+        let response = RetryExecutor::execute_response_with_retry(
+            &self.retry_config,
+            // operation per attempt
+            |_: u32| async {
+                let worker = match self.select_worker_for_model(model_id, Some(&text), headers) {
+                    Some(w) => w,
+                    None => {
+                        RouterMetrics::record_request_error(route, "no_available_workers");
+                        return (
+                            StatusCode::SERVICE_UNAVAILABLE,
+                            "No available workers (all circuits open or unhealthy)",
+                        )
+                            .into_response();
+                    }
+                };
+
+                // Optional load tracking for cache-aware policy
+                let policy = match model_id {
+                    Some(model) => self.policy_registry.get_policy_or_default(model),
+                    None => self.policy_registry.get_default_policy(),
+                };
+
+                let load_incremented = if policy.name() == "cache_aware" {
+                    worker.increment_load();
+                    RouterMetrics::set_running_requests(worker.url(), worker.load());
+                    true
+                } else {
+                    false
+                };
+
+                let worker_for_cleanup = if load_incremented {
+                    Some(worker.clone())
+                } else {
+                    None
+                };
+
+                let response = self
+                    .send_typed_request(
+                        headers,
+                        body,
+                        route,
+                        worker.url(),
+                        is_stream,
+                        load_incremented,
+                    )
+                    .await;
+
+                let status = response.status();
+                worker.record_outcome(status.is_success() || status.is_client_error());
+
                 if is_retryable_status(response.status()) && load_incremented {
                     if let Some(cleanup_worker) = worker_for_cleanup {
                         cleanup_worker.decrement_load();
@@ -1399,10 +1507,10 @@ impl RouterTrait for Router {
     async fn route_chat(
         &self,
         headers: Option<&HeaderMap>,
-        body: &ChatCompletionRequest,
+        body: &serde_json::Value,
         model_id: Option<&str>,
     ) -> Response {
-        self.route_typed_request(headers, body, "/v1/chat/completions", model_id)
+        self.route_value_request(headers, body, "/v1/chat/completions", model_id)
             .await
     }
 

--- a/src/routers/http/vllm_pd_router.rs
+++ b/src/routers/http/vllm_pd_router.rs
@@ -1172,7 +1172,7 @@ impl RouterTrait for VllmPDRouter {
     async fn route_chat(
         &self,
         headers: Option<&HeaderMap>,
-        body: &crate::protocols::spec::ChatCompletionRequest,
+        body: &serde_json::Value,
         _model_id: Option<&str>,
     ) -> Response {
         info!(
@@ -1184,23 +1184,11 @@ impl RouterTrait for VllmPDRouter {
             // Discovery mode - use vLLM-specific two-stage processing
             info!("Using service discovery mode, processing vLLM two-stage request");
 
-            // Convert to generic request and use vLLM processing
-            let request_json = match serde_json::to_value(body) {
-                Ok(json) => {
-                    debug!(
-                        "Serialized chat request: {}",
-                        serde_json::to_string_pretty(&json).unwrap_or_default()
-                    );
-                    json
-                }
-                Err(e) => {
-                    return (
-                        axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                        format!("Serialization error: {}", e),
-                    )
-                        .into_response()
-                }
-            };
+            let request_json = body.clone();
+            debug!(
+                "Chat request: {}",
+                serde_json::to_string_pretty(&request_json).unwrap_or_default()
+            );
 
             // Process vLLM two-stage request with service discovery
             self.process_vllm_request(request_json, "/v1/chat/completions", headers)
@@ -1209,23 +1197,11 @@ impl RouterTrait for VllmPDRouter {
             // Direct URL mode - implement routing logic here (not delegating to PDRouter)
             info!("Using direct URL mode with VllmPDRouter's own routing logic");
 
-            // Convert request to JSON
-            let request_json = match serde_json::to_value(body) {
-                Ok(json) => {
-                    debug!(
-                        "Serialized chat request: {}",
-                        serde_json::to_string_pretty(&json).unwrap_or_default()
-                    );
-                    json
-                }
-                Err(e) => {
-                    return (
-                        axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                        format!("Serialization error: {}", e),
-                    )
-                        .into_response()
-                }
-            };
+            let request_json = body.clone();
+            debug!(
+                "Chat request: {}",
+                serde_json::to_string_pretty(&request_json).unwrap_or_default()
+            );
 
             // Get prefill and decode workers from worker_registry
             let prefill_workers = self.pd_router.worker_registry.get_prefill_workers();

--- a/src/routers/mod.rs
+++ b/src/routers/mod.rs
@@ -10,8 +10,7 @@ use axum::{
 use std::fmt::Debug;
 
 use crate::protocols::spec::{
-    ChatCompletionRequest, CompletionRequest, EmbeddingRequest, GenerateRequest, RerankRequest,
-    ResponsesRequest,
+    CompletionRequest, EmbeddingRequest, GenerateRequest, RerankRequest, ResponsesRequest,
 };
 
 pub mod factory;
@@ -72,11 +71,11 @@ pub trait RouterTrait: Send + Sync + Debug + WorkerManagement {
         model_id: Option<&str>,
     ) -> Response;
 
-    /// Route a chat completion request
+    /// Route a chat completion request (accepts raw JSON for transparent pass-through)
     async fn route_chat(
         &self,
         headers: Option<&HeaderMap>,
-        body: &ChatCompletionRequest,
+        body: &serde_json::Value,
         model_id: Option<&str>,
     ) -> Response;
 

--- a/src/routers/router_manager.rs
+++ b/src/routers/router_manager.rs
@@ -7,8 +7,7 @@
 use crate::config::RouterConfig;
 use crate::core::{CircuitBreakerConfig, Worker, WorkerFactory, WorkerRegistry, WorkerType};
 use crate::protocols::spec::{
-    ChatCompletionRequest, CompletionRequest, EmbeddingRequest, GenerateRequest, RerankRequest,
-    ResponsesRequest,
+    CompletionRequest, EmbeddingRequest, GenerateRequest, RerankRequest, ResponsesRequest,
 };
 use crate::protocols::worker_spec::{
     ServerInfo, WorkerApiResponse, WorkerConfigRequest, WorkerErrorResponse, WorkerInfo,
@@ -589,14 +588,14 @@ impl RouterTrait for RouterManager {
     async fn route_chat(
         &self,
         headers: Option<&HeaderMap>,
-        body: &ChatCompletionRequest,
+        body: &serde_json::Value,
         _model_id: Option<&str>,
     ) -> Response {
         // Select router based on headers and model.
         // When model is None, select_router_for_request considers all registered
         // routers (including PD routers), so a single-model deployment will still
         // route correctly even without the model field.
-        let model_id = body.model.as_deref();
+        let model_id = body.get("model").and_then(|v| v.as_str());
         let router = self.select_router_for_request(headers, model_id);
 
         if let Some(router) = router {

--- a/src/server.rs
+++ b/src/server.rs
@@ -8,8 +8,7 @@ use crate::{
     policies::PolicyRegistry,
     protocols::{
         spec::{
-            ChatCompletionRequest, CompletionRequest, EmbeddingRequest, GenerateRequest,
-            RerankRequest, V1RerankReqInput,
+            CompletionRequest, EmbeddingRequest, GenerateRequest, RerankRequest, V1RerankReqInput,
         },
         worker_spec::{WorkerApiResponse, WorkerConfigRequest, WorkerErrorResponse},
     },
@@ -255,13 +254,17 @@ async fn generate(
 async fn v1_chat_completions(
     State(state): State<Arc<AppState>>,
     headers: http::HeaderMap,
-    Json(body): Json<ChatCompletionRequest>,
+    Json(body): Json<serde_json::Value>,
 ) -> Response {
     if let Err(response) = authorize_request(&state, &headers).await {
         return response;
     }
 
-    state.router.route_chat(Some(&headers), &body, None).await
+    let model_id = body.get("model").and_then(|v| v.as_str());
+    state
+        .router
+        .route_chat(Some(&headers), &body, model_id)
+        .await
 }
 
 async fn v1_completions(

--- a/tests/common/mock_worker.rs
+++ b/tests/common/mock_worker.rs
@@ -148,8 +148,12 @@ impl Drop for MockWorker {
 
 // Handler implementations
 
-/// Check if request should fail based on configured fail_rate
+/// Check if request should fail based on configured fail_rate or deterministic failure schedule
 async fn should_fail(config: &MockWorkerConfig) -> bool {
+    // Check deterministic failure schedule first (set via set_deterministic_failures)
+    if let Some(should) = check_deterministic_failure(config.port) {
+        return should;
+    }
     rand::random::<f32>() < config.fail_rate
 }
 
@@ -404,8 +408,13 @@ async fn chat_completions_handler(
 ) -> Response {
     let config = config.read().await;
 
-    // Capture request for test inspection
-    capture_request(config.port, "/v1/chat/completions", &headers);
+    // Capture request with body for test inspection
+    capture_request_with_body(
+        config.port,
+        "/v1/chat/completions",
+        &headers,
+        Some(payload.clone()),
+    );
 
     if should_fail(&config).await {
         return (
@@ -886,11 +895,12 @@ impl Default for MockWorkerConfig {
 
 // --- Request header capture for verifying router behavior (e.g., X-data-parallel-rank) ---
 
-/// A captured request with headers and path
+/// A captured request with headers, path, and optionally the request body
 #[derive(Debug, Clone)]
 pub struct CapturedRequest {
     pub path: String,
     pub headers: HashMap<String, String>,
+    pub body: Option<serde_json::Value>,
 }
 
 static REQ_CAPTURE_STORE: OnceLock<Mutex<HashMap<u16, Vec<CapturedRequest>>>> = OnceLock::new();
@@ -899,8 +909,18 @@ fn get_capture_store() -> &'static Mutex<HashMap<u16, Vec<CapturedRequest>>> {
     REQ_CAPTURE_STORE.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
-/// Record a request for a given worker port
+/// Record a request for a given worker port (without body)
 pub fn capture_request(port: u16, path: &str, headers: &axum::http::HeaderMap) {
+    capture_request_with_body(port, path, headers, None);
+}
+
+/// Record a request for a given worker port (with optional body)
+pub fn capture_request_with_body(
+    port: u16,
+    path: &str,
+    headers: &axum::http::HeaderMap,
+    body: Option<serde_json::Value>,
+) {
     let captured = CapturedRequest {
         path: path.to_string(),
         headers: headers
@@ -912,6 +932,7 @@ pub fn capture_request(port: u16, path: &str, headers: &axum::http::HeaderMap) {
                     .map(|v| (name.as_str().to_string(), v.to_string()))
             })
             .collect(),
+        body,
     };
     let mut store = get_capture_store().lock().unwrap();
     store.entry(port).or_default().push(captured);
@@ -927,4 +948,49 @@ pub fn get_captured_requests(port: u16) -> Vec<CapturedRequest> {
 pub fn clear_captured_requests(port: u16) {
     let mut store = get_capture_store().lock().unwrap();
     store.remove(&port);
+}
+
+// --- Deterministic failure scheduling ---
+
+struct DeterministicFailureState {
+    fail_on_requests: Vec<usize>,
+    counter: usize,
+}
+
+static DETERMINISTIC_FAILURE_STORE: OnceLock<Mutex<HashMap<u16, DeterministicFailureState>>> =
+    OnceLock::new();
+
+fn get_failure_store() -> &'static Mutex<HashMap<u16, DeterministicFailureState>> {
+    DETERMINISTIC_FAILURE_STORE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Set deterministic failure schedule for a worker port.
+/// `fail_on_requests` is a list of 1-indexed request numbers that should fail.
+pub fn set_deterministic_failures(port: u16, fail_on_requests: Vec<usize>) {
+    let mut store = get_failure_store().lock().unwrap();
+    store.insert(
+        port,
+        DeterministicFailureState {
+            fail_on_requests,
+            counter: 0,
+        },
+    );
+}
+
+/// Clear deterministic failure schedule for a worker port.
+pub fn clear_deterministic_failures(port: u16) {
+    let mut store = get_failure_store().lock().unwrap();
+    store.remove(&port);
+}
+
+/// Check if the current request should fail deterministically.
+/// Returns None if no schedule is set for this port.
+fn check_deterministic_failure(port: u16) -> Option<bool> {
+    let mut store = get_failure_store().lock().unwrap();
+    if let Some(state) = store.get_mut(&port) {
+        state.counter += 1;
+        Some(state.fail_on_requests.contains(&state.counter))
+    } else {
+        None
+    }
 }

--- a/tests/test_chat_completion_features.rs
+++ b/tests/test_chat_completion_features.rs
@@ -1,0 +1,704 @@
+/// Regression tests for chat completion routing features.
+/// These tests verify the features provided by route_typed_request for /v1/chat/completions:
+/// retry with worker re-selection, circuit breaker, model-specific routing, streaming SSE,
+/// header forwarding, and JSON field pass-through.
+mod common;
+
+use axum::{
+    body::Body,
+    extract::Request,
+    http::{header::CONTENT_TYPE, StatusCode},
+};
+use common::mock_worker::{
+    clear_captured_requests, clear_deterministic_failures, get_captured_requests,
+    set_deterministic_failures, HealthStatus, MockWorker, MockWorkerConfig, WorkerType,
+};
+use reqwest::Client;
+use serde_json::json;
+use std::sync::Arc;
+use tower::ServiceExt;
+use vllm_router_rs::config::{
+    CircuitBreakerConfig, ConnectionMode, PolicyConfig, RetryConfig, RouterConfig, RoutingMode,
+};
+use vllm_router_rs::routers::{RouterFactory, RouterTrait};
+
+/// Test context that manages mock workers and provides helper methods
+struct TestContext {
+    workers: Vec<MockWorker>,
+    router: Arc<dyn RouterTrait>,
+    client: Client,
+    config: RouterConfig,
+    ports: Vec<u16>,
+}
+
+impl TestContext {
+    async fn new_with_config(
+        mut config: RouterConfig,
+        worker_configs: Vec<MockWorkerConfig>,
+    ) -> Self {
+        let mut workers = Vec::new();
+        let mut worker_urls = Vec::new();
+        let mut ports = Vec::new();
+
+        for worker_config in worker_configs {
+            let port = worker_config.port;
+            ports.push(port);
+            let mut worker = MockWorker::new(worker_config);
+            let url = worker.start().await.unwrap();
+            worker_urls.push(url);
+            workers.push(worker);
+        }
+
+        if !workers.is_empty() {
+            tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
+        }
+
+        if let RoutingMode::Regular {
+            worker_urls: ref mut urls,
+        } = config.mode
+        {
+            if urls.is_empty() {
+                *urls = worker_urls.clone();
+            }
+        }
+
+        let client = Client::builder()
+            .timeout(std::time::Duration::from_secs(config.request_timeout_secs))
+            .build()
+            .unwrap();
+
+        let app_context = common::create_test_context(config.clone());
+        let router = RouterFactory::create_router(&app_context).await.unwrap();
+        let router = Arc::from(router);
+
+        if !workers.is_empty() {
+            tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+        }
+
+        Self {
+            workers,
+            router,
+            client,
+            config,
+            ports,
+        }
+    }
+
+    async fn create_app(&self) -> axum::Router {
+        common::test_app::create_test_app(
+            Arc::clone(&self.router),
+            self.client.clone(),
+            &self.config,
+        )
+    }
+
+    async fn shutdown(mut self) {
+        for worker in &mut self.workers {
+            worker.stop().await;
+        }
+        for port in &self.ports {
+            clear_captured_requests(*port);
+            clear_deterministic_failures(*port);
+        }
+    }
+}
+
+fn default_config() -> RouterConfig {
+    RouterConfig {
+        mode: RoutingMode::Regular {
+            worker_urls: vec![],
+        },
+        policy: PolicyConfig::RoundRobin,
+        host: "127.0.0.1".to_string(),
+        port: 3010,
+        max_payload_size: 256 * 1024 * 1024,
+        request_timeout_secs: 30,
+        worker_startup_timeout_secs: 10,
+        worker_startup_check_interval_secs: 1,
+        discovery: None,
+        intra_node_data_parallel_size: 1,
+        api_key: None,
+        api_key_validation_urls: vec![],
+        metrics: None,
+        log_dir: None,
+        log_level: None,
+        request_id_headers: None,
+        max_concurrent_requests: 64,
+        queue_size: 0,
+        queue_timeout_secs: 60,
+        rate_limit_tokens_per_second: None,
+        cors_allowed_origins: vec![],
+        retry: RetryConfig::default(),
+        circuit_breaker: CircuitBreakerConfig::default(),
+        disable_retries: false,
+        disable_circuit_breaker: false,
+        health_check: vllm_router_rs::config::HealthCheckConfig::default(),
+        enable_igw: false,
+        connection_mode: ConnectionMode::Http,
+        model_path: None,
+        tokenizer_path: None,
+        history_backend: vllm_router_rs::config::HistoryBackend::Memory,
+        enable_profiling: false,
+        profile_timeout_secs: 30,
+    }
+}
+
+fn chat_payload() -> serde_json::Value {
+    json!({
+        "messages": [{"role": "user", "content": "Hello!"}],
+        "stream": false
+    })
+}
+
+fn make_chat_request(payload: &serde_json::Value) -> Request<Body> {
+    Request::builder()
+        .method("POST")
+        .uri("/v1/chat/completions")
+        .header(CONTENT_TYPE, "application/json")
+        .body(Body::from(serde_json::to_string(payload).unwrap()))
+        .unwrap()
+}
+
+// =============================================================================
+// Test 1: Retry selects a different worker on failure
+// =============================================================================
+
+#[tokio::test]
+async fn test_retry_selects_different_worker_on_failure() {
+    let port1 = 21001;
+    let port2 = 21002;
+
+    // Both workers fail their first request so that regardless of which worker
+    // round-robin selects first, a retry is triggered.
+    set_deterministic_failures(port1, vec![1]);
+    set_deterministic_failures(port2, vec![1]);
+
+    let config = RouterConfig {
+        retry: RetryConfig {
+            max_retries: 3,
+            initial_backoff_ms: 10,
+            max_backoff_ms: 100,
+            backoff_multiplier: 2.0,
+            jitter_factor: 0.0,
+        },
+        ..default_config()
+    };
+
+    let ctx = TestContext::new_with_config(
+        config,
+        vec![
+            MockWorkerConfig {
+                port: port1,
+                worker_type: WorkerType::Regular,
+                health_status: HealthStatus::Healthy,
+                response_delay_ms: 0,
+                fail_rate: 0.0,
+            },
+            MockWorkerConfig {
+                port: port2,
+                worker_type: WorkerType::Regular,
+                health_status: HealthStatus::Healthy,
+                response_delay_ms: 0,
+                fail_rate: 0.0,
+            },
+        ],
+    )
+    .await;
+
+    let app = ctx.create_app().await;
+    let resp = app
+        .oneshot(make_chat_request(&chat_payload()))
+        .await
+        .unwrap();
+
+    // The request should succeed after retry (first attempt fails, second succeeds)
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    // Verify that a retry occurred: total requests across both workers should be >= 2
+    let reqs1 = get_captured_requests(port1);
+    let reqs2 = get_captured_requests(port2);
+    let total = reqs1.len() + reqs2.len();
+    assert!(
+        total >= 2,
+        "Expected at least 2 total requests (1 failure + 1 retry success), got {}",
+        total
+    );
+
+    ctx.shutdown().await;
+}
+
+// =============================================================================
+// Test 2: Circuit breaker opens after repeated failures
+// =============================================================================
+
+#[tokio::test]
+async fn test_circuit_breaker_opens_after_repeated_failures() {
+    let port1 = 21003;
+    let port2 = 21004;
+
+    let config = RouterConfig {
+        circuit_breaker: CircuitBreakerConfig {
+            failure_threshold: 2,
+            success_threshold: 1,
+            timeout_duration_secs: 60,
+            window_duration_secs: 120,
+        },
+        retry: RetryConfig {
+            max_retries: 0, // No retries - we want to see the circuit breaker in action
+            ..RetryConfig::default()
+        },
+        ..default_config()
+    };
+
+    let ctx = TestContext::new_with_config(
+        config,
+        vec![
+            MockWorkerConfig {
+                port: port1,
+                worker_type: WorkerType::Regular,
+                health_status: HealthStatus::Healthy,
+                response_delay_ms: 0,
+                fail_rate: 1.0, // Always fails
+            },
+            MockWorkerConfig {
+                port: port2,
+                worker_type: WorkerType::Regular,
+                health_status: HealthStatus::Healthy,
+                response_delay_ms: 0,
+                fail_rate: 0.0, // Always succeeds
+            },
+        ],
+    )
+    .await;
+
+    // Send enough requests to trip the circuit breaker on worker 1
+    // With failure_threshold=2, after 2 failures worker 1's circuit should open
+    for _ in 0..5 {
+        let app = ctx.create_app().await;
+        let _resp = app
+            .oneshot(make_chat_request(&chat_payload()))
+            .await
+            .unwrap();
+    }
+
+    // Clear capture and send more requests
+    clear_captured_requests(port1);
+    clear_captured_requests(port2);
+
+    // After circuit breaker opens, requests should mostly go to worker 2
+    for _ in 0..3 {
+        let app = ctx.create_app().await;
+        let resp = app
+            .oneshot(make_chat_request(&chat_payload()))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    let reqs2 = get_captured_requests(port2);
+    assert!(
+        reqs2.len() >= 2,
+        "Expected most requests to go to worker 2 after circuit breaker opened on worker 1, got {} requests to worker 2",
+        reqs2.len()
+    );
+
+    ctx.shutdown().await;
+}
+
+// =============================================================================
+// Test 3: Streaming response has SSE content type
+// =============================================================================
+
+#[tokio::test]
+async fn test_streaming_response_has_sse_content_type() {
+    let port = 21005;
+
+    let ctx = TestContext::new_with_config(
+        default_config(),
+        vec![MockWorkerConfig {
+            port,
+            worker_type: WorkerType::Regular,
+            health_status: HealthStatus::Healthy,
+            response_delay_ms: 0,
+            fail_rate: 0.0,
+        }],
+    )
+    .await;
+
+    let payload = json!({
+        "messages": [{"role": "user", "content": "Hello!"}],
+        "stream": true
+    });
+
+    let app = ctx.create_app().await;
+    let resp = app.oneshot(make_chat_request(&payload)).await.unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+    assert!(
+        content_type.contains("text/event-stream"),
+        "Expected text/event-stream content type for streaming, got: {}",
+        content_type
+    );
+
+    // Read the body and verify it contains SSE events
+    let body_bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let body_str = String::from_utf8_lossy(&body_bytes);
+    assert!(
+        body_str.contains("[DONE]"),
+        "Expected [DONE] in streaming response body"
+    );
+
+    ctx.shutdown().await;
+}
+
+// =============================================================================
+// Test 4: Header forwarding to backend
+// =============================================================================
+
+#[tokio::test]
+async fn test_header_forwarding_to_backend() {
+    let port = 21006;
+
+    let ctx = TestContext::new_with_config(
+        default_config(),
+        vec![MockWorkerConfig {
+            port,
+            worker_type: WorkerType::Regular,
+            health_status: HealthStatus::Healthy,
+            response_delay_ms: 0,
+            fail_rate: 0.0,
+        }],
+    )
+    .await;
+
+    let app = ctx.create_app().await;
+
+    let req = Request::builder()
+        .method("POST")
+        .uri("/v1/chat/completions")
+        .header(CONTENT_TYPE, "application/json")
+        .header("x-custom-header", "test-value-123")
+        .header("authorization", "Bearer test-token")
+        .body(Body::from(serde_json::to_string(&chat_payload()).unwrap()))
+        .unwrap();
+
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    // Check that the mock worker received our custom headers
+    let captured = get_captured_requests(port);
+    assert!(
+        !captured.is_empty(),
+        "Expected at least one captured request"
+    );
+
+    let req = &captured[0];
+    assert_eq!(
+        req.headers.get("x-custom-header").map(|s| s.as_str()),
+        Some("test-value-123"),
+        "Custom header should be forwarded to backend"
+    );
+    assert_eq!(
+        req.headers.get("authorization").map(|s| s.as_str()),
+        Some("Bearer test-token"),
+        "Authorization header should be forwarded to backend"
+    );
+
+    ctx.shutdown().await;
+}
+
+// =============================================================================
+// Test 5: Unknown JSON fields pass through to backend
+// This test validates the core value of the migration: fields the router
+// doesn't know about should arrive at the backend unchanged.
+// NOTE: This test will FAIL before the migration (typed struct strips unknown
+// fields) and PASS after (Value pass-through preserves them).
+// =============================================================================
+
+#[tokio::test]
+async fn test_unknown_fields_pass_through() {
+    let port = 21007;
+
+    let ctx = TestContext::new_with_config(
+        default_config(),
+        vec![MockWorkerConfig {
+            port,
+            worker_type: WorkerType::Regular,
+            health_status: HealthStatus::Healthy,
+            response_delay_ms: 0,
+            fail_rate: 0.0,
+        }],
+    )
+    .await;
+
+    let app = ctx.create_app().await;
+
+    // Send a chat request with extra fields that ChatCompletionRequest doesn't know about
+    let payload = json!({
+        "messages": [{"role": "user", "content": "Hello!"}],
+        "stream": false,
+        "reasoning": {"effort": "high"},
+        "custom_vllm_param": 42,
+        "future_field": "should_survive"
+    });
+
+    let resp = app.oneshot(make_chat_request(&payload)).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    // Check that the mock worker received the complete JSON including unknown fields
+    let captured = get_captured_requests(port);
+    assert!(
+        !captured.is_empty(),
+        "Expected at least one captured request"
+    );
+
+    let body = captured[0]
+        .body
+        .as_ref()
+        .expect("Expected captured request to have a body");
+
+    assert_eq!(
+        body.get("custom_vllm_param").and_then(|v| v.as_i64()),
+        Some(42),
+        "Unknown field 'custom_vllm_param' should be preserved in pass-through"
+    );
+    assert_eq!(
+        body.get("future_field").and_then(|v| v.as_str()),
+        Some("should_survive"),
+        "Unknown field 'future_field' should be preserved in pass-through"
+    );
+    assert!(
+        body.get("reasoning").is_some(),
+        "Unknown field 'reasoning' should be preserved in pass-through"
+    );
+
+    ctx.shutdown().await;
+}
+
+// =============================================================================
+// Test 6: Non-streaming chat completion returns valid response
+// =============================================================================
+
+#[tokio::test]
+async fn test_non_streaming_chat_completion_success() {
+    let port = 21008;
+
+    let ctx = TestContext::new_with_config(
+        default_config(),
+        vec![MockWorkerConfig {
+            port,
+            worker_type: WorkerType::Regular,
+            health_status: HealthStatus::Healthy,
+            response_delay_ms: 0,
+            fail_rate: 0.0,
+        }],
+    )
+    .await;
+
+    let app = ctx.create_app().await;
+    let resp = app
+        .oneshot(make_chat_request(&chat_payload()))
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let body_bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let body: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
+
+    assert_eq!(
+        body.get("object").and_then(|v| v.as_str()),
+        Some("chat.completion")
+    );
+    assert!(
+        body.get("choices").is_some(),
+        "Response should have choices"
+    );
+
+    ctx.shutdown().await;
+}
+
+// =============================================================================
+// Test 7: Request without model field routes successfully
+// =============================================================================
+
+#[tokio::test]
+async fn test_request_without_model_field_routes_successfully() {
+    let port = 21009;
+
+    let ctx = TestContext::new_with_config(
+        default_config(),
+        vec![MockWorkerConfig {
+            port,
+            worker_type: WorkerType::Regular,
+            health_status: HealthStatus::Healthy,
+            response_delay_ms: 0,
+            fail_rate: 0.0,
+        }],
+    )
+    .await;
+
+    // Send request WITHOUT a model field — should fall back to get_all() workers
+    let payload = json!({
+        "messages": [{"role": "user", "content": "Hello!"}],
+        "stream": false
+    });
+
+    let app = ctx.create_app().await;
+    let resp = app.oneshot(make_chat_request(&payload)).await.unwrap();
+
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "Request without model field should succeed by routing to any available worker"
+    );
+
+    ctx.shutdown().await;
+}
+
+// =============================================================================
+// Test 8: Request with unknown model returns 503
+// =============================================================================
+
+#[tokio::test]
+async fn test_request_with_unknown_model_returns_503() {
+    let port = 21010;
+
+    let ctx = TestContext::new_with_config(
+        default_config(),
+        vec![MockWorkerConfig {
+            port,
+            worker_type: WorkerType::Regular,
+            health_status: HealthStatus::Healthy,
+            response_delay_ms: 0,
+            fail_rate: 0.0,
+        }],
+    )
+    .await;
+
+    // Send request with a model name that no worker is registered for.
+    // Workers are registered with model_id=None, so get_by_model_fast("nonexistent")
+    // returns empty, and route_chat returns 503.
+    let payload = json!({
+        "model": "nonexistent-model",
+        "messages": [{"role": "user", "content": "Hello!"}],
+        "stream": false
+    });
+
+    let app = ctx.create_app().await;
+    let resp = app.oneshot(make_chat_request(&payload)).await.unwrap();
+
+    assert_eq!(
+        resp.status(),
+        StatusCode::SERVICE_UNAVAILABLE,
+        "Request with unknown model should return 503 (model-specific routing active in route_chat)"
+    );
+
+    ctx.shutdown().await;
+}
+
+// =============================================================================
+// Test 9: route_chat retries on failure, route_transparent does not
+// =============================================================================
+
+#[tokio::test]
+async fn test_route_chat_retries_on_failure_unlike_transparent() {
+    let port1 = 21011;
+    let port2 = 21012;
+
+    let config = RouterConfig {
+        retry: RetryConfig {
+            max_retries: 3,
+            initial_backoff_ms: 10,
+            max_backoff_ms: 100,
+            backoff_multiplier: 2.0,
+            jitter_factor: 0.0,
+        },
+        ..default_config()
+    };
+
+    let ctx = TestContext::new_with_config(
+        config,
+        vec![
+            MockWorkerConfig {
+                port: port1,
+                worker_type: WorkerType::Regular,
+                health_status: HealthStatus::Healthy,
+                response_delay_ms: 0,
+                fail_rate: 0.0,
+            },
+            MockWorkerConfig {
+                port: port2,
+                worker_type: WorkerType::Regular,
+                health_status: HealthStatus::Healthy,
+                response_delay_ms: 0,
+                fail_rate: 0.0,
+            },
+        ],
+    )
+    .await;
+
+    // Part 1: route_chat (/v1/chat/completions) SHOULD retry on failure
+    set_deterministic_failures(port1, vec![1]);
+    set_deterministic_failures(port2, vec![1]);
+
+    let chat_payload = json!({
+        "messages": [{"role": "user", "content": "Hello!"}],
+        "stream": false
+    });
+
+    let app = ctx.create_app().await;
+    let chat_req = Request::builder()
+        .method("POST")
+        .uri("/v1/chat/completions")
+        .header(CONTENT_TYPE, "application/json")
+        .body(Body::from(serde_json::to_string(&chat_payload).unwrap()))
+        .unwrap();
+    let chat_resp = app.oneshot(chat_req).await.unwrap();
+
+    assert_eq!(
+        chat_resp.status(),
+        StatusCode::OK,
+        "route_chat should succeed via retry after initial failure"
+    );
+
+    // Part 2: route_transparent (/v1/responses) should NOT retry
+    clear_deterministic_failures(port1);
+    clear_deterministic_failures(port2);
+    set_deterministic_failures(port1, vec![1]);
+    set_deterministic_failures(port2, vec![1]);
+
+    let responses_payload = json!({
+        "model": "test",
+        "input": "Hello!"
+    });
+
+    let app = ctx.create_app().await;
+    let responses_req = Request::builder()
+        .method("POST")
+        .uri("/v1/responses")
+        .header(CONTENT_TYPE, "application/json")
+        .body(Body::from(
+            serde_json::to_string(&responses_payload).unwrap(),
+        ))
+        .unwrap();
+    let responses_resp = app.oneshot(responses_req).await.unwrap();
+
+    assert!(
+        responses_resp.status().is_server_error(),
+        "route_transparent should return server error (no retry): got {}",
+        responses_resp.status()
+    );
+
+    ctx.shutdown().await;
+}

--- a/tests/test_openai_routing.rs
+++ b/tests/test_openai_routing.rs
@@ -12,10 +12,7 @@ use std::sync::Arc;
 use tower::ServiceExt;
 use vllm_router_rs::{
     config::{RouterConfig, RoutingMode},
-    protocols::spec::{
-        ChatCompletionRequest, ChatMessage, CompletionRequest, GenerateRequest, PromptInput,
-        UserMessageContent,
-    },
+    protocols::spec::{CompletionRequest, GenerateRequest, PromptInput},
     routers::{openai_router::OpenAIRouter, RouterTrait},
 };
 
@@ -23,15 +20,14 @@ mod common;
 use common::mock_openai_server::MockOpenAIServer;
 
 /// Helper function to create a minimal chat completion request for testing
-fn create_minimal_chat_request() -> ChatCompletionRequest {
-    let val = json!({
+fn create_minimal_chat_request() -> serde_json::Value {
+    json!({
         "model": "gpt-3.5-turbo",
         "messages": [
             {"role": "user", "content": "Hello"}
         ],
         "max_tokens": 100
-    });
-    serde_json::from_value(val).unwrap()
+    })
 }
 
 /// Helper function to create a minimal completion request for testing
@@ -221,14 +217,15 @@ async fn test_openai_router_chat_completion_with_mock() {
     // Create router pointing to mock server
     let router = OpenAIRouter::new(base_url, None).await.unwrap();
 
-    // Create a minimal chat completion request
-    let mut chat_request = create_minimal_chat_request();
-    chat_request.messages = vec![ChatMessage::User {
-        role: "user".to_string(),
-        content: UserMessageContent::Text("Hello, how are you?".to_string()),
-        name: None,
-    }];
-    chat_request.temperature = Some(0.7);
+    // Create a chat completion request as JSON Value
+    let chat_request = json!({
+        "model": "gpt-3.5-turbo",
+        "messages": [
+            {"role": "user", "content": "Hello, how are you?"}
+        ],
+        "max_tokens": 100,
+        "temperature": 0.7
+    });
 
     // Route the request
     let response = router.route_chat(None, &chat_request, None).await;
@@ -267,10 +264,9 @@ async fn test_openai_e2e_with_server() {
                 async move {
                     let (parts, body) = req.into_parts();
                     let body_bytes = axum::body::to_bytes(body, usize::MAX).await.unwrap();
-                    let body_str = String::from_utf8(body_bytes.to_vec()).unwrap();
 
-                    let chat_request: ChatCompletionRequest =
-                        serde_json::from_str(&body_str).unwrap();
+                    let chat_request: serde_json::Value =
+                        serde_json::from_slice(&body_bytes).unwrap();
 
                     router
                         .route_chat(Some(&parts.headers), &chat_request, None)
@@ -322,7 +318,7 @@ async fn test_openai_router_chat_streaming_with_mock() {
     let router = OpenAIRouter::new(base_url, None).await.unwrap();
 
     // Build a streaming chat request
-    let val = json!({
+    let chat_request = json!({
         "model": "gpt-3.5-turbo",
         "messages": [
             {"role": "user", "content": "Hello"}
@@ -330,7 +326,6 @@ async fn test_openai_router_chat_streaming_with_mock() {
         "max_tokens": 10,
         "stream": true
     });
-    let chat_request: ChatCompletionRequest = serde_json::from_value(val).unwrap();
 
     let response = router.route_chat(None, &chat_request, None).await;
     assert_eq!(response.status(), StatusCode::OK);
@@ -433,7 +428,7 @@ async fn test_openai_router_chat_with_reasoning_fields() {
     let router = OpenAIRouter::new(base_url, None).await.unwrap();
 
     // Create a chat request with all three new reasoning fields
-    let val = json!({
+    let chat_request = json!({
         "model": "gpt-3.5-turbo",
         "messages": [
             {"role": "user", "content": "What is 2+2?"}
@@ -443,15 +438,11 @@ async fn test_openai_router_chat_with_reasoning_fields() {
         "reasoning_effort": "low",
         "include_reasoning": false
     });
-    let chat_request: ChatCompletionRequest = serde_json::from_value(val).unwrap();
 
-    // Verify the fields are correctly deserialized
-    assert_eq!(chat_request.echo, Some(true));
-    assert!(!chat_request.include_reasoning);
-    assert!(matches!(
-        chat_request.reasoning_effort,
-        Some(vllm_router_rs::protocols::spec::ReasoningEffort::Low)
-    ));
+    // Verify the fields exist in the JSON
+    assert_eq!(chat_request["echo"], true);
+    assert_eq!(chat_request["include_reasoning"], false);
+    assert_eq!(chat_request["reasoning_effort"], "low");
 
     // Route the request to mock server
     let response = router.route_chat(None, &chat_request, None).await;

--- a/tests/test_vllm_pd_chat.rs
+++ b/tests/test_vllm_pd_chat.rs
@@ -1,0 +1,124 @@
+/// Tests for VllmPD Router's route_chat after JSON pass-through migration.
+/// The migration changed route_chat from serializing ChatCompletionRequest to
+/// directly using serde_json::Value (body.clone()), removing the serialize+error path.
+mod common;
+
+use axum::http::StatusCode;
+use serde_json::json;
+use vllm_router_rs::config::{
+    ConnectionMode, PolicyConfig, RetryConfig, RouterConfig, RoutingMode,
+};
+use vllm_router_rs::routers::http::vllm_pd_router::VllmPDRouter;
+use vllm_router_rs::routers::RouterTrait;
+
+fn vllm_pd_config() -> RouterConfig {
+    RouterConfig {
+        mode: RoutingMode::VllmPrefillDecode {
+            prefill_urls: vec![],
+            decode_urls: vec![],
+            prefill_policy: None,
+            decode_policy: None,
+            discovery_address: None,
+        },
+        policy: PolicyConfig::RoundRobin,
+        host: "127.0.0.1".to_string(),
+        port: 3010,
+        max_payload_size: 256 * 1024 * 1024,
+        request_timeout_secs: 30,
+        worker_startup_timeout_secs: 10,
+        worker_startup_check_interval_secs: 1,
+        discovery: None,
+        intra_node_data_parallel_size: 1,
+        api_key: None,
+        api_key_validation_urls: vec![],
+        metrics: None,
+        log_dir: None,
+        log_level: None,
+        request_id_headers: None,
+        max_concurrent_requests: 64,
+        queue_size: 0,
+        queue_timeout_secs: 60,
+        rate_limit_tokens_per_second: None,
+        cors_allowed_origins: vec![],
+        retry: RetryConfig::default(),
+        circuit_breaker: vllm_router_rs::config::CircuitBreakerConfig::default(),
+        disable_retries: false,
+        disable_circuit_breaker: false,
+        health_check: vllm_router_rs::config::HealthCheckConfig::default(),
+        enable_igw: false,
+        connection_mode: ConnectionMode::Http,
+        model_path: None,
+        tokenizer_path: None,
+        history_backend: vllm_router_rs::config::HistoryBackend::Memory,
+        enable_profiling: false,
+        profile_timeout_secs: 30,
+    }
+}
+
+// =============================================================================
+// Test: VllmPD route_chat returns 503 when no workers are available
+// =============================================================================
+
+#[tokio::test]
+async fn test_vllm_pd_route_chat_returns_503_without_workers() {
+    let config = vllm_pd_config();
+    let app_context = common::create_test_context(config);
+
+    // Create VllmPDRouter in direct-URL mode with no workers
+    let router = VllmPDRouter::new(vec![], vec![], None, &app_context)
+        .await
+        .unwrap();
+
+    let body = json!({
+        "messages": [{"role": "user", "content": "Hello!"}],
+        "stream": false,
+        "reasoning": {"effort": "high"},
+        "custom_field": 42
+    });
+
+    let resp = router.route_chat(None, &body, None).await;
+
+    assert_eq!(
+        resp.status(),
+        StatusCode::SERVICE_UNAVAILABLE,
+        "VllmPD route_chat with no workers should return 503"
+    );
+}
+
+// =============================================================================
+// Test: VllmPD route_chat accepts JSON with extra fields without error
+// =============================================================================
+
+#[tokio::test]
+async fn test_vllm_pd_route_chat_accepts_arbitrary_json() {
+    let config = vllm_pd_config();
+    let app_context = common::create_test_context(config);
+
+    // Create VllmPDRouter in direct-URL mode with no workers
+    let router = VllmPDRouter::new(vec![], vec![], None, &app_context)
+        .await
+        .unwrap();
+
+    // Send JSON with fields that would have been rejected by ChatCompletionRequest deserialization.
+    // After the migration, route_chat accepts any valid JSON — it should reach the
+    // "no workers" check rather than failing on deserialization.
+    let body = json!({
+        "messages": [{"role": "user", "content": "Hello!"}],
+        "stream": false,
+        "unknown_future_field": "should not cause deserialization error",
+        "reasoning": {"effort": "high"},
+        "custom_vllm_param": 42,
+        "nested": {"deeply": {"nested": true}}
+    });
+
+    let resp = router.route_chat(None, &body, None).await;
+
+    // We expect 503 (no workers), NOT a deserialization error (400/500).
+    // This proves that arbitrary JSON passes through without being rejected.
+    assert_eq!(
+        resp.status(),
+        StatusCode::SERVICE_UNAVAILABLE,
+        "VllmPD route_chat should accept arbitrary JSON fields (got {} instead of 503)",
+        resp.status()
+    );
+}


### PR DESCRIPTION
## Purpose

  Migrate `/v1/chat/completions` from typed `ChatCompletionRequest` struct to JSON pass-through (`serde_json::Value`).                                                  
                                                                                                                                                                      
  The previous implementation deserialized the request body into a `ChatCompletionRequest` struct before forwarding it to backend workers. This caused requests with
  extra fields (e.g. `reasoning`, custom vLLM parameters) to fail with deserialization errors, even though the router doesn't need to interpret those fields — it just
  forwards them.

  This PR changes `route_chat` across all router types to accept `&serde_json::Value`, allowing arbitrary JSON to pass through unchanged. The `v1_chat_completions`
  handler now parses the body as raw JSON instead of a typed struct.

## Test Plan

  cargo test
  cargo fmt --check
  cargo clippy

  New test files:
  - tests/test_chat_completion_features.rs — 9 tests for Regular Router's route_chat: round-robin routing, streaming/non-streaming, header forwarding, JSON pass-through
   integrity, retry on failure, model-specific routing, and a regression test proving route_chat retries while route_transparent does not.
  - tests/test_vllm_pd_chat.rs — 2 tests for VllmPD Router: error path (503 with no workers) and arbitrary JSON acceptance.

## Test Result
All tests pass