### PR TITLE
Improve Prometheus HTTP status metrics and cache/discovery observability

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,8 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Only regenerate if the proto file changes
     println!("cargo:rerun-if-changed=src/proto/vllm_scheduler.proto");
+    println!("cargo:rerun-if-changed=src/proto/google/protobuf/timestamp.proto");
+    println!("cargo:rerun-if-changed=src/proto/google/protobuf/struct.proto");
 
     // Configure protobuf compilation with custom settings
     let config = tonic_prost_build::Config::new();
@@ -8,7 +10,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Skip serde for types that use prost_types::Struct
     // These cause conflicts and we don't need serde for all generated types
 
-    // Configure tonic-build for gRPC code generation
+    // Vendored well-known protos keep clean builds and clippy runs working
+    // even when the system protoc installation does not ship them.
     tonic_prost_build::configure()
         // Generate both client and server code
         .build_server(true)

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,3 +1,4 @@
+use http::StatusCode;
 use metrics::{counter, describe_counter, describe_gauge, describe_histogram, gauge, histogram};
 use metrics_exporter_prometheus::{Matcher, PrometheusBuilder};
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
@@ -18,19 +19,47 @@ impl Default for PrometheusConfig {
     }
 }
 
+const DURATION_BUCKETS: [f64; 20] = [
+    0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 15.0, 30.0, 45.0, 60.0,
+    90.0, 120.0, 180.0, 240.0,
+];
+
+const NO_STATUS_LABEL: &str = "none";
+
+fn status_code_label(status: StatusCode) -> String {
+    status.as_u16().to_string()
+}
+
+fn status_class_label(status: StatusCode) -> &'static str {
+    match status.as_u16() / 100 {
+        1 => "1xx",
+        2 => "2xx",
+        3 => "3xx",
+        4 => "4xx",
+        5 => "5xx",
+        _ => "other",
+    }
+}
+
+fn optional_status_labels(status: Option<StatusCode>) -> (String, &'static str) {
+    status
+        .map(|status| (status_code_label(status), status_class_label(status)))
+        .unwrap_or_else(|| (NO_STATUS_LABEL.to_string(), NO_STATUS_LABEL))
+}
+
 pub fn init_metrics() {
     // Request metrics
     describe_counter!(
         "vllm_router_requests_total",
-        "Total number of requests by route and method"
+        "Total number of HTTP responses by route, method, and status"
     );
     describe_histogram!(
         "vllm_router_request_duration_seconds",
-        "Request duration in seconds by route"
+        "HTTP request duration in seconds by route, method, and status class"
     );
     describe_counter!(
         "vllm_router_request_errors_total",
-        "Total number of request errors by route and error type"
+        "Total number of structured request errors by route, method, error type, and status"
     );
     describe_counter!(
         "vllm_router_retries_total",
@@ -95,27 +124,27 @@ pub fn init_metrics() {
     // PD-specific metrics
     describe_counter!(
         "vllm_router_pd_requests_total",
-        "Total PD requests by route"
+        "Total number of PD HTTP responses by route, method, and status"
     );
     describe_counter!(
         "vllm_router_pd_prefill_requests_total",
-        "Total prefill requests per worker"
+        "Total number of prefill-stage HTTP responses by worker and status"
     );
     describe_counter!(
         "vllm_router_pd_decode_requests_total",
-        "Total decode requests per worker"
+        "Total number of decode-stage HTTP responses by worker and status"
     );
     describe_counter!(
         "vllm_router_pd_errors_total",
-        "Total PD errors by error type"
+        "Total number of structured PD errors by route, method, error type, and status"
     );
     describe_counter!(
         "vllm_router_pd_prefill_errors_total",
-        "Total prefill server errors"
+        "Total number of structured prefill-stage errors by worker, error type, and status"
     );
     describe_counter!(
         "vllm_router_pd_decode_errors_total",
-        "Total decode server errors"
+        "Total number of structured decode-stage errors by worker, error type, and status"
     );
     describe_counter!(
         "vllm_router_pd_stream_errors_total",
@@ -123,7 +152,7 @@ pub fn init_metrics() {
     );
     describe_histogram!(
         "vllm_router_pd_request_duration_seconds",
-        "PD request duration by route"
+        "PD request duration in seconds by route, method, and status class"
     );
 
     // Service discovery metrics
@@ -154,7 +183,7 @@ pub fn init_metrics() {
     );
     describe_counter!(
         "vllm_router_embeddings_errors_total",
-        "Embedding request errors"
+        "Embedding request errors by HTTP status"
     );
     describe_gauge!("vllm_router_embeddings_queue_size", "Embedding queue size");
 
@@ -258,11 +287,6 @@ pub fn start_prometheus(config: PrometheusConfig) {
     init_metrics();
 
     let duration_matcher = Matcher::Suffix(String::from("duration_seconds"));
-    let duration_bucket = [
-        0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 15.0, 30.0, 45.0,
-        60.0, 90.0, 120.0, 180.0, 240.0,
-    ];
-
     let ip_addr: IpAddr = config
         .host
         .parse()
@@ -272,7 +296,7 @@ pub fn start_prometheus(config: PrometheusConfig) {
     PrometheusBuilder::new()
         .with_http_listener(socket_addr)
         .upkeep_timeout(Duration::from_secs(5 * 60))
-        .set_buckets_for_metric(duration_matcher, &duration_bucket)
+        .set_buckets_for_metric(duration_matcher, &DURATION_BUCKETS)
         .expect("failed to set duration bucket")
         .install()
         .expect("failed to install Prometheus metrics exporter");
@@ -284,24 +308,33 @@ pub struct TokenizerMetrics;
 
 impl RouterMetrics {
     // Request metrics
-    pub fn record_request(route: &str) {
+    pub fn observe_request(route: &str, method: &str, status: StatusCode, duration: Duration) {
+        let status_code = status_code_label(status);
+        let status_class = status_class_label(status);
         counter!("vllm_router_requests_total",
-            "route" => route.to_string()
+            "route" => route.to_string(),
+            "method" => method.to_string(),
+            "status_code" => status_code,
+            "status_class" => status_class.to_string()
         )
         .increment(1);
-    }
-
-    pub fn record_request_duration(route: &str, duration: Duration) {
         histogram!("vllm_router_request_duration_seconds",
-            "route" => route.to_string()
+            "route" => route.to_string(),
+            "method" => method.to_string(),
+            "status_class" => status_class.to_string()
         )
         .record(duration.as_secs_f64());
     }
 
-    pub fn record_request_error(route: &str, error_type: &str) {
+    pub fn record_request_error(route: &str, method: &str, status: StatusCode, error_type: &str) {
+        let status_code = status_code_label(status);
+        let status_class = status_class_label(status);
         counter!("vllm_router_request_errors_total",
             "route" => route.to_string(),
-            "error_type" => error_type.to_string()
+            "method" => method.to_string(),
+            "error_type" => error_type.to_string(),
+            "status_code" => status_code,
+            "status_class" => status_class.to_string()
         )
         .increment(1);
     }
@@ -387,51 +420,77 @@ impl RouterMetrics {
     }
 
     // PD-specific metrics
-    pub fn record_pd_request(route: &str) {
+    pub fn observe_pd_request(route: &str, method: &str, status: StatusCode, duration: Duration) {
+        let status_code = status_code_label(status);
+        let status_class = status_class_label(status);
         counter!("vllm_router_pd_requests_total",
-            "route" => route.to_string()
+            "route" => route.to_string(),
+            "method" => method.to_string(),
+            "status_code" => status_code,
+            "status_class" => status_class.to_string()
         )
         .increment(1);
-    }
-
-    pub fn record_pd_request_duration(route: &str, duration: Duration) {
         histogram!("vllm_router_pd_request_duration_seconds",
-            "route" => route.to_string()
+            "route" => route.to_string(),
+            "method" => method.to_string(),
+            "status_class" => status_class.to_string()
         )
         .record(duration.as_secs_f64());
     }
 
-    pub fn record_pd_prefill_request(worker: &str) {
+    pub fn record_pd_prefill_request(worker: &str, status: StatusCode) {
+        let status_code = status_code_label(status);
+        let status_class = status_class_label(status);
         counter!("vllm_router_pd_prefill_requests_total",
-            "worker" => worker.to_string()
+            "worker" => worker.to_string(),
+            "status_code" => status_code,
+            "status_class" => status_class.to_string()
         )
         .increment(1);
     }
 
-    pub fn record_pd_decode_request(worker: &str) {
+    pub fn record_pd_decode_request(worker: &str, status: StatusCode) {
+        let status_code = status_code_label(status);
+        let status_class = status_class_label(status);
         counter!("vllm_router_pd_decode_requests_total",
-            "worker" => worker.to_string()
+            "worker" => worker.to_string(),
+            "status_code" => status_code,
+            "status_class" => status_class.to_string()
         )
         .increment(1);
     }
 
-    pub fn record_pd_error(error_type: &str) {
+    pub fn record_pd_error(route: &str, method: &str, status: StatusCode, error_type: &str) {
+        let status_code = status_code_label(status);
+        let status_class = status_class_label(status);
         counter!("vllm_router_pd_errors_total",
-            "error_type" => error_type.to_string()
+            "route" => route.to_string(),
+            "method" => method.to_string(),
+            "error_type" => error_type.to_string(),
+            "status_code" => status_code,
+            "status_class" => status_class.to_string()
         )
         .increment(1);
     }
 
-    pub fn record_pd_prefill_error(worker: &str) {
+    pub fn record_pd_prefill_error(worker: &str, error_type: &str, status: Option<StatusCode>) {
+        let (status_code, status_class) = optional_status_labels(status);
         counter!("vllm_router_pd_prefill_errors_total",
-            "worker" => worker.to_string()
+            "worker" => worker.to_string(),
+            "error_type" => error_type.to_string(),
+            "status_code" => status_code,
+            "status_class" => status_class.to_string()
         )
         .increment(1);
     }
 
-    pub fn record_pd_decode_error(worker: &str) {
+    pub fn record_pd_decode_error(worker: &str, error_type: &str, status: Option<StatusCode>) {
+        let (status_code, status_class) = optional_status_labels(status);
         counter!("vllm_router_pd_decode_errors_total",
-            "worker" => worker.to_string()
+            "worker" => worker.to_string(),
+            "error_type" => error_type.to_string(),
+            "status_code" => status_code,
+            "status_class" => status_class.to_string()
         )
         .increment(1);
     }
@@ -464,10 +523,13 @@ impl RouterMetrics {
         histogram!("vllm_router_embeddings_duration_seconds").record(duration.as_secs_f64());
     }
 
-    pub fn record_embeddings_error(error_type: &str) {
+    pub fn record_embeddings_error(status: StatusCode) {
+        let status_code = status_code_label(status);
+        let status_class = status_class_label(status);
         counter!(
             "vllm_router_embeddings_errors_total",
-            "error_type" => error_type.to_string()
+            "status_code" => status_code,
+            "status_class" => status_class.to_string()
         )
         .increment(1);
     }
@@ -857,9 +919,18 @@ mod tests {
     #[test]
     fn test_metrics_static_methods() {
         // Test that all static methods can be called without panic
-        RouterMetrics::record_request("/generate");
-        RouterMetrics::record_request_duration("/generate", Duration::from_millis(100));
-        RouterMetrics::record_request_error("/generate", "timeout");
+        RouterMetrics::observe_request(
+            "/generate",
+            "POST",
+            StatusCode::OK,
+            Duration::from_millis(100),
+        );
+        RouterMetrics::record_request_error(
+            "/generate",
+            "POST",
+            StatusCode::REQUEST_TIMEOUT,
+            "timeout",
+        );
         RouterMetrics::record_retry("/generate");
 
         RouterMetrics::set_active_workers(5);
@@ -874,17 +945,31 @@ mod tests {
         RouterMetrics::record_load_balancing_event();
         RouterMetrics::set_load_range(20, 5);
 
-        RouterMetrics::record_pd_request("/v1/chat/completions");
-        RouterMetrics::record_pd_request_duration("/v1/chat/completions", Duration::from_secs(1));
-        RouterMetrics::record_pd_prefill_request("http://prefill1");
-        RouterMetrics::record_pd_decode_request("http://decode1");
-        RouterMetrics::record_pd_error("invalid_request");
-        RouterMetrics::record_pd_prefill_error("http://prefill1");
-        RouterMetrics::record_pd_decode_error("http://decode1");
+        RouterMetrics::observe_pd_request(
+            "/v1/chat/completions",
+            "POST",
+            StatusCode::BAD_GATEWAY,
+            Duration::from_secs(1),
+        );
+        RouterMetrics::record_pd_prefill_request("http://prefill1", StatusCode::OK);
+        RouterMetrics::record_pd_decode_request("http://decode1", StatusCode::BAD_GATEWAY);
+        RouterMetrics::record_pd_error(
+            "/v1/chat/completions",
+            "POST",
+            StatusCode::SERVICE_UNAVAILABLE,
+            "invalid_request",
+        );
+        RouterMetrics::record_pd_prefill_error("http://prefill1", "transport", None);
+        RouterMetrics::record_pd_decode_error(
+            "http://decode1",
+            "http_response",
+            Some(StatusCode::BAD_GATEWAY),
+        );
         RouterMetrics::record_pd_stream_error("http://decode1");
 
         RouterMetrics::record_discovery_update(3, 1);
         RouterMetrics::record_generate_duration(Duration::from_secs(2));
+        RouterMetrics::record_embeddings_error(StatusCode::TOO_MANY_REQUESTS);
         RouterMetrics::set_running_requests("http://worker1", 15);
     }
 
@@ -1002,7 +1087,7 @@ mod tests {
     #[test]
     fn test_empty_string_metrics() {
         // Test that empty strings don't cause issues
-        RouterMetrics::record_request("");
+        RouterMetrics::observe_request("", "GET", StatusCode::OK, Duration::from_millis(1));
         RouterMetrics::set_worker_health("", true);
         RouterMetrics::record_policy_decision("", "");
     }
@@ -1011,7 +1096,12 @@ mod tests {
     fn test_very_long_metric_labels() {
         let long_label = "a".repeat(1000);
 
-        RouterMetrics::record_request(&long_label);
+        RouterMetrics::observe_request(
+            &long_label,
+            "GET",
+            StatusCode::OK,
+            Duration::from_millis(1),
+        );
         RouterMetrics::set_worker_health(&long_label, false);
     }
 
@@ -1026,7 +1116,7 @@ mod tests {
         ];
 
         for label in special_labels {
-            RouterMetrics::record_request(label);
+            RouterMetrics::observe_request(label, "GET", StatusCode::OK, Duration::from_millis(1));
             RouterMetrics::set_worker_health(label, true);
         }
     }
@@ -1040,8 +1130,8 @@ mod tests {
         RouterMetrics::set_worker_load("worker", 0);
         RouterMetrics::set_worker_load("worker", usize::MAX);
 
-        RouterMetrics::record_request_duration("route", Duration::from_nanos(1));
+        RouterMetrics::observe_request("route", "GET", StatusCode::OK, Duration::from_nanos(1));
         // 24 hours
-        RouterMetrics::record_request_duration("route", Duration::from_secs(86400));
+        RouterMetrics::observe_request("route", "GET", StatusCode::OK, Duration::from_secs(86400));
     }
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -69,10 +69,19 @@ pub fn init_metrics() {
     // Request metrics
     describe_counter!(
         "vllm_router_requests_total",
-        "Total number of HTTP responses by route, method, and status"
+        "Total number of requests by route and method"
     );
     describe_histogram!(
         "vllm_router_request_duration_seconds",
+        "Request duration in seconds by route"
+    );
+    // HTTP middleware metrics (separate from legacy vllm_router_requests_total)
+    describe_counter!(
+        "vllm_router_http_requests_total",
+        "Total number of HTTP responses by route, method, and status"
+    );
+    describe_histogram!(
+        "vllm_router_http_request_duration_seconds",
         "HTTP request duration in seconds by route, method, and status class"
     );
     describe_counter!(
@@ -257,17 +266,17 @@ pub struct RouterMetrics;
 
 impl RouterMetrics {
     // Request metrics
-    pub fn observe_request(route: &str, method: &str, status: StatusCode, duration: Duration) {
+    pub fn observe_http_request(route: &str, method: &str, status: StatusCode, duration: Duration) {
         let status_code = status_code_label(status);
         let status_class = status_class_label(status);
-        counter!("vllm_router_requests_total",
+        counter!("vllm_router_http_requests_total",
             "route" => route.to_string(),
             "method" => method.to_string(),
             "status_code" => status_code,
             "status_class" => status_class.to_string()
         )
         .increment(1);
-        histogram!("vllm_router_request_duration_seconds",
+        histogram!("vllm_router_http_request_duration_seconds",
             "route" => route.to_string(),
             "method" => method.to_string(),
             "status_class" => status_class.to_string()
@@ -808,7 +817,7 @@ mod tests {
     #[test]
     fn test_metrics_static_methods() {
         // Test that all static methods can be called without panic
-        RouterMetrics::observe_request(
+        RouterMetrics::observe_http_request(
             "/generate",
             "POST",
             StatusCode::OK,
@@ -966,7 +975,7 @@ mod tests {
         let handle = recorder.handle();
 
         with_local_recorder(&recorder, || {
-            RouterMetrics::observe_request(
+            RouterMetrics::observe_http_request(
                 "/v1/chat/completions",
                 "POST",
                 StatusCode::TOO_MANY_REQUESTS,
@@ -998,7 +1007,7 @@ mod tests {
         let rendered = handle.render();
 
         assert!(rendered.lines().any(|line| {
-            line.starts_with("vllm_router_requests_total{")
+            line.starts_with("vllm_router_http_requests_total{")
                 && line.contains("route=\"/v1/chat/completions\"")
                 && line.contains("method=\"POST\"")
                 && line.contains("status_code=\"429\"")
@@ -1006,7 +1015,7 @@ mod tests {
                 && line.ends_with(" 1")
         }));
         assert!(rendered.lines().any(|line| {
-            line.starts_with("vllm_router_request_duration_seconds_count{")
+            line.starts_with("vllm_router_http_request_duration_seconds_count{")
                 && line.contains("route=\"/v1/chat/completions\"")
                 && line.contains("method=\"POST\"")
                 && line.contains("status_class=\"4xx\"")
@@ -1073,7 +1082,7 @@ mod tests {
 
         with_local_recorder(&recorder, || {
             RouterMetrics::set_active_workers(1);
-            RouterMetrics::observe_request(
+            RouterMetrics::observe_http_request(
                 "/generate",
                 "POST",
                 StatusCode::OK,
@@ -1161,7 +1170,7 @@ mod tests {
     #[test]
     fn test_empty_string_metrics() {
         // Test that empty strings don't cause issues
-        RouterMetrics::observe_request("", "GET", StatusCode::OK, Duration::from_millis(1));
+        RouterMetrics::observe_http_request("", "GET", StatusCode::OK, Duration::from_millis(1));
         RouterMetrics::set_worker_health("", true);
         RouterMetrics::record_policy_decision("", "");
     }
@@ -1170,7 +1179,7 @@ mod tests {
     fn test_very_long_metric_labels() {
         let long_label = "a".repeat(1000);
 
-        RouterMetrics::observe_request(
+        RouterMetrics::observe_http_request(
             &long_label,
             "GET",
             StatusCode::OK,
@@ -1190,7 +1199,7 @@ mod tests {
         ];
 
         for label in special_labels {
-            RouterMetrics::observe_request(label, "GET", StatusCode::OK, Duration::from_millis(1));
+            RouterMetrics::observe_http_request(label, "GET", StatusCode::OK, Duration::from_millis(1));
             RouterMetrics::set_worker_health(label, true);
         }
     }
@@ -1204,8 +1213,8 @@ mod tests {
         RouterMetrics::set_running_requests("worker", 0);
         RouterMetrics::set_running_requests("worker", usize::MAX);
 
-        RouterMetrics::observe_request("route", "GET", StatusCode::OK, Duration::from_nanos(1));
+        RouterMetrics::observe_http_request("route", "GET", StatusCode::OK, Duration::from_nanos(1));
         // 24 hours
-        RouterMetrics::observe_request("route", "GET", StatusCode::OK, Duration::from_secs(86400));
+        RouterMetrics::observe_http_request("route", "GET", StatusCode::OK, Duration::from_secs(86400));
     }
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -62,6 +62,22 @@ pub fn init_metrics() {
         "Total number of structured request errors by route, method, error type, and status"
     );
     describe_counter!(
+        "vllm_router_http_responses_total",
+        "Total number of client-visible HTTP responses by route, method, and status"
+    );
+    describe_histogram!(
+        "vllm_router_http_response_duration_seconds",
+        "Client-visible HTTP response duration in seconds by route, method, and status"
+    );
+    describe_counter!(
+        "vllm_router_backend_http_responses_total",
+        "Total number of downstream backend HTTP responses by route, worker, phase, method, and status"
+    );
+    describe_histogram!(
+        "vllm_router_backend_http_response_duration_seconds",
+        "Downstream backend HTTP response duration in seconds by route, worker, phase, method, and status"
+    );
+    describe_counter!(
         "vllm_router_retries_total",
         "Total number of request retries by route"
     );
@@ -237,6 +253,60 @@ impl RouterMetrics {
             "route" => route.to_string(),
             "method" => method.to_string(),
             "status_class" => status_class.to_string()
+        )
+        .record(duration.as_secs_f64());
+    }
+
+    pub fn observe_http_response(
+        route: &str,
+        method: &str,
+        status: StatusCode,
+        duration: Duration,
+    ) {
+        let status_code = status_code_label(status);
+        let status_class = status_class_label(status);
+        counter!("vllm_router_http_responses_total",
+            "route" => route.to_string(),
+            "http_request_method" => method.to_string(),
+            "http_response_status_code" => status_code.clone(),
+            "http_response_status_class" => status_class.to_string()
+        )
+        .increment(1);
+        histogram!("vllm_router_http_response_duration_seconds",
+            "route" => route.to_string(),
+            "http_request_method" => method.to_string(),
+            "http_response_status_code" => status_code,
+            "http_response_status_class" => status_class.to_string()
+        )
+        .record(duration.as_secs_f64());
+    }
+
+    pub fn observe_backend_http_response(
+        route: &str,
+        worker: &str,
+        request_phase: &str,
+        method: &str,
+        status: StatusCode,
+        duration: Duration,
+    ) {
+        let status_code = status_code_label(status);
+        let status_class = status_class_label(status);
+        counter!("vllm_router_backend_http_responses_total",
+            "route" => route.to_string(),
+            "worker" => worker.to_string(),
+            "vllm_request_phase" => request_phase.to_string(),
+            "http_request_method" => method.to_string(),
+            "http_response_status_code" => status_code.clone(),
+            "http_response_status_class" => status_class.to_string()
+        )
+        .increment(1);
+        histogram!("vllm_router_backend_http_response_duration_seconds",
+            "route" => route.to_string(),
+            "worker" => worker.to_string(),
+            "vllm_request_phase" => request_phase.to_string(),
+            "http_request_method" => method.to_string(),
+            "http_response_status_code" => status_code,
+            "http_response_status_class" => status_class.to_string()
         )
         .record(duration.as_secs_f64());
     }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -108,11 +108,17 @@ pub fn init_metrics() {
         "vllm_router_policy_decisions_total",
         "Total routing policy decisions by policy and worker"
     );
-    describe_counter!("vllm_router_cache_hits_total", "Total cache hits");
-    describe_counter!("vllm_router_cache_misses_total", "Total cache misses");
+    describe_counter!(
+        "vllm_router_cache_hits_total",
+        "Cache-aware routing decisions that reused a worker above the cache threshold"
+    );
+    describe_counter!(
+        "vllm_router_cache_misses_total",
+        "Cache-aware routing decisions that fell back to low-affinity worker selection"
+    );
     describe_gauge!(
         "vllm_router_tree_size",
-        "Current tree size for cache-aware routing"
+        "Tracked cache-aware tree size per worker in characters"
     );
     describe_counter!(
         "vllm_router_load_balancing_events_total",
@@ -158,15 +164,15 @@ pub fn init_metrics() {
     // Service discovery metrics
     describe_counter!(
         "vllm_router_discovery_updates_total",
-        "Total service discovery update events"
+        "Total successful service discovery change events"
     );
     describe_gauge!(
         "vllm_router_discovery_workers_added",
-        "Number of workers added in last discovery update"
+        "Workers added in the most recent successful service discovery change"
     );
     describe_gauge!(
         "vllm_router_discovery_workers_removed",
-        "Number of workers removed in last discovery update"
+        "Workers removed in the most recent successful service discovery change"
     );
 
     // Generate request specific metrics
@@ -1062,6 +1068,32 @@ mod tests {
                 && line.contains("status_code=\"429\"")
                 && line.contains("status_class=\"4xx\"")
         }));
+    }
+
+    #[test]
+    fn test_rendered_metrics_include_cache_and_discovery_metrics() {
+        let recorder = build_test_recorder();
+        let handle = recorder.handle();
+
+        with_local_recorder(&recorder, || {
+            RouterMetrics::record_cache_hit();
+            RouterMetrics::record_cache_miss();
+            RouterMetrics::set_tree_size("http://worker1", 12);
+            RouterMetrics::record_discovery_update(1, 0);
+        });
+
+        let rendered = handle.render();
+
+        assert!(rendered.contains("vllm_router_cache_hits_total 1"));
+        assert!(rendered.contains("vllm_router_cache_misses_total 1"));
+        assert!(rendered.lines().any(|line| {
+            line.starts_with("vllm_router_tree_size{")
+                && line.contains("worker=\"http://worker1\"")
+                && line.ends_with(" 12")
+        }));
+        assert!(rendered.contains("vllm_router_discovery_updates_total 1"));
+        assert!(rendered.contains("vllm_router_discovery_workers_added 1"));
+        assert!(rendered.contains("vllm_router_discovery_workers_removed 0"));
     }
 
     #[test]

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -691,7 +691,18 @@ impl TokenizerMetrics {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use metrics::with_local_recorder;
     use std::net::TcpListener;
+
+    fn build_test_recorder() -> metrics_exporter_prometheus::PrometheusRecorder {
+        PrometheusBuilder::new()
+            .set_buckets_for_metric(
+                Matcher::Suffix(String::from("duration_seconds")),
+                &DURATION_BUCKETS,
+            )
+            .expect("failed to configure buckets")
+            .build_recorder()
+    }
 
     // ============= PrometheusConfig Tests =============
 
@@ -971,6 +982,86 @@ mod tests {
         RouterMetrics::record_generate_duration(Duration::from_secs(2));
         RouterMetrics::record_embeddings_error(StatusCode::TOO_MANY_REQUESTS);
         RouterMetrics::set_running_requests("http://worker1", 15);
+    }
+
+    #[test]
+    fn test_rendered_metrics_include_structured_http_labels() {
+        let recorder = build_test_recorder();
+        let handle = recorder.handle();
+
+        with_local_recorder(&recorder, || {
+            RouterMetrics::observe_request(
+                "/v1/chat/completions",
+                "POST",
+                StatusCode::TOO_MANY_REQUESTS,
+                Duration::from_millis(25),
+            );
+            RouterMetrics::record_request_error(
+                "/v1/chat/completions",
+                "POST",
+                StatusCode::TOO_MANY_REQUESTS,
+                "non_retryable_error",
+            );
+            RouterMetrics::observe_pd_request(
+                "/v1/chat/completions",
+                "POST",
+                StatusCode::BAD_GATEWAY,
+                Duration::from_millis(50),
+            );
+            RouterMetrics::record_pd_prefill_request("http://prefill1", StatusCode::OK);
+            RouterMetrics::record_pd_prefill_error("http://prefill1", "transport", None);
+            RouterMetrics::record_pd_decode_request("http://decode1", StatusCode::BAD_GATEWAY);
+            RouterMetrics::record_pd_decode_error(
+                "http://decode1",
+                "http_response",
+                Some(StatusCode::BAD_GATEWAY),
+            );
+            RouterMetrics::record_embeddings_error(StatusCode::TOO_MANY_REQUESTS);
+        });
+
+        let rendered = handle.render();
+
+        assert!(rendered.lines().any(|line| {
+            line.starts_with("vllm_router_requests_total{")
+                && line.contains("route=\"/v1/chat/completions\"")
+                && line.contains("method=\"POST\"")
+                && line.contains("status_code=\"429\"")
+                && line.contains("status_class=\"4xx\"")
+                && line.ends_with(" 1")
+        }));
+        assert!(rendered.lines().any(|line| {
+            line.starts_with("vllm_router_request_duration_seconds_count{")
+                && line.contains("route=\"/v1/chat/completions\"")
+                && line.contains("method=\"POST\"")
+                && line.contains("status_class=\"4xx\"")
+                && line.ends_with(" 1")
+        }));
+        assert!(rendered.lines().any(|line| {
+            line.starts_with("vllm_router_request_errors_total{")
+                && line.contains("error_type=\"non_retryable_error\"")
+                && line.contains("status_code=\"429\"")
+                && line.contains("status_class=\"4xx\"")
+        }));
+        assert!(rendered.lines().any(|line| {
+            line.starts_with("vllm_router_pd_requests_total{")
+                && line.contains("route=\"/v1/chat/completions\"")
+                && line.contains("method=\"POST\"")
+                && line.contains("status_code=\"502\"")
+                && line.contains("status_class=\"5xx\"")
+                && line.ends_with(" 1")
+        }));
+        assert!(rendered.lines().any(|line| {
+            line.starts_with("vllm_router_pd_prefill_errors_total{")
+                && line.contains("worker=\"http://prefill1\"")
+                && line.contains("error_type=\"transport\"")
+                && line.contains("status_code=\"none\"")
+                && line.contains("status_class=\"none\"")
+        }));
+        assert!(rendered.lines().any(|line| {
+            line.starts_with("vllm_router_embeddings_errors_total{")
+                && line.contains("status_code=\"429\"")
+                && line.contains("status_class=\"4xx\"")
+        }));
     }
 
     #[test]

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -25,6 +25,9 @@ const DURATION_BUCKETS: [f64; 20] = [
 ];
 
 const NO_STATUS_LABEL: &str = "none";
+const HTTP_REQUEST_METHOD_LABEL: &str = "http_request_method";
+const HTTP_RESPONSE_STATUS_CODE_LABEL: &str = "http_response_status_code";
+const HTTP_RESPONSE_STATUS_CLASS_LABEL: &str = "http_response_status_class";
 
 fn status_code_label(status: StatusCode) -> String {
     status.as_u16().to_string()
@@ -45,6 +48,21 @@ fn optional_status_labels(status: Option<StatusCode>) -> (String, &'static str) 
     status
         .map(|status| (status_code_label(status), status_class_label(status)))
         .unwrap_or_else(|| (NO_STATUS_LABEL.to_string(), NO_STATUS_LABEL))
+}
+
+fn http_response_status_code(status: StatusCode) -> String {
+    status_code_label(status)
+}
+
+fn http_response_status_class(status: StatusCode) -> &'static str {
+    status_class_label(status)
+}
+
+fn http_response_status_labels(status: StatusCode) -> (String, &'static str) {
+    (
+        http_response_status_code(status),
+        http_response_status_class(status),
+    )
 }
 
 pub fn init_metrics() {
@@ -263,20 +281,19 @@ impl RouterMetrics {
         status: StatusCode,
         duration: Duration,
     ) {
-        let status_code = status_code_label(status);
-        let status_class = status_class_label(status);
+        let (status_code, status_class) = http_response_status_labels(status);
         counter!("vllm_router_http_responses_total",
             "route" => route.to_string(),
-            "http_request_method" => method.to_string(),
-            "http_response_status_code" => status_code.clone(),
-            "http_response_status_class" => status_class.to_string()
+            HTTP_REQUEST_METHOD_LABEL => method.to_string(),
+            HTTP_RESPONSE_STATUS_CODE_LABEL => status_code.clone(),
+            HTTP_RESPONSE_STATUS_CLASS_LABEL => status_class.to_string()
         )
         .increment(1);
         histogram!("vllm_router_http_response_duration_seconds",
             "route" => route.to_string(),
-            "http_request_method" => method.to_string(),
-            "http_response_status_code" => status_code,
-            "http_response_status_class" => status_class.to_string()
+            HTTP_REQUEST_METHOD_LABEL => method.to_string(),
+            HTTP_RESPONSE_STATUS_CODE_LABEL => status_code,
+            HTTP_RESPONSE_STATUS_CLASS_LABEL => status_class.to_string()
         )
         .record(duration.as_secs_f64());
     }
@@ -289,24 +306,23 @@ impl RouterMetrics {
         status: StatusCode,
         duration: Duration,
     ) {
-        let status_code = status_code_label(status);
-        let status_class = status_class_label(status);
+        let (status_code, status_class) = http_response_status_labels(status);
         counter!("vllm_router_backend_http_responses_total",
             "route" => route.to_string(),
             "worker" => worker.to_string(),
             "vllm_request_phase" => request_phase.to_string(),
-            "http_request_method" => method.to_string(),
-            "http_response_status_code" => status_code.clone(),
-            "http_response_status_class" => status_class.to_string()
+            HTTP_REQUEST_METHOD_LABEL => method.to_string(),
+            HTTP_RESPONSE_STATUS_CODE_LABEL => status_code.clone(),
+            HTTP_RESPONSE_STATUS_CLASS_LABEL => status_class.to_string()
         )
         .increment(1);
         histogram!("vllm_router_backend_http_response_duration_seconds",
             "route" => route.to_string(),
             "worker" => worker.to_string(),
             "vllm_request_phase" => request_phase.to_string(),
-            "http_request_method" => method.to_string(),
-            "http_response_status_code" => status_code,
-            "http_response_status_class" => status_class.to_string()
+            HTTP_REQUEST_METHOD_LABEL => method.to_string(),
+            HTTP_RESPONSE_STATUS_CODE_LABEL => status_code,
+            HTTP_RESPONSE_STATUS_CLASS_LABEL => status_class.to_string()
         )
         .record(duration.as_secs_f64());
     }
@@ -798,6 +814,20 @@ mod tests {
             StatusCode::OK,
             Duration::from_millis(100),
         );
+        RouterMetrics::observe_http_response(
+            "/generate",
+            "POST",
+            StatusCode::OK,
+            Duration::from_millis(100),
+        );
+        RouterMetrics::observe_backend_http_response(
+            "/generate",
+            "http://worker1",
+            "inference",
+            "POST",
+            StatusCode::BAD_GATEWAY,
+            Duration::from_millis(75),
+        );
         RouterMetrics::record_request_error(
             "/generate",
             "POST",
@@ -843,6 +873,91 @@ mod tests {
         RouterMetrics::record_generate_duration(Duration::from_secs(2));
         RouterMetrics::record_embeddings_error(StatusCode::TOO_MANY_REQUESTS);
         RouterMetrics::set_running_requests("http://worker1", 15);
+    }
+
+    #[test]
+    fn test_http_response_status_helpers() {
+        assert_eq!(http_response_status_code(StatusCode::OK), "200");
+        assert_eq!(http_response_status_class(StatusCode::OK), "2xx");
+        assert_eq!(
+            http_response_status_labels(StatusCode::TOO_MANY_REQUESTS),
+            ("429".to_string(), "4xx")
+        );
+        assert_eq!(
+            http_response_status_labels(StatusCode::SERVICE_UNAVAILABLE),
+            ("503".to_string(), "5xx")
+        );
+    }
+
+    #[test]
+    fn test_rendered_metrics_include_status_aware_http_response_labels() {
+        let recorder = build_test_recorder();
+        let handle = recorder.handle();
+
+        with_local_recorder(&recorder, || {
+            RouterMetrics::observe_http_response(
+                "/generate",
+                "POST",
+                StatusCode::TOO_MANY_REQUESTS,
+                Duration::from_millis(25),
+            );
+            RouterMetrics::observe_backend_http_response(
+                "/generate",
+                "http://worker1",
+                "decode",
+                "POST",
+                StatusCode::SERVICE_UNAVAILABLE,
+                Duration::from_millis(50),
+            );
+        });
+
+        let rendered = handle.render();
+
+        let http_response_counter = rendered
+            .lines()
+            .find(|line| line.starts_with("vllm_router_http_responses_total{"))
+            .expect("expected rendered final-response counter");
+        assert!(http_response_counter.contains("route=\"/generate\""));
+        assert!(http_response_counter.contains("http_request_method=\"POST\""));
+        assert!(http_response_counter.contains("http_response_status_code=\"429\""));
+        assert!(http_response_counter.contains("http_response_status_class=\"4xx\""));
+
+        let http_response_duration = rendered
+            .lines()
+            .find(|line| line.starts_with("vllm_router_http_response_duration_seconds_count{"))
+            .expect("expected rendered final-response duration histogram");
+        assert!(http_response_duration.contains("http_request_method=\"POST\""));
+        assert!(http_response_duration.contains("http_response_status_code=\"429\""));
+        assert!(http_response_duration.contains("http_response_status_class=\"4xx\""));
+        assert!(http_response_duration.ends_with(" 1"));
+
+        let backend_response_counter = rendered
+            .lines()
+            .find(|line| line.starts_with("vllm_router_backend_http_responses_total{"))
+            .expect("expected rendered backend-response counter");
+        assert!(backend_response_counter.contains("route=\"/generate\""));
+        assert!(backend_response_counter.contains("worker=\"http://worker1\""));
+        assert!(backend_response_counter.contains("vllm_request_phase=\"decode\""));
+        assert!(backend_response_counter.contains("http_request_method=\"POST\""));
+        assert!(backend_response_counter.contains("http_response_status_code=\"503\""));
+        assert!(backend_response_counter.contains("http_response_status_class=\"5xx\""));
+
+        let backend_response_duration = rendered
+            .lines()
+            .find(|line| {
+                line.starts_with("vllm_router_backend_http_response_duration_seconds_count{")
+            })
+            .expect("expected rendered backend-response duration histogram");
+        assert!(backend_response_duration.contains("worker=\"http://worker1\""));
+        assert!(backend_response_duration.contains("vllm_request_phase=\"decode\""));
+        assert!(backend_response_duration.contains("http_request_method=\"POST\""));
+        assert!(backend_response_duration.contains("http_response_status_code=\"503\""));
+        assert!(backend_response_duration.contains("http_response_status_class=\"5xx\""));
+        assert!(backend_response_duration.ends_with(" 1"));
+
+        assert!(!rendered.contains("http.request.method"));
+        assert!(!rendered.contains("http.response.status_code"));
+        assert!(!rendered.contains("http.response.status_class"));
     }
 
     #[test]

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -97,7 +97,6 @@ pub fn init_metrics() {
         "vllm_router_worker_health",
         "Worker health status (1=healthy, 0=unhealthy)"
     );
-    describe_gauge!("vllm_router_worker_load", "Current load on each worker");
     describe_counter!(
         "vllm_router_processed_requests_total",
         "Total requests processed by each worker"
@@ -198,94 +197,6 @@ pub fn init_metrics() {
         "vllm_router_running_requests",
         "Number of running requests per worker"
     );
-
-    // Tokenizer metrics
-    describe_histogram!(
-        "vllm_tokenizer_encode_duration_seconds",
-        "Time to encode text to tokens"
-    );
-    describe_histogram!(
-        "vllm_tokenizer_decode_duration_seconds",
-        "Time to decode tokens to text"
-    );
-    describe_histogram!(
-        "vllm_tokenizer_encode_batch_duration_seconds",
-        "Time to encode a batch of texts"
-    );
-    describe_counter!(
-        "vllm_tokenizer_encode_requests_total",
-        "Total number of encode requests by tokenizer type"
-    );
-    describe_counter!(
-        "vllm_tokenizer_decode_requests_total",
-        "Total number of decode requests by tokenizer type"
-    );
-    describe_counter!(
-        "vllm_tokenizer_encode_errors_total",
-        "Total number of encode errors by error type"
-    );
-    describe_counter!(
-        "vllm_tokenizer_decode_errors_total",
-        "Total number of decode errors by error type"
-    );
-    describe_histogram!(
-        "vllm_tokenizer_tokens_per_encode",
-        "Number of tokens produced per encode operation"
-    );
-    describe_histogram!(
-        "vllm_tokenizer_chars_per_encode",
-        "Number of characters in input text per encode"
-    );
-    describe_histogram!(
-        "vllm_tokenizer_tokens_per_decode",
-        "Number of tokens decoded per operation"
-    );
-    describe_gauge!(
-        "vllm_tokenizer_vocab_size",
-        "Vocabulary size of the loaded tokenizer"
-    );
-
-    // Stop sequence detection metrics
-    describe_counter!(
-        "vllm_tokenizer_stop_sequences_detected_total",
-        "Total stop sequences detected by type"
-    );
-    describe_counter!(
-        "vllm_tokenizer_partial_matches_total",
-        "Total partial stop sequence matches (jailed text)"
-    );
-    describe_histogram!(
-        "vllm_tokenizer_stop_detection_duration_seconds",
-        "Time to check for stop sequences per token"
-    );
-
-    // Streaming decode metrics
-    describe_counter!(
-        "vllm_tokenizer_stream_tokens_total",
-        "Total tokens processed in streaming decode"
-    );
-    describe_counter!(
-        "vllm_tokenizer_stream_incomplete_utf8_total",
-        "Total incomplete UTF-8 sequences detected"
-    );
-    describe_histogram!(
-        "vllm_tokenizer_stream_step_duration_seconds",
-        "Time per streaming decode step"
-    );
-
-    // Factory metrics
-    describe_counter!(
-        "vllm_tokenizer_factory_loads_total",
-        "Total tokenizer loads by file type"
-    );
-    describe_counter!(
-        "vllm_tokenizer_factory_errors_total",
-        "Total tokenizer loading errors by type"
-    );
-    describe_histogram!(
-        "vllm_tokenizer_factory_load_duration_seconds",
-        "Time to load and initialize tokenizer"
-    );
 }
 
 pub fn start_prometheus(config: PrometheusConfig) {
@@ -309,8 +220,6 @@ pub fn start_prometheus(config: PrometheusConfig) {
 }
 
 pub struct RouterMetrics;
-
-pub struct TokenizerMetrics;
 
 impl RouterMetrics {
     // Request metrics
@@ -376,13 +285,6 @@ impl RouterMetrics {
             "worker" => worker_url.to_string()
         )
         .set(if healthy { 1.0 } else { 0.0 });
-    }
-
-    pub fn set_worker_load(worker_url: &str, load: usize) {
-        gauge!("vllm_router_worker_load",
-            "worker" => worker_url.to_string()
-        )
-        .set(load as f64);
     }
 
     pub fn record_processed_request(worker_url: &str) {
@@ -575,122 +477,6 @@ impl RouterMetrics {
             "outcome" => outcome.to_string()
         )
         .increment(1);
-    }
-}
-
-impl TokenizerMetrics {
-    // Encoding metrics
-    pub fn record_encode_request(tokenizer_type: &str) {
-        counter!("vllm_tokenizer_encode_requests_total",
-            "tokenizer_type" => tokenizer_type.to_string()
-        )
-        .increment(1);
-    }
-
-    pub fn record_encode_duration(duration: Duration) {
-        histogram!("vllm_tokenizer_encode_duration_seconds").record(duration.as_secs_f64());
-    }
-
-    pub fn record_encode_error(error_type: &str) {
-        counter!("vllm_tokenizer_encode_errors_total",
-            "error_type" => error_type.to_string()
-        )
-        .increment(1);
-    }
-
-    pub fn record_tokens_per_encode(token_count: usize) {
-        histogram!("vllm_tokenizer_tokens_per_encode").record(token_count as f64);
-    }
-
-    pub fn record_chars_per_encode(char_count: usize) {
-        histogram!("vllm_tokenizer_chars_per_encode").record(char_count as f64);
-    }
-
-    // Decoding metrics
-    pub fn record_decode_request(tokenizer_type: &str) {
-        counter!("vllm_tokenizer_decode_requests_total",
-            "tokenizer_type" => tokenizer_type.to_string()
-        )
-        .increment(1);
-    }
-
-    pub fn record_decode_duration(duration: Duration) {
-        histogram!("vllm_tokenizer_decode_duration_seconds").record(duration.as_secs_f64());
-    }
-
-    pub fn record_decode_error(error_type: &str) {
-        counter!("vllm_tokenizer_decode_errors_total",
-            "error_type" => error_type.to_string()
-        )
-        .increment(1);
-    }
-
-    pub fn record_tokens_per_decode(token_count: usize) {
-        histogram!("vllm_tokenizer_tokens_per_decode").record(token_count as f64);
-    }
-
-    // Batch encoding metrics
-    pub fn record_encode_batch_duration(duration: Duration, batch_size: usize) {
-        histogram!("vllm_tokenizer_encode_batch_duration_seconds",
-            "batch_size" => batch_size.to_string()
-        )
-        .record(duration.as_secs_f64());
-    }
-
-    // Stop sequence detection metrics
-    pub fn record_stop_sequence_detected(stop_type: &str) {
-        counter!("vllm_tokenizer_stop_sequences_detected_total",
-            "type" => stop_type.to_string()
-        )
-        .increment(1);
-    }
-
-    pub fn record_partial_match() {
-        counter!("vllm_tokenizer_partial_matches_total").increment(1);
-    }
-
-    pub fn record_stop_detection_duration(duration: Duration) {
-        histogram!("vllm_tokenizer_stop_detection_duration_seconds").record(duration.as_secs_f64());
-    }
-
-    // Streaming decode metrics
-    pub fn record_stream_token() {
-        counter!("vllm_tokenizer_stream_tokens_total").increment(1);
-    }
-
-    pub fn record_incomplete_utf8() {
-        counter!("vllm_tokenizer_stream_incomplete_utf8_total").increment(1);
-    }
-
-    pub fn record_stream_step_duration(duration: Duration) {
-        histogram!("vllm_tokenizer_stream_step_duration_seconds").record(duration.as_secs_f64());
-    }
-
-    // Factory metrics
-    pub fn record_factory_load(file_type: &str) {
-        counter!("vllm_tokenizer_factory_loads_total",
-            "file_type" => file_type.to_string()
-        )
-        .increment(1);
-    }
-
-    pub fn record_factory_error(error_type: &str) {
-        counter!("vllm_tokenizer_factory_errors_total",
-            "error_type" => error_type.to_string()
-        )
-        .increment(1);
-    }
-
-    pub fn record_factory_load_duration(duration: Duration) {
-        histogram!("vllm_tokenizer_factory_load_duration_seconds").record(duration.as_secs_f64());
-    }
-
-    // Vocabulary metrics
-    pub fn set_vocab_size(tokenizer_type: &str, size: usize) {
-        gauge!("vllm_tokenizer_vocab_size",
-            "tokenizer_type" => tokenizer_type.to_string()
-        )
-        .set(size as f64);
     }
 }
 
@@ -952,7 +738,6 @@ mod tests {
 
         RouterMetrics::set_active_workers(5);
         RouterMetrics::set_worker_health("http://worker1", true);
-        RouterMetrics::set_worker_load("http://worker1", 10);
         RouterMetrics::record_processed_request("http://worker1");
 
         RouterMetrics::record_policy_decision("random", "http://worker1");
@@ -1097,43 +882,24 @@ mod tests {
     }
 
     #[test]
-    fn test_tokenizer_metrics_static_methods() {
-        // Test that all tokenizer metric methods can be called without panic
+    fn test_rendered_metrics_exclude_removed_dormant_families() {
+        let recorder = build_test_recorder();
+        let handle = recorder.handle();
 
-        // Encoding metrics
-        TokenizerMetrics::record_encode_request("huggingface");
-        TokenizerMetrics::record_encode_duration(Duration::from_millis(10));
-        TokenizerMetrics::record_encode_error("invalid_input");
-        TokenizerMetrics::record_tokens_per_encode(100);
-        TokenizerMetrics::record_chars_per_encode(500);
+        with_local_recorder(&recorder, || {
+            RouterMetrics::set_active_workers(1);
+            RouterMetrics::observe_request(
+                "/generate",
+                "POST",
+                StatusCode::OK,
+                Duration::from_millis(10),
+            );
+        });
 
-        // Decoding metrics
-        TokenizerMetrics::record_decode_request("huggingface");
-        TokenizerMetrics::record_decode_duration(Duration::from_millis(5));
-        TokenizerMetrics::record_decode_error("invalid_tokens");
-        TokenizerMetrics::record_tokens_per_decode(50);
+        let rendered = handle.render();
 
-        // Batch encoding
-        TokenizerMetrics::record_encode_batch_duration(Duration::from_millis(100), 10);
-
-        // Stop sequence detection
-        TokenizerMetrics::record_stop_sequence_detected("token");
-        TokenizerMetrics::record_stop_sequence_detected("string");
-        TokenizerMetrics::record_partial_match();
-        TokenizerMetrics::record_stop_detection_duration(Duration::from_micros(100));
-
-        // Streaming decode
-        TokenizerMetrics::record_stream_token();
-        TokenizerMetrics::record_incomplete_utf8();
-        TokenizerMetrics::record_stream_step_duration(Duration::from_micros(50));
-
-        // Factory metrics
-        TokenizerMetrics::record_factory_load("json");
-        TokenizerMetrics::record_factory_error("unsupported_format");
-        TokenizerMetrics::record_factory_load_duration(Duration::from_millis(200));
-
-        // Vocabulary metrics
-        TokenizerMetrics::set_vocab_size("huggingface", 50000);
+        assert!(!rendered.contains("vllm_router_worker_load"));
+        assert!(!rendered.contains("vllm_tokenizer_"));
     }
 
     // ============= Port Availability Tests =============
@@ -1187,7 +953,7 @@ mod tests {
             let handle = thread::spawn(move || {
                 let worker = format!("http://worker{}", i);
                 while !done_clone.load(Ordering::Relaxed) {
-                    RouterMetrics::set_worker_load(&worker, i * 10);
+                    RouterMetrics::set_running_requests(&worker, i * 10);
                     RouterMetrics::record_processed_request(&worker);
                     thread::sleep(Duration::from_millis(1));
                 }
@@ -1250,8 +1016,8 @@ mod tests {
         RouterMetrics::set_active_workers(0);
         RouterMetrics::set_active_workers(usize::MAX);
 
-        RouterMetrics::set_worker_load("worker", 0);
-        RouterMetrics::set_worker_load("worker", usize::MAX);
+        RouterMetrics::set_running_requests("worker", 0);
+        RouterMetrics::set_running_requests("worker", usize::MAX);
 
         RouterMetrics::observe_request("route", "GET", StatusCode::OK, Duration::from_nanos(1));
         // 24 hours

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1199,7 +1199,12 @@ mod tests {
         ];
 
         for label in special_labels {
-            RouterMetrics::observe_http_request(label, "GET", StatusCode::OK, Duration::from_millis(1));
+            RouterMetrics::observe_http_request(
+                label,
+                "GET",
+                StatusCode::OK,
+                Duration::from_millis(1),
+            );
             RouterMetrics::set_worker_health(label, true);
         }
     }
@@ -1213,8 +1218,18 @@ mod tests {
         RouterMetrics::set_running_requests("worker", 0);
         RouterMetrics::set_running_requests("worker", usize::MAX);
 
-        RouterMetrics::observe_http_request("route", "GET", StatusCode::OK, Duration::from_nanos(1));
+        RouterMetrics::observe_http_request(
+            "route",
+            "GET",
+            StatusCode::OK,
+            Duration::from_nanos(1),
+        );
         // 24 hours
-        RouterMetrics::observe_http_request("route", "GET", StatusCode::OK, Duration::from_secs(86400));
+        RouterMetrics::observe_http_request(
+            "route",
+            "GET",
+            StatusCode::OK,
+            Duration::from_secs(86400),
+        );
     }
 }

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -3,7 +3,6 @@ use axum::{
     middleware::Next, response::IntoResponse, response::Response,
 };
 use rand::Rng;
-use std::borrow::Cow;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
@@ -217,18 +216,18 @@ impl<B> OnRequest<B> for RequestLogger {
     }
 }
 
-fn request_route_label<B>(request: &Request<B>) -> Cow<'_, str> {
+fn request_route_label<B>(request: &Request<B>) -> &str {
     request
         .extensions()
         .get::<MatchedPath>()
-        .map(|route| Cow::Borrowed(route.as_str()))
-        .unwrap_or_else(|| Cow::Owned(request.uri().path().to_string()))
+        .map(|route| route.as_str())
+        .unwrap_or("unmatched")
 }
 
 pub async fn http_metrics_middleware(request: Request<axum::body::Body>, next: Next) -> Response {
     let start = Instant::now();
     let method = request.method().to_string();
-    let route = request_route_label(&request).into_owned();
+    let route = request_route_label(&request).to_string();
 
     let response = next.run(request).await;
     RouterMetrics::observe_request(&route, &method, response.status(), start.elapsed());

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -1,8 +1,9 @@
 use axum::{
-    extract::Request, extract::State, http::HeaderValue, http::StatusCode, middleware::Next,
-    response::IntoResponse, response::Response,
+    extract::MatchedPath, extract::Request, extract::State, http::HeaderValue, http::StatusCode,
+    middleware::Next, response::IntoResponse, response::Response,
 };
 use rand::Rng;
+use std::borrow::Cow;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
@@ -214,6 +215,24 @@ impl<B> OnRequest<B> for RequestLogger {
             "started processing request"
         );
     }
+}
+
+fn request_route_label<B>(request: &Request<B>) -> Cow<'_, str> {
+    request
+        .extensions()
+        .get::<MatchedPath>()
+        .map(|route| Cow::Borrowed(route.as_str()))
+        .unwrap_or_else(|| Cow::Owned(request.uri().path().to_string()))
+}
+
+pub async fn http_metrics_middleware(request: Request<axum::body::Body>, next: Next) -> Response {
+    let start = Instant::now();
+    let method = request.method().to_string();
+    let route = request_route_label(&request).into_owned();
+
+    let response = next.run(request).await;
+    RouterMetrics::observe_request(&route, &method, response.status(), start.elapsed());
+    response
 }
 
 /// Custom on_response handler

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -604,3 +604,74 @@ pub async fn concurrency_limit_middleware(
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{body::Body, http::Request as HttpRequest, routing::get, Router};
+    use metrics::set_default_local_recorder;
+    use metrics_exporter_prometheus::{Matcher, PrometheusBuilder};
+    use tower::ServiceExt;
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_http_metrics_middleware_uses_matched_route_and_status_labels() {
+        let recorder = PrometheusBuilder::new()
+            .set_buckets_for_metric(
+                Matcher::Suffix(String::from("duration_seconds")),
+                &[
+                    0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 15.0,
+                    30.0, 45.0, 60.0, 90.0, 120.0, 180.0, 240.0,
+                ],
+            )
+            .expect("failed to set buckets")
+            .build_recorder();
+        let handle = recorder.handle();
+        let _guard = set_default_local_recorder(&recorder);
+
+        let app = Router::new()
+            .route(
+                "/widgets/{widget_id}",
+                get(|| async { StatusCode::ACCEPTED }),
+            )
+            .layer(axum::middleware::from_fn(http_metrics_middleware));
+
+        let response = app
+            .oneshot(
+                HttpRequest::builder()
+                    .method("GET")
+                    .uri("/widgets/123")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::ACCEPTED);
+
+        let rendered = handle.render();
+        let request_line = rendered
+            .lines()
+            .find(|line| line.starts_with("vllm_router_requests_total{"))
+            .expect("missing request counter output");
+        assert!(
+            request_line.contains("route=\"/widgets/{widget_id}\"")
+                && request_line.contains("method=\"GET\"")
+                && request_line.contains("status_code=\"202\"")
+                && request_line.contains("status_class=\"2xx\"")
+                && request_line.ends_with(" 1"),
+            "unexpected request metric line: {request_line}"
+        );
+
+        let duration_line = rendered
+            .lines()
+            .find(|line| line.starts_with("vllm_router_request_duration_seconds_count{"))
+            .expect("missing request duration output");
+        assert!(
+            duration_line.contains("route=\"/widgets/{widget_id}\"")
+                && duration_line.contains("method=\"GET\"")
+                && duration_line.contains("status_class=\"2xx\"")
+                && duration_line.ends_with(" 1"),
+            "unexpected request duration metric line: {duration_line}"
+        );
+    }
+}

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -230,7 +230,7 @@ pub async fn http_metrics_middleware(request: Request<axum::body::Body>, next: N
     let route = request_route_label(&request).to_string();
 
     let response = next.run(request).await;
-    RouterMetrics::observe_request(&route, &method, response.status(), start.elapsed());
+    RouterMetrics::observe_http_request(&route, &method, response.status(), start.elapsed());
     response
 }
 
@@ -650,7 +650,7 @@ mod tests {
         let rendered = handle.render();
         let request_line = rendered
             .lines()
-            .find(|line| line.starts_with("vllm_router_requests_total{"))
+            .find(|line| line.starts_with("vllm_router_http_requests_total{"))
             .expect("missing request counter output");
         assert!(
             request_line.contains("route=\"/widgets/{widget_id}\"")
@@ -663,7 +663,7 @@ mod tests {
 
         let duration_line = rendered
             .lines()
-            .find(|line| line.starts_with("vllm_router_request_duration_seconds_count{"))
+            .find(|line| line.starts_with("vllm_router_http_request_duration_seconds_count{"))
             .expect("missing request duration output");
         assert!(
             duration_line.contains("route=\"/widgets/{widget_id}\"")

--- a/src/policies/cache_aware.rs
+++ b/src/policies/cache_aware.rs
@@ -84,6 +84,24 @@ pub struct CacheAwarePolicy {
     eviction_handle: Option<thread::JoinHandle<()>>,
 }
 
+fn update_tree_size_metric(tree: &Tree, worker_url: &str) {
+    RouterMetrics::set_tree_size(worker_url, tree.tenant_size(worker_url));
+}
+
+fn sync_tree_size_metrics(tree: &Tree, previous_sizes: &HashMap<String, usize>) {
+    let current_sizes = tree.get_tenant_char_count();
+
+    for (worker, size) in &current_sizes {
+        RouterMetrics::set_tree_size(worker, *size);
+    }
+
+    for worker in previous_sizes.keys() {
+        if !current_sizes.contains_key(worker) {
+            RouterMetrics::set_tree_size(worker, 0);
+        }
+    }
+}
+
 impl CacheAwarePolicy {
     pub fn new() -> Self {
         Self::with_config(CacheAwareConfig::default())
@@ -105,7 +123,9 @@ impl CacheAwarePolicy {
                 for entry in trees_clone.iter() {
                     let model_id = entry.key();
                     let tree = entry.value();
+                    let previous_sizes = tree.get_tenant_char_count();
                     tree.evict_tenant_by_size(max_tree_size);
+                    sync_tree_size_metrics(tree, &previous_sizes);
                     debug!(
                         "Cache eviction completed for model {}, max_size: {}",
                         model_id, max_tree_size
@@ -131,6 +151,7 @@ impl CacheAwarePolicy {
             .entry(tree_key.to_string())
             .or_insert_with(|| Arc::new(Tree::new()));
         tree.insert("", worker.url());
+        update_tree_size_metric(&tree, worker.url());
     }
 
     /// Add a worker by URL and model (for backward compatibility)
@@ -140,6 +161,7 @@ impl CacheAwarePolicy {
             .entry(model_id.to_string())
             .or_insert_with(|| Arc::new(Tree::new()));
         tree.insert("", url);
+        update_tree_size_metric(&tree, url);
     }
 
     /// Remove a worker from the tree
@@ -147,6 +169,7 @@ impl CacheAwarePolicy {
         let tree_key = normalize_model_key(worker.model_id());
         if let Some(tree) = self.trees.get(tree_key) {
             tree.remove_tenant(worker.url());
+            RouterMetrics::set_tree_size(worker.url(), 0);
         }
     }
 
@@ -156,6 +179,7 @@ impl CacheAwarePolicy {
         for tree_ref in self.trees.iter() {
             tree_ref.value().remove_tenant(url);
         }
+        RouterMetrics::set_tree_size(url, 0);
     }
 
     /// Run cache eviction to prevent unbounded growth
@@ -163,7 +187,9 @@ impl CacheAwarePolicy {
         for tree_ref in self.trees.iter() {
             let model_id = tree_ref.key();
             let tree = tree_ref.value();
+            let previous_sizes = tree.get_tenant_char_count();
             tree.evict_tenant_by_size(max_size);
+            sync_tree_size_metrics(tree, &previous_sizes);
             debug!(
                 "Cache eviction for model {}, max_size: {}",
                 model_id, max_size
@@ -208,6 +234,7 @@ impl CacheAwarePolicy {
             if let Some(tree) = tree {
                 let worker_url = workers[min_load_idx].url();
                 tree.insert(text, worker_url);
+                update_tree_size_metric(&tree, worker_url);
             } else {
                 debug!(
                     "Warning: No tree found for model '{}', skipping cache update",
@@ -310,8 +337,9 @@ impl LoadBalancingPolicy for CacheAwarePolicy {
             "Cache match for model '{}': matched_chars={}, input_chars={}, match_rate={:.2}",
             model_id, result.matched_char_count, result.input_char_count, match_rate
         );
+        let is_cache_hit = match_rate > self.config.cache_threshold;
         // Select worker without String allocation
-        let selected_idx = if match_rate > self.config.cache_threshold {
+        let selected_idx = if is_cache_hit {
             // Cache hit path: find worker by URL (compare &str directly, no allocation)
             let tenant_url: &str = &result.tenant;
             workers
@@ -329,6 +357,13 @@ impl LoadBalancingPolicy for CacheAwarePolicy {
         if let Some(idx) = selected_idx {
             // Update the tree with this request (use worker URL directly, no allocation)
             tree.insert(text, workers[idx].url());
+            update_tree_size_metric(&tree, workers[idx].url());
+
+            if is_cache_hit {
+                RouterMetrics::record_cache_hit();
+            } else {
+                RouterMetrics::record_cache_miss();
+            }
 
             // Increment processed counter
             workers[idx].increment_processed();
@@ -339,9 +374,11 @@ impl LoadBalancingPolicy for CacheAwarePolicy {
         }
 
         // Selected worker no longer exists or unhealthy, remove stale tenant from tree
-        if match_rate > self.config.cache_threshold {
+        if is_cache_hit {
             let tenant_url: &str = &result.tenant;
             tree.remove_tenant(tenant_url);
+            RouterMetrics::set_tree_size(tenant_url, 0);
+            RouterMetrics::record_cache_miss();
             debug!("Removed stale worker {} from cache tree", tenant_url);
         }
 
@@ -478,6 +515,8 @@ impl Drop for CacheAwarePolicy {
 mod tests {
     use super::*;
     use crate::core::{BasicWorker, WorkerType};
+    use metrics::with_local_recorder;
+    use metrics_exporter_prometheus::PrometheusBuilder;
 
     #[test]
     fn test_cache_aware_with_balanced_load() {
@@ -573,5 +612,76 @@ mod tests {
         // All requests should now go to worker2
         let idx = policy.select_worker(&workers, Some("test1")).unwrap();
         assert_eq!(idx, 1);
+    }
+
+    #[test]
+    fn test_cache_aware_emits_hit_miss_and_tree_size_metrics() {
+        let recorder = PrometheusBuilder::new().build_recorder();
+        let handle = recorder.handle();
+        let policy = CacheAwarePolicy::with_config(CacheAwareConfig {
+            eviction_interval_secs: 0,
+            ..Default::default()
+        });
+        let workers: Vec<Arc<dyn Worker>> = vec![
+            Arc::new(BasicWorker::new(
+                "http://w1:8000".to_string(),
+                WorkerType::Regular,
+            )),
+            Arc::new(BasicWorker::new(
+                "http://w2:8000".to_string(),
+                WorkerType::Regular,
+            )),
+        ];
+
+        policy.init_workers(&workers);
+
+        let selected_worker = with_local_recorder(&recorder, || {
+            let idx = policy.select_worker(&workers, Some("hello")).unwrap();
+            let selected_worker = workers[idx].url().to_string();
+            let repeat_idx = policy.select_worker(&workers, Some("hello")).unwrap();
+            assert_eq!(repeat_idx, idx);
+            selected_worker
+        });
+
+        let rendered = handle.render();
+
+        assert!(rendered.contains("vllm_router_cache_hits_total 1"));
+        assert!(rendered.contains("vllm_router_cache_misses_total 1"));
+        assert!(rendered.lines().any(|line| {
+            line.starts_with("vllm_router_tree_size{")
+                && line.contains(&format!("worker=\"{}\"", selected_worker))
+                && line.ends_with(" 5")
+        }));
+    }
+
+    #[test]
+    fn test_cache_aware_removal_clears_tree_size_metric() {
+        let recorder = PrometheusBuilder::new().build_recorder();
+        let handle = recorder.handle();
+        let config = CacheAwareConfig {
+            eviction_interval_secs: 0,
+            ..Default::default()
+        };
+        let policy = CacheAwarePolicy::with_config(config);
+        let workers: Vec<Arc<dyn Worker>> = vec![Arc::new(BasicWorker::new(
+            "http://w1:8000".to_string(),
+            WorkerType::Regular,
+        ))];
+
+        policy.init_workers(&workers);
+
+        with_local_recorder(&recorder, || {
+            let worker_url = workers[0].url().to_string();
+            policy.select_worker(&workers, Some("hello")).unwrap();
+            policy.remove_worker_by_url(&worker_url);
+        });
+
+        let rendered = handle.render();
+
+        assert!(rendered.lines().any(|line| {
+            line.starts_with("vllm_router_tree_size{")
+                && line.contains("worker=\"http://w1:8000\"")
+                && line.ends_with(" 0")
+        }));
     }
 }

--- a/src/proto/google/protobuf/struct.proto
+++ b/src/proto/google/protobuf/struct.proto
@@ -1,0 +1,81 @@
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+syntax = "proto3";
+
+package google.protobuf;
+
+option cc_enable_arenas = true;
+option go_package = "google.golang.org/protobuf/types/known/structpb";
+option java_package = "com.google.protobuf";
+option java_outer_classname = "StructProto";
+option java_multiple_files = true;
+option objc_class_prefix = "GPB";
+option csharp_namespace = "Google.Protobuf.WellKnownTypes";
+
+// Struct represents a structured data value, consisting of fields which map to
+// dynamically typed values.
+message Struct {
+  // Unordered map of dynamically typed values.
+  map<string, Value> fields = 1;
+}
+
+// Value represents a dynamically typed value which can be either null, a
+// number, a string, a boolean, a recursive struct value, or a list of values.
+message Value {
+  // The kind of value.
+  oneof kind {
+    // Represents a null value.
+    NullValue null_value = 1;
+    // Represents a double value.
+    double number_value = 2;
+    // Represents a string value.
+    string string_value = 3;
+    // Represents a boolean value.
+    bool bool_value = 4;
+    // Represents a structured value.
+    Struct struct_value = 5;
+    // Represents a repeated Value.
+    ListValue list_value = 6;
+  }
+}
+
+// NullValue is a singleton enumeration to represent the null value for the
+// Value type union.
+enum NullValue {
+  // Null value.
+  NULL_VALUE = 0;
+}
+
+// ListValue is a wrapper around a repeated field of values.
+message ListValue {
+  // Repeated field of dynamically typed values.
+  repeated Value values = 1;
+}

--- a/src/proto/google/protobuf/timestamp.proto
+++ b/src/proto/google/protobuf/timestamp.proto
@@ -1,0 +1,57 @@
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+syntax = "proto3";
+
+package google.protobuf;
+
+option cc_enable_arenas = true;
+option go_package = "google.golang.org/protobuf/types/known/timestamppb";
+option java_package = "com.google.protobuf";
+option java_outer_classname = "TimestampProto";
+option java_multiple_files = true;
+option objc_class_prefix = "GPB";
+option csharp_namespace = "Google.Protobuf.WellKnownTypes";
+
+// A Timestamp represents a point in time independent of any time zone or local
+// calendar, encoded as a count of seconds and fractions of seconds at
+// nanosecond resolution. The count is relative to an epoch at UTC midnight on
+// January 1, 1970, in the proleptic Gregorian calendar which extends the
+// Gregorian calendar backwards to year one.
+message Timestamp {
+  // Represents seconds of UTC time since Unix epoch 1970-01-01T00:00:00Z.
+  // Must be from 0001-01-01T00:00:00Z to 9999-12-31T23:59:59Z inclusive.
+  int64 seconds = 1;
+
+  // Non-negative fractions of a second at nanosecond resolution. Negative
+  // second values with fractions must still have non-negative nanos values
+  // that count forward in time. Must be from 0 to 999,999,999 inclusive.
+  int32 nanos = 2;
+}

--- a/src/routers/http/pd_router.rs
+++ b/src/routers/http/pd_router.rs
@@ -651,7 +651,6 @@ impl PDRouter {
 
                             if !status.is_success() {
                                 error!("Prefill drain: error status={} url={}", status, url);
-                                RouterMetrics::record_pd_prefill_error(&url);
                             }
 
                             // Drain the response body efficiently
@@ -715,7 +714,6 @@ impl PDRouter {
     // Helper to handle server selection errors
     fn handle_server_selection_error(error: String) -> Response {
         error!("Failed to select PD pair error={}", error);
-        RouterMetrics::record_pd_error("server_selection");
         (
             StatusCode::SERVICE_UNAVAILABLE,
             format!("No available servers: {}", error),
@@ -858,16 +856,18 @@ impl PDRouter {
         context: PDRequestContext<'_>,
     ) -> Response {
         let start_time = Instant::now();
-
         let route = context.route;
-        RetryExecutor::execute_response_with_retry(
+        let last_error_type = Arc::new(std::sync::Mutex::new(None::<&'static str>));
+        let response = RetryExecutor::execute_response_with_retry(
             &self.retry_config,
             // Operation per attempt
             {
                 let original_request = original_request.clone();
+                let last_error_type = Arc::clone(&last_error_type);
                 move |attempt: u32| {
                     let original_request = original_request.clone();
                     let context = context.clone();
+                    let last_error_type = Arc::clone(&last_error_type);
                     async move {
                         // Select workers fresh for each attempt
                         let (prefill, decode) = match self
@@ -876,10 +876,12 @@ impl PDRouter {
                         {
                             Ok(pair) => pair,
                             Err(e) => {
-                                RouterMetrics::record_pd_error("server_selection");
+                                *last_error_type.lock().expect("pd error mutex poisoned") =
+                                    Some("server_selection");
                                 return Self::handle_server_selection_error(e);
                             }
                         };
+                        *last_error_type.lock().expect("pd error mutex poisoned") = None;
 
                         debug!(
                             "PD retry attempt {} using prefill={} decode={}",
@@ -912,7 +914,6 @@ impl PDRouter {
                                 context,
                                 prefill.as_ref(),
                                 decode.as_ref(),
-                                start_time,
                             )
                             .await;
 
@@ -936,7 +937,20 @@ impl PDRouter {
             // On exhausted hook
             || RouterMetrics::record_retries_exhausted(route),
         )
-        .await
+        .await;
+
+        let status = response.status();
+        RouterMetrics::observe_pd_request(route, "POST", status, start_time.elapsed());
+
+        if let Some(error_type) = last_error_type
+            .lock()
+            .expect("pd error mutex poisoned")
+            .take()
+        {
+            RouterMetrics::record_pd_error(route, "POST", status, error_type);
+        }
+
+        response
     }
 
     async fn handle_decode_error_response(
@@ -998,7 +1012,6 @@ impl PDRouter {
         context: PDRequestContext<'_>,
         prefill: &dyn Worker,
         decode: &dyn Worker,
-        start_time: Instant,
     ) -> Response {
         // For non-streaming: use guard for automatic load management
         // For streaming: load will be managed in create_streaming_response
@@ -1060,13 +1073,6 @@ impl PDRouter {
                 tokio::join!(prefill_request.send(), decode_request.send());
             debug!("Received responses from both servers");
 
-            // Update metrics
-            let duration = start_time.elapsed();
-            RouterMetrics::record_pd_request_duration(context.route, duration);
-            RouterMetrics::record_pd_request(context.route);
-            RouterMetrics::record_pd_prefill_request(prefill.url());
-            RouterMetrics::record_pd_decode_request(decode.url());
-
             // Process decode response with prefill for logprobs
             debug!("Processing decode response with logprobs");
             match decode_result {
@@ -1074,9 +1080,14 @@ impl PDRouter {
                     let status = StatusCode::from_u16(res.status().as_u16())
                         .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
                     debug!("Decode response status: {}", status);
+                    RouterMetrics::record_pd_decode_request(decode.url(), status);
 
                     if !status.is_success() {
-                        RouterMetrics::record_pd_decode_error(decode.url());
+                        RouterMetrics::record_pd_decode_error(
+                            decode.url(),
+                            "http_response",
+                            Some(status),
+                        );
                         error!(
                             "Decode server returned error status decode_url={} status={}",
                             decode.url(),
@@ -1140,7 +1151,7 @@ impl PDRouter {
                         error = %e,
                         "Decode request failed"
                     );
-                    RouterMetrics::record_pd_decode_error(decode.url());
+                    RouterMetrics::record_pd_decode_error(decode.url(), "transport", None);
                     (
                         StatusCode::BAD_GATEWAY,
                         format!("Decode server error: {}", e),
@@ -1176,35 +1187,67 @@ impl PDRouter {
             let drain_tx = self.prefill_drain_tx.clone();
             let prefill_url = prefill.url().to_string();
             tokio::spawn(async move {
-                if let Ok(response) = prefill_request.send().await {
-                    // Try to send to drain worker
-                    // If channel is full (under extreme load), drain inline as fallback
-                    match drain_tx.try_send(response) {
-                        Ok(_) => {
-                            // Successfully queued for draining
-                            debug!("Prefill response queued for draining");
+                match prefill_request.send().await {
+                    Ok(response) => {
+                        let status = StatusCode::from_u16(response.status().as_u16())
+                            .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+                        RouterMetrics::record_pd_prefill_request(&prefill_url, status);
+                        if !status.is_success() {
+                            RouterMetrics::record_pd_prefill_error(
+                                &prefill_url,
+                                "http_response",
+                                Some(status),
+                            );
                         }
-                        Err(mpsc::error::TrySendError::Full(response)) => {
-                            // Channel full - drain inline as fallback
-                            warn!("Prefill drain channel full (capacity exceeded), draining inline for {}", prefill_url);
-                            RouterMetrics::record_pd_prefill_error(&prefill_url);
 
-                            // Drain inline with timeout to prevent blocking too long
-                            let drain_future = async {
-                                let mut stream = response.bytes_stream();
-                                while stream.next().await.is_some() {
-                                    // Just drain
+                        // Try to send to drain worker
+                        // If channel is full (under extreme load), drain inline as fallback
+                        match drain_tx.try_send(response) {
+                            Ok(_) => {
+                                // Successfully queued for draining
+                                debug!("Prefill response queued for draining");
+                            }
+                            Err(mpsc::error::TrySendError::Full(response)) => {
+                                // Channel full - drain inline as fallback
+                                warn!("Prefill drain channel full (capacity exceeded), draining inline for {}", prefill_url);
+                                RouterMetrics::record_pd_prefill_error(
+                                    &prefill_url,
+                                    "drain_queue_full",
+                                    Some(status),
+                                );
+
+                                // Drain inline with timeout to prevent blocking too long
+                                let drain_future = async {
+                                    let mut stream = response.bytes_stream();
+                                    while stream.next().await.is_some() {
+                                        // Just drain
+                                    }
+                                };
+
+                                match tokio::time::timeout(Duration::from_secs(1), drain_future)
+                                    .await
+                                {
+                                    Ok(_) => debug!("Inline drain completed for {}", prefill_url),
+                                    Err(_) => error!("Inline drain timeout for {}", prefill_url),
                                 }
-                            };
-
-                            match tokio::time::timeout(Duration::from_secs(1), drain_future).await {
-                                Ok(_) => debug!("Inline drain completed for {}", prefill_url),
-                                Err(_) => error!("Inline drain timeout for {}", prefill_url),
+                            }
+                            Err(mpsc::error::TrySendError::Closed(_)) => {
+                                RouterMetrics::record_pd_prefill_error(
+                                    &prefill_url,
+                                    "drain_channel_closed",
+                                    Some(status),
+                                );
+                                error!("Prefill drain channel closed!");
                             }
                         }
-                        Err(mpsc::error::TrySendError::Closed(_)) => {
-                            error!("Prefill drain channel closed!");
-                        }
+                    }
+                    Err(e) => {
+                        error!(
+                            prefill_url = %prefill_url,
+                            error = %e,
+                            "Prefill request failed"
+                        );
+                        RouterMetrics::record_pd_prefill_error(&prefill_url, "transport", None);
                     }
                 }
             });
@@ -1213,13 +1256,6 @@ impl PDRouter {
             let decode_result = decode_request.send().await;
             debug!("Received decode response");
 
-            // Update metrics
-            let duration = start_time.elapsed();
-            RouterMetrics::record_pd_request_duration(context.route, duration);
-            RouterMetrics::record_pd_request(context.route);
-            RouterMetrics::record_pd_prefill_request(prefill.url());
-            RouterMetrics::record_pd_decode_request(decode.url());
-
             // Process decode response immediately
             debug!("Processing decode response (no logprobs)");
             match decode_result {
@@ -1227,9 +1263,14 @@ impl PDRouter {
                     let status = StatusCode::from_u16(res.status().as_u16())
                         .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
                     debug!("Decode response status: {}", status);
+                    RouterMetrics::record_pd_decode_request(decode.url(), status);
 
                     if !status.is_success() {
-                        RouterMetrics::record_pd_decode_error(decode.url());
+                        RouterMetrics::record_pd_decode_error(
+                            decode.url(),
+                            "http_response",
+                            Some(status),
+                        );
                         error!(
                             "Decode server returned error status decode_url={} status={}",
                             decode.url(),
@@ -1269,6 +1310,11 @@ impl PDRouter {
                             }
                             Err(e) => {
                                 error!("Failed to read decode response: {}", e);
+                                RouterMetrics::record_pd_decode_error(
+                                    decode.url(),
+                                    "body_read",
+                                    Some(status),
+                                );
                                 (StatusCode::INTERNAL_SERVER_ERROR, "Failed to read response")
                                     .into_response()
                             }
@@ -1281,7 +1327,7 @@ impl PDRouter {
                         error = %e,
                         "Decode request failed"
                     );
-                    RouterMetrics::record_pd_decode_error(decode.url());
+                    RouterMetrics::record_pd_decode_error(decode.url(), "transport", None);
                     (
                         StatusCode::BAD_GATEWAY,
                         format!("Decode server error: {}", e),
@@ -1602,7 +1648,7 @@ impl PDRouter {
         let prefill_response = match prefill_result {
             Ok(response) => response,
             Err(e) => {
-                RouterMetrics::record_pd_prefill_error(prefill_url);
+                RouterMetrics::record_pd_prefill_error(prefill_url, "transport", None);
                 error!(
                     "Prefill server failed (CRITICAL) prefill_url={} error={}. Decode will timeout without prefill KV cache.",
                     prefill_url,
@@ -1623,10 +1669,15 @@ impl PDRouter {
 
         let prefill_status = StatusCode::from_u16(prefill_response.status().as_u16())
             .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+        RouterMetrics::record_pd_prefill_request(prefill_url, prefill_status);
 
         // Check if prefill succeeded
         if !prefill_status.is_success() {
-            RouterMetrics::record_pd_prefill_error(prefill_url);
+            RouterMetrics::record_pd_prefill_error(
+                prefill_url,
+                "http_response",
+                Some(prefill_status),
+            );
 
             // Get error body from prefill
             let error_msg = prefill_response

--- a/src/routers/http/pd_router.rs
+++ b/src/routers/http/pd_router.rs
@@ -2460,123 +2460,144 @@ impl RouterTrait for PDRouter {
         method: &Method,
         body: serde_json::Value,
     ) -> Response {
-        // Only handle POST requests for inference
-        if *method != Method::POST {
-            return (
-                StatusCode::METHOD_NOT_ALLOWED,
-                "Only POST requests are supported for transparent proxy",
-            )
-                .into_response();
-        }
+        let start_time = Instant::now();
 
-        debug!(
-            "PDRouter transparent proxy: routing {} {} to decode worker",
-            method, path
-        );
-
-        // Get decode workers, filtered by availability
-        let all_decode_workers = self.worker_registry.get_decode_workers();
-        let decode_workers: Vec<Arc<dyn Worker>> = all_decode_workers
-            .iter()
-            .filter(|w| w.is_available())
-            .cloned()
-            .collect();
-
-        if decode_workers.is_empty() {
-            return (
-                StatusCode::SERVICE_UNAVAILABLE,
-                "No decode workers available",
-            )
-                .into_response();
-        }
-
-        // Select a decode worker using policy with headers for consistent hash
-        let decode_policy = self.policy_registry.get_decode_policy();
-        let request_text = serde_json::to_string(&body).ok();
-        let request_headers: Option<HashMap<String, String>> = headers.map(|h| {
-            h.iter()
-                .filter_map(|(name, value)| {
-                    value
-                        .to_str()
-                        .ok()
-                        .map(|v| (name.as_str().to_lowercase(), v.to_string()))
-                })
-                .collect()
-        });
-        let decode_idx = match decode_policy.select_worker_with_headers(
-            &decode_workers,
-            request_text.as_deref(),
-            request_headers.as_ref(),
-        ) {
-            Some(idx) => idx,
-            None => {
-                return (
-                    StatusCode::SERVICE_UNAVAILABLE,
-                    "Decode policy failed to select a worker".to_string(),
+        let response = {
+            // Only handle POST requests for inference
+            if *method != Method::POST {
+                (
+                    StatusCode::METHOD_NOT_ALLOWED,
+                    "Only POST requests are supported for transparent proxy",
                 )
-                    .into_response();
+                    .into_response()
+            } else {
+                debug!(
+                    "PDRouter transparent proxy: routing {} {} to decode worker",
+                    method, path
+                );
+
+                // Get decode workers, filtered by availability
+                let all_decode_workers = self.worker_registry.get_decode_workers();
+                let decode_workers: Vec<Arc<dyn Worker>> = all_decode_workers
+                    .iter()
+                    .filter(|w| w.is_available())
+                    .cloned()
+                    .collect();
+
+                if decode_workers.is_empty() {
+                    (
+                        StatusCode::SERVICE_UNAVAILABLE,
+                        "No decode workers available",
+                    )
+                        .into_response()
+                } else {
+                    // Select a decode worker using policy with headers for consistent hash
+                    let decode_policy = self.policy_registry.get_decode_policy();
+                    let request_text = serde_json::to_string(&body).ok();
+                    let request_headers: Option<HashMap<String, String>> = headers.map(|h| {
+                        h.iter()
+                            .filter_map(|(name, value)| {
+                                value
+                                    .to_str()
+                                    .ok()
+                                    .map(|v| (name.as_str().to_lowercase(), v.to_string()))
+                            })
+                            .collect()
+                    });
+                    let decode_idx = match decode_policy.select_worker_with_headers(
+                        &decode_workers,
+                        request_text.as_deref(),
+                        request_headers.as_ref(),
+                    ) {
+                        Some(idx) => idx,
+                        None => {
+                            return Self::finish_pd_request(
+                                path,
+                                method.as_str(),
+                                start_time,
+                                (
+                                    StatusCode::SERVICE_UNAVAILABLE,
+                                    "Decode policy failed to select a worker".to_string(),
+                                )
+                                    .into_response(),
+                            );
+                        }
+                    };
+
+                    let decode_worker = &decode_workers[decode_idx];
+                    let url = decode_worker.endpoint_url(path);
+
+                    debug!("PDRouter transparent proxy: forwarding to {}", url);
+
+                    // Build the request
+                    let mut request_builder = self.client.post(&url);
+
+                    // Add X-data-parallel-rank header for DP-aware routing
+                    request_builder =
+                        dp_utils::add_dp_rank_header(request_builder, decode_worker.dp_rank());
+
+                    // Add JSON body if not null
+                    if !body.is_null() {
+                        request_builder = request_builder.json(&body);
+                    }
+
+                    // Send request
+                    let request_start = Instant::now();
+                    match otel_http::send_client_request(
+                        request_builder,
+                        headers,
+                        ClientRequestOptions {
+                            method: "POST",
+                            url: &url,
+                            route: Some(path),
+                            request_phase: Some("inference"),
+                        },
+                    )
+                    .await
+                    {
+                        Ok(response) => {
+                            let status = StatusCode::from_u16(response.status().as_u16())
+                                .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+                            Self::observe_backend_response(
+                                path,
+                                decode_worker.url(),
+                                "inference",
+                                method.as_str(),
+                                status,
+                                request_start.elapsed(),
+                            );
+                            let resp_headers = response.headers().clone();
+
+                            // Stream the response body
+                            let body = Body::from_stream(response.bytes_stream());
+                            let mut response_builder = Response::builder().status(status);
+
+                            for (name, value) in resp_headers.iter() {
+                                if name != "transfer-encoding" && name != "content-length" {
+                                    response_builder = response_builder.header(name, value);
+                                }
+                            }
+
+                            match response_builder.body(body) {
+                                Ok(response) => response,
+                                Err(e) => (
+                                    StatusCode::INTERNAL_SERVER_ERROR,
+                                    format!("Failed to build response: {}", e),
+                                )
+                                    .into_response(),
+                            }
+                        }
+                        Err(e) => (
+                            StatusCode::BAD_GATEWAY,
+                            format!("Backend request failed: {}", e),
+                        )
+                            .into_response(),
+                    }
+                }
             }
         };
 
-        let decode_worker = &decode_workers[decode_idx];
-        let url = decode_worker.endpoint_url(path);
-
-        debug!("PDRouter transparent proxy: forwarding to {}", url);
-
-        // Build the request
-        let mut request_builder = self.client.post(&url);
-
-        // Add X-data-parallel-rank header for DP-aware routing
-        request_builder = dp_utils::add_dp_rank_header(request_builder, decode_worker.dp_rank());
-
-        // Add JSON body if not null
-        if !body.is_null() {
-            request_builder = request_builder.json(&body);
-        }
-
-        // Send request
-        match otel_http::send_client_request(
-            request_builder,
-            headers,
-            ClientRequestOptions {
-                method: "POST",
-                url: &url,
-                route: Some(path),
-                request_phase: Some("inference"),
-            },
-        )
-        .await
-        {
-            Ok(response) => {
-                let status = StatusCode::from_u16(response.status().as_u16())
-                    .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
-                let resp_headers = response.headers().clone();
-
-                // Stream the response body
-                let body = Body::from_stream(response.bytes_stream());
-                let mut response_builder = Response::builder().status(status);
-
-                for (name, value) in resp_headers.iter() {
-                    if name != "transfer-encoding" && name != "content-length" {
-                        response_builder = response_builder.header(name, value);
-                    }
-                }
-
-                match response_builder.body(body) {
-                    Ok(response) => response,
-                    Err(e) => (
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        format!("Failed to build response: {}", e),
-                    )
-                        .into_response(),
-                }
-            }
-            Err(e) => (
-                StatusCode::BAD_GATEWAY,
-                format!("Backend request failed: {}", e),
-            )
-                .into_response(),
-        }
+        Self::finish_pd_request(path, method.as_str(), start_time, response)
     }
 }
 

--- a/src/routers/http/pd_router.rs
+++ b/src/routers/http/pd_router.rs
@@ -731,6 +731,36 @@ impl PDRouter {
             .into_response()
     }
 
+    fn finish_pd_request(
+        route: &str,
+        method: &str,
+        start_time: Instant,
+        response: Response,
+    ) -> Response {
+        let duration = start_time.elapsed();
+        RouterMetrics::observe_http_response(route, method, response.status(), duration);
+        RouterMetrics::observe_pd_request(route, method, response.status(), duration);
+        response
+    }
+
+    fn observe_backend_response(
+        route: &str,
+        worker: &str,
+        request_phase: &str,
+        method: &str,
+        status: StatusCode,
+        duration: Duration,
+    ) {
+        RouterMetrics::observe_backend_http_response(
+            route,
+            worker,
+            request_phase,
+            method,
+            status,
+            duration,
+        );
+    }
+
     // Helper to determine batch size from a GenerateRequest
     fn get_generate_batch_size(req: &GenerateRequest) -> Option<usize> {
         // Check prompt array
@@ -940,7 +970,6 @@ impl PDRouter {
         .await;
 
         let status = response.status();
-        RouterMetrics::observe_pd_request(route, "POST", status, start_time.elapsed());
 
         if let Some(error_type) = last_error_type
             .lock()
@@ -950,7 +979,7 @@ impl PDRouter {
             RouterMetrics::record_pd_error(route, "POST", status, error_type);
         }
 
-        response
+        Self::finish_pd_request(route, "POST", start_time, response)
     }
 
     async fn handle_decode_error_response(
@@ -1069,9 +1098,31 @@ impl PDRouter {
                 },
             );
             // When we need logprobs, wait for both responses
-            let (prefill_result, decode_result) =
-                tokio::join!(prefill_request.send(), decode_request.send());
+            let (prefill_result, decode_result) = tokio::join!(
+                async {
+                    let request_start = Instant::now();
+                    (prefill_request.send().await, request_start.elapsed())
+                },
+                async {
+                    let request_start = Instant::now();
+                    (decode_request.send().await, request_start.elapsed())
+                }
+            );
             debug!("Received responses from both servers");
+
+            let (prefill_result, prefill_duration) = prefill_result;
+            let (decode_result, decode_duration) = decode_result;
+
+            if let Ok(prefill_response) = prefill_result.as_ref() {
+                Self::observe_backend_response(
+                    context.route,
+                    prefill.url(),
+                    "prefill",
+                    "POST",
+                    prefill_response.status(),
+                    prefill_duration,
+                );
+            }
 
             // Process decode response with prefill for logprobs
             debug!("Processing decode response with logprobs");
@@ -1080,6 +1131,14 @@ impl PDRouter {
                     let status = StatusCode::from_u16(res.status().as_u16())
                         .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
                     debug!("Decode response status: {}", status);
+                    Self::observe_backend_response(
+                        context.route,
+                        decode.url(),
+                        "decode",
+                        "POST",
+                        status,
+                        decode_duration,
+                    );
                     RouterMetrics::record_pd_decode_request(decode.url(), status);
 
                     if !status.is_success() {
@@ -1186,11 +1245,21 @@ impl PDRouter {
             // This ensures HTTP compliance without blocking
             let drain_tx = self.prefill_drain_tx.clone();
             let prefill_url = prefill.url().to_string();
+            let route = context.route;
             tokio::spawn(async move {
+                let request_start = Instant::now();
                 match prefill_request.send().await {
                     Ok(response) => {
                         let status = StatusCode::from_u16(response.status().as_u16())
                             .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+                        Self::observe_backend_response(
+                            route,
+                            &prefill_url,
+                            "prefill",
+                            "POST",
+                            status,
+                            request_start.elapsed(),
+                        );
                         RouterMetrics::record_pd_prefill_request(&prefill_url, status);
                         if !status.is_success() {
                             RouterMetrics::record_pd_prefill_error(
@@ -1253,6 +1322,7 @@ impl PDRouter {
             });
 
             // Wait only for decode response
+            let decode_request_start = Instant::now();
             let decode_result = decode_request.send().await;
             debug!("Received decode response");
 
@@ -1263,6 +1333,14 @@ impl PDRouter {
                     let status = StatusCode::from_u16(res.status().as_u16())
                         .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
                     debug!("Decode response status: {}", status);
+                    Self::observe_backend_response(
+                        context.route,
+                        decode.url(),
+                        "decode",
+                        "POST",
+                        status,
+                        decode_request_start.elapsed(),
+                    );
                     RouterMetrics::record_pd_decode_request(decode.url(), status);
 
                     if !status.is_success() {

--- a/src/routers/http/router.rs
+++ b/src/routers/http/router.rs
@@ -659,6 +659,38 @@ impl Router {
         response
     }
 
+    fn finish_regular_request(
+        route: &str,
+        method: &str,
+        start_time: Instant,
+        response: Response,
+    ) -> Response {
+        RouterMetrics::observe_http_response(
+            route,
+            method,
+            response.status(),
+            start_time.elapsed(),
+        );
+        response
+    }
+
+    fn observe_backend_response(
+        route: &str,
+        worker: &str,
+        method: &str,
+        status: StatusCode,
+        duration: Duration,
+    ) {
+        RouterMetrics::observe_backend_http_response(
+            route,
+            worker,
+            "inference",
+            method,
+            status,
+            duration,
+        );
+    }
+
     // Helper: return base worker URL (strips DP suffix when enabled)
     fn worker_base_url(&self, worker_url: &str) -> String {
         if self.intra_node_data_parallel_size > 1 {
@@ -674,6 +706,7 @@ impl Router {
         &self,
         headers: Option<&HeaderMap>,
         endpoint: &str,
+        route: &str,
         method: Method,
     ) -> Response {
         // TODO: currently the vllm worker is using in-memory state management, so this implementation has to fan out to all workers.
@@ -688,7 +721,6 @@ impl Router {
             let base = self.worker_base_url(&worker_url);
 
             let url = format!("{}/{}", base, endpoint);
-            let route_name = format!("/{}", endpoint);
             let method_name = method.as_str().to_string();
             let mut request_builder = match method.clone() {
                 Method::GET => self.client.get(&url),
@@ -714,13 +746,14 @@ impl Router {
                 }
             }
 
+            let request_start = Instant::now();
             match otel_http::send_client_request(
                 request_builder,
                 headers,
                 ClientRequestOptions {
                     method: &method_name,
                     url: &url,
-                    route: Some(&route_name),
+                    route: Some(route),
                     request_phase: None,
                 },
             )
@@ -729,6 +762,13 @@ impl Router {
                 Ok(res) => {
                     let status = StatusCode::from_u16(res.status().as_u16())
                         .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+                    Self::observe_backend_response(
+                        route,
+                        &worker_url,
+                        &method_name,
+                        status,
+                        request_start.elapsed(),
+                    );
                     let response_headers = header_utils::preserve_response_headers(res.headers());
                     match res.bytes().await {
                         Ok(body) => {
@@ -768,8 +808,13 @@ impl Router {
     }
 
     // Route a GET request with provided headers to a specific endpoint
-    async fn route_get_request(&self, headers: Option<&HeaderMap>, endpoint: &str) -> Response {
-        self.route_simple_request(headers, endpoint, Method::GET)
+    async fn route_get_request(
+        &self,
+        headers: Option<&HeaderMap>,
+        endpoint: &str,
+        route: &str,
+    ) -> Response {
+        self.route_simple_request(headers, endpoint, route, Method::GET)
             .await
     }
 
@@ -778,8 +823,9 @@ impl Router {
         &self,
         headers: Option<&HeaderMap>,
         endpoint: &str,
+        route: &str,
     ) -> Response {
-        self.route_simple_request(headers, endpoint, Method::POST)
+        self.route_simple_request(headers, endpoint, route, Method::POST)
             .await
     }
 
@@ -857,6 +903,7 @@ impl Router {
             request_builder = request_builder.header("X-data-parallel-rank", dp_rank.to_string());
         }
 
+        let request_start = Instant::now();
         let res = match otel_http::send_client_request(
             request_builder,
             headers,
@@ -894,6 +941,7 @@ impl Router {
 
         let status = StatusCode::from_u16(res.status().as_u16())
             .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+        Self::observe_backend_response(route, worker_url, "POST", status, request_start.elapsed());
 
         if !is_stream {
             // For non-streaming requests, preserve headers
@@ -1464,8 +1512,11 @@ impl RouterTrait for Router {
         body: &GenerateRequest,
         model_id: Option<&str>,
     ) -> Response {
-        self.route_typed_request(headers, body, "/generate", model_id)
-            .await
+        let start_time = Instant::now();
+        let response = self
+            .route_typed_request(headers, body, "/generate", model_id)
+            .await;
+        Self::finish_regular_request("/generate", "POST", start_time, response)
     }
 
     async fn route_chat(
@@ -1474,8 +1525,11 @@ impl RouterTrait for Router {
         body: &ChatCompletionRequest,
         model_id: Option<&str>,
     ) -> Response {
-        self.route_typed_request(headers, body, "/v1/chat/completions", model_id)
-            .await
+        let start_time = Instant::now();
+        let response = self
+            .route_typed_request(headers, body, "/v1/chat/completions", model_id)
+            .await;
+        Self::finish_regular_request("/v1/chat/completions", "POST", start_time, response)
     }
 
     async fn route_completion(
@@ -1484,8 +1538,11 @@ impl RouterTrait for Router {
         body: &CompletionRequest,
         model_id: Option<&str>,
     ) -> Response {
-        self.route_typed_request(headers, body, "/v1/completions", model_id)
-            .await
+        let start_time = Instant::now();
+        let response = self
+            .route_typed_request(headers, body, "/v1/completions", model_id)
+            .await;
+        Self::finish_regular_request("/v1/completions", "POST", start_time, response)
     }
 
     async fn route_responses(
@@ -1494,18 +1551,29 @@ impl RouterTrait for Router {
         body: &ResponsesRequest,
         model_id: Option<&str>,
     ) -> Response {
-        self.route_typed_request(headers, body, "/v1/responses", model_id)
-            .await
+        let start_time = Instant::now();
+        let response = self
+            .route_typed_request(headers, body, "/v1/responses", model_id)
+            .await;
+        Self::finish_regular_request("/v1/responses", "POST", start_time, response)
     }
 
     async fn get_response(&self, headers: Option<&HeaderMap>, response_id: &str) -> Response {
+        let start_time = Instant::now();
         let endpoint = format!("v1/responses/{}", response_id);
-        self.route_get_request(headers, &endpoint).await
+        let route = "/v1/responses/{response_id}";
+        let response = self.route_get_request(headers, &endpoint, route).await;
+        Self::finish_regular_request(route, "GET", start_time, response)
     }
 
     async fn cancel_response(&self, headers: Option<&HeaderMap>, response_id: &str) -> Response {
+        let start_time = Instant::now();
         let endpoint = format!("v1/responses/{}/cancel", response_id);
-        self.route_post_empty_request(headers, &endpoint).await
+        let route = "/v1/responses/{response_id}/cancel";
+        let response = self
+            .route_post_empty_request(headers, &endpoint, route)
+            .await;
+        Self::finish_regular_request(route, "POST", start_time, response)
     }
 
     async fn route_embeddings(
@@ -1528,7 +1596,7 @@ impl RouterTrait for Router {
             RouterMetrics::record_embeddings_error(res.status());
         }
 
-        res
+        Self::finish_regular_request("/v1/embeddings", "POST", start, res)
     }
 
     async fn route_rerank(
@@ -1537,27 +1605,30 @@ impl RouterTrait for Router {
         body: &RerankRequest,
         model_id: Option<&str>,
     ) -> Response {
-        if let Err(e) = body.validate() {
-            return (StatusCode::BAD_REQUEST, e).into_response();
-        }
-        let response = self
-            .route_typed_request(headers, body, "/v1/rerank", model_id)
-            .await;
-        if response.status().is_success() {
-            match Self::build_rerank_response(body, response).await {
-                Ok(rerank_response) => rerank_response,
-                Err(e) => {
-                    error!("Failed to build rerank response: {}", e);
-                    return (
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        "Failed to build rerank response".to_string(),
-                    )
-                        .into_response();
-                }
-            }
+        let start_time = Instant::now();
+        let response = if let Err(e) = body.validate() {
+            (StatusCode::BAD_REQUEST, e).into_response()
         } else {
-            response
-        }
+            let response = self
+                .route_typed_request(headers, body, "/v1/rerank", model_id)
+                .await;
+            if response.status().is_success() {
+                match Self::build_rerank_response(body, response).await {
+                    Ok(rerank_response) => rerank_response,
+                    Err(e) => {
+                        error!("Failed to build rerank response: {}", e);
+                        (
+                            StatusCode::INTERNAL_SERVER_ERROR,
+                            "Failed to build rerank response".to_string(),
+                        )
+                            .into_response()
+                    }
+                }
+            } else {
+                response
+            }
+        };
+        Self::finish_regular_request("/v1/rerank", "POST", start_time, response)
     }
 
     async fn flush_cache(&self) -> Response {
@@ -1667,125 +1738,244 @@ impl RouterTrait for Router {
         method: &Method,
         body: serde_json::Value,
     ) -> Response {
+        let start_time = Instant::now();
         debug!("Transparent proxy: routing {} {} to backend", method, path);
 
-        // Select a worker (filter by availability like select_worker_for_model)
-        let all_workers = self.worker_registry.get_all();
-        let workers: Vec<Arc<dyn Worker>> = all_workers
-            .iter()
-            .filter(|w| w.is_available())
-            .cloned()
-            .collect();
-        if workers.is_empty() {
-            return (
-                StatusCode::SERVICE_UNAVAILABLE,
-                "No available workers".to_string(),
-            )
-                .into_response();
-        }
-
-        let policy = self.policy_registry.get_default_policy();
-        let request_text = serde_json::to_string(&body).ok();
-        let request_headers = Self::headers_to_request_headers(headers);
-        let worker_idx = match policy.select_worker_with_headers(
-            &workers,
-            request_text.as_deref(),
-            request_headers.as_ref(),
-        ) {
-            Some(idx) => idx,
-            None => {
-                return (
+        let response = {
+            // Select a worker (filter by availability like select_worker_for_model)
+            let all_workers = self.worker_registry.get_all();
+            let workers: Vec<Arc<dyn Worker>> = all_workers
+                .iter()
+                .filter(|w| w.is_available())
+                .cloned()
+                .collect();
+            if workers.is_empty() {
+                (
                     StatusCode::SERVICE_UNAVAILABLE,
-                    "Failed to select a worker".to_string(),
+                    "No available workers".to_string(),
                 )
-                    .into_response();
-            }
-        };
-
-        let worker: &dyn Worker = workers[worker_idx].as_ref();
-        let url = worker.endpoint_url(path);
-
-        debug!("Transparent proxy: forwarding to {}", url);
-
-        // Build the request
-        let mut request_builder = match *method {
-            Method::GET => self.client.get(&url),
-            Method::POST => self.client.post(&url),
-            Method::PUT => self.client.put(&url),
-            Method::DELETE => self.client.delete(&url),
-            Method::PATCH => self.client.patch(&url),
-            Method::HEAD => self.client.head(&url),
-            _ => {
-                return (
-                    StatusCode::METHOD_NOT_ALLOWED,
-                    format!("Method {} not supported", method),
-                )
-                    .into_response();
-            }
-        };
-
-        // Add X-data-parallel-rank header for DP-aware routing
-        request_builder = dp_utils::add_dp_rank_header(request_builder, worker.dp_rank());
-
-        // Add JSON body if not null/empty
-        if !body.is_null() {
-            request_builder = request_builder.json(&body);
-        }
-
-        // Add authorization if configured
-        if let Some(ref key) = self.api_key {
-            request_builder = request_builder.header("Authorization", format!("Bearer {}", key));
-        }
-
-        // Send request
-        match otel_http::send_client_request(
-            request_builder,
-            headers,
-            ClientRequestOptions {
-                method: method.as_str(),
-                url: &url,
-                route: Some(path),
-                request_phase: Some("inference"),
-            },
-        )
-        .await
-        {
-            Ok(response) => {
-                let status = response.status();
-                let headers = response.headers().clone();
-
-                // Stream the response body
-                let body = Body::from_stream(response.bytes_stream());
-                let mut response_builder = Response::builder().status(status.as_u16());
-
-                for (name, value) in headers.iter() {
-                    if name != "transfer-encoding" && name != "content-length" {
-                        response_builder = response_builder.header(name, value);
+                    .into_response()
+            } else {
+                let policy = self.policy_registry.get_default_policy();
+                let request_text = serde_json::to_string(&body).ok();
+                let request_headers = Self::headers_to_request_headers(headers);
+                let worker_idx = match policy.select_worker_with_headers(
+                    &workers,
+                    request_text.as_deref(),
+                    request_headers.as_ref(),
+                ) {
+                    Some(idx) => idx,
+                    None => {
+                        return Self::finish_regular_request(
+                            path,
+                            method.as_str(),
+                            start_time,
+                            (
+                                StatusCode::SERVICE_UNAVAILABLE,
+                                "Failed to select a worker".to_string(),
+                            )
+                                .into_response(),
+                        );
                     }
+                };
+
+                let worker: &dyn Worker = workers[worker_idx].as_ref();
+                let url = worker.endpoint_url(path);
+
+                debug!("Transparent proxy: forwarding to {}", url);
+
+                // Build the request
+                let mut request_builder = match *method {
+                    Method::GET => self.client.get(&url),
+                    Method::POST => self.client.post(&url),
+                    Method::PUT => self.client.put(&url),
+                    Method::DELETE => self.client.delete(&url),
+                    Method::PATCH => self.client.patch(&url),
+                    Method::HEAD => self.client.head(&url),
+                    _ => {
+                        return Self::finish_regular_request(
+                            path,
+                            method.as_str(),
+                            start_time,
+                            (
+                                StatusCode::METHOD_NOT_ALLOWED,
+                                format!("Method {} not supported", method),
+                            )
+                                .into_response(),
+                        );
+                    }
+                };
+
+                // Add X-data-parallel-rank header for DP-aware routing
+                request_builder = dp_utils::add_dp_rank_header(request_builder, worker.dp_rank());
+
+                // Add JSON body if not null/empty
+                if !body.is_null() {
+                    request_builder = request_builder.json(&body);
                 }
 
-                match response_builder.body(body) {
-                    Ok(response) => response,
+                // Add authorization if configured
+                if let Some(ref key) = self.api_key {
+                    request_builder =
+                        request_builder.header("Authorization", format!("Bearer {}", key));
+                }
+
+                // Send request
+                let request_start = Instant::now();
+                match otel_http::send_client_request(
+                    request_builder,
+                    headers,
+                    ClientRequestOptions {
+                        method: method.as_str(),
+                        url: &url,
+                        route: Some(path),
+                        request_phase: Some("inference"),
+                    },
+                )
+                .await
+                {
+                    Ok(backend_response) => {
+                        let status = StatusCode::from_u16(backend_response.status().as_u16())
+                            .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+                        Self::observe_backend_response(
+                            path,
+                            worker.url(),
+                            method.as_str(),
+                            status,
+                            request_start.elapsed(),
+                        );
+                        let headers = backend_response.headers().clone();
+
+                        // Stream the response body
+                        let body = Body::from_stream(backend_response.bytes_stream());
+                        let mut response_builder = Response::builder().status(status.as_u16());
+
+                        for (name, value) in headers.iter() {
+                            if name != "transfer-encoding" && name != "content-length" {
+                                response_builder = response_builder.header(name, value);
+                            }
+                        }
+
+                        match response_builder.body(body) {
+                            Ok(response) => response,
+                            Err(e) => (
+                                StatusCode::INTERNAL_SERVER_ERROR,
+                                format!("Failed to build response: {}", e),
+                            )
+                                .into_response(),
+                        }
+                    }
                     Err(e) => (
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        format!("Failed to build response: {}", e),
+                        StatusCode::BAD_GATEWAY,
+                        format!("Backend request failed: {}", e),
                     )
                         .into_response(),
                 }
             }
-            Err(e) => (
-                StatusCode::BAD_GATEWAY,
-                format!("Backend request failed: {}", e),
-            )
-                .into_response(),
-        }
+        };
+
+        Self::finish_regular_request(path, method.as_str(), start_time, response)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use axum::{extract::State, routing::any, Json, Router as AxumRouter};
+    use metrics::set_default_local_recorder;
+    use metrics_exporter_prometheus::PrometheusBuilder;
+    use serde_json::json;
     use std::collections::HashMap;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use tokio::net::TcpListener;
+
+    #[derive(Clone)]
+    struct ResponseSequenceState {
+        statuses: Arc<Vec<StatusCode>>,
+        attempts: Arc<AtomicUsize>,
+    }
+
+    fn build_test_recorder() -> metrics_exporter_prometheus::PrometheusRecorder {
+        PrometheusBuilder::new().build_recorder()
+    }
+
+    fn assert_metric_line(rendered: &str, prefix: &str, fragments: &[&str], suffix: &str) {
+        assert!(
+            rendered.lines().any(|line| {
+                line.starts_with(prefix)
+                    && fragments.iter().all(|fragment| line.contains(fragment))
+                    && line.ends_with(suffix)
+            }),
+            "missing metric line: prefix={prefix}, fragments={fragments:?}, suffix={suffix}\n{rendered}"
+        );
+    }
+
+    async fn response_sequence_handler(State(state): State<ResponseSequenceState>) -> Response {
+        let attempt = state.attempts.fetch_add(1, Ordering::SeqCst);
+        let status = state
+            .statuses
+            .get(attempt)
+            .copied()
+            .or_else(|| state.statuses.last().copied())
+            .unwrap_or(StatusCode::OK);
+        (
+            status,
+            Json(json!({
+                "attempt": attempt + 1,
+                "status": status.as_u16(),
+            })),
+        )
+            .into_response()
+    }
+
+    async fn start_status_sequence_server(
+        route: &str,
+        statuses: Vec<StatusCode>,
+    ) -> (String, tokio::task::JoinHandle<()>) {
+        let state = ResponseSequenceState {
+            statuses: Arc::new(statuses),
+            attempts: Arc::new(AtomicUsize::new(0)),
+        };
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let app = AxumRouter::new()
+            .route(route, any(response_sequence_handler))
+            .with_state(state);
+        let handle = tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        (format!("http://{}", addr), handle)
+    }
+
+    fn create_router_with_worker_urls(worker_urls: &[String], retry_config: RetryConfig) -> Router {
+        let worker_registry = Arc::new(WorkerRegistry::new());
+        let policy_registry = Arc::new(PolicyRegistry::new(
+            crate::config::types::PolicyConfig::RoundRobin,
+        ));
+
+        for worker_url in worker_urls {
+            worker_registry.register(Arc::new(BasicWorker::new(
+                worker_url.clone(),
+                WorkerType::Regular,
+            )));
+        }
+
+        let (_, rx) = tokio::sync::watch::channel(HashMap::new());
+        Router {
+            worker_registry,
+            policy_registry,
+            worker_startup_timeout_secs: 5,
+            worker_startup_check_interval_secs: 1,
+            intra_node_data_parallel_size: 1,
+            api_key: None,
+            client: Client::new(),
+            retry_config,
+            circuit_breaker_config: CircuitBreakerConfig::default(),
+            _worker_loads: Arc::new(rx),
+            _load_monitor_handle: None,
+        }
+    }
 
     fn create_test_regular_router() -> Router {
         // Create registries
@@ -2224,5 +2414,246 @@ mod tests {
         );
 
         health_checker.shutdown().await;
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_route_generate_records_retryable_backend_and_final_status_metrics() {
+        let (worker_url, server_handle) = start_status_sequence_server(
+            "/generate",
+            vec![StatusCode::SERVICE_UNAVAILABLE, StatusCode::OK],
+        )
+        .await;
+        let retry_config = RetryConfig {
+            max_retries: 2,
+            initial_backoff_ms: 1,
+            max_backoff_ms: 1,
+            backoff_multiplier: 1.0,
+            jitter_factor: 0.0,
+        };
+        let router = create_router_with_worker_urls(&[worker_url.clone()], retry_config);
+
+        let recorder = build_test_recorder();
+        let handle = recorder.handle();
+        let _recorder_guard = set_default_local_recorder(&recorder);
+
+        let response = router
+            .route_generate(
+                None,
+                &GenerateRequest {
+                    text: Some("retry me".to_string()),
+                    prompt: None,
+                    input_ids: None,
+                    stream: false,
+                    parameters: None,
+                    sampling_params: None,
+                    return_logprob: false,
+                    lora_path: None,
+                    session_params: None,
+                    return_hidden_states: false,
+                    rid: None,
+                },
+                None,
+            )
+            .await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let _ = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+
+        let rendered = handle.render();
+        let route = "route=\"/generate\"";
+        let method = "http_request_method=\"POST\"";
+        let worker = format!("worker=\"{worker_url}\"");
+
+        assert_metric_line(
+            &rendered,
+            "vllm_router_backend_http_responses_total{",
+            &[
+                route,
+                worker.as_str(),
+                "vllm_request_phase=\"inference\"",
+                method,
+                "http_response_status_code=\"503\"",
+                "http_response_status_class=\"5xx\"",
+            ],
+            " 1",
+        );
+        assert_metric_line(
+            &rendered,
+            "vllm_router_backend_http_responses_total{",
+            &[
+                route,
+                worker.as_str(),
+                "vllm_request_phase=\"inference\"",
+                method,
+                "http_response_status_code=\"200\"",
+                "http_response_status_class=\"2xx\"",
+            ],
+            " 1",
+        );
+        assert_metric_line(
+            &rendered,
+            "vllm_router_backend_http_response_duration_seconds_count{",
+            &[
+                route,
+                worker.as_str(),
+                "vllm_request_phase=\"inference\"",
+                method,
+                "http_response_status_code=\"503\"",
+                "http_response_status_class=\"5xx\"",
+            ],
+            " 1",
+        );
+        assert_metric_line(
+            &rendered,
+            "vllm_router_http_responses_total{",
+            &[
+                route,
+                method,
+                "http_response_status_code=\"200\"",
+                "http_response_status_class=\"2xx\"",
+            ],
+            " 1",
+        );
+        assert_metric_line(
+            &rendered,
+            "vllm_router_http_response_duration_seconds_count{",
+            &[
+                route,
+                method,
+                "http_response_status_code=\"200\"",
+                "http_response_status_class=\"2xx\"",
+            ],
+            " 1",
+        );
+        assert!(
+            !rendered.lines().any(|line| {
+                line.starts_with("vllm_router_http_responses_total{")
+                    && line.contains(route)
+                    && line.contains("http_response_status_code=\"503\"")
+            }),
+            "final response metrics should reflect only the client-visible response\n{rendered}"
+        );
+
+        server_handle.abort();
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_get_response_uses_normalized_route_label_for_status_metrics() {
+        let (worker_url, server_handle) =
+            start_status_sequence_server("/v1/responses/{response_id}", vec![StatusCode::OK]).await;
+        let router = create_router_with_worker_urls(&[worker_url.clone()], RetryConfig::default());
+
+        let recorder = build_test_recorder();
+        let handle = recorder.handle();
+        let _recorder_guard = set_default_local_recorder(&recorder);
+
+        let response = router.get_response(None, "resp_123").await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let _ = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+
+        let rendered = handle.render();
+        let normalized_route = "route=\"/v1/responses/{response_id}\"";
+        let raw_route = "route=\"/v1/responses/resp_123\"";
+        let method = "http_request_method=\"GET\"";
+        let worker = format!("worker=\"{worker_url}\"");
+
+        assert_metric_line(
+            &rendered,
+            "vllm_router_backend_http_responses_total{",
+            &[
+                normalized_route,
+                worker.as_str(),
+                "vllm_request_phase=\"inference\"",
+                method,
+                "http_response_status_code=\"200\"",
+                "http_response_status_class=\"2xx\"",
+            ],
+            " 1",
+        );
+        assert_metric_line(
+            &rendered,
+            "vllm_router_http_responses_total{",
+            &[
+                normalized_route,
+                method,
+                "http_response_status_code=\"200\"",
+                "http_response_status_class=\"2xx\"",
+            ],
+            " 1",
+        );
+        assert!(
+            !rendered.contains(raw_route),
+            "raw response IDs should not appear in status metric labels\n{rendered}"
+        );
+
+        server_handle.abort();
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_route_transparent_records_status_metrics_for_client_and_backend() {
+        let (worker_url, server_handle) =
+            start_status_sequence_server("/v1/responses", vec![StatusCode::TOO_MANY_REQUESTS])
+                .await;
+        let router = create_router_with_worker_urls(&[worker_url.clone()], RetryConfig::default());
+
+        let recorder = build_test_recorder();
+        let handle = recorder.handle();
+        let _recorder_guard = set_default_local_recorder(&recorder);
+
+        let response = router
+            .route_transparent(
+                None,
+                "/v1/responses",
+                &Method::POST,
+                json!({
+                    "model": "mock-model",
+                    "input": "transparent route",
+                }),
+            )
+            .await;
+        assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+        let _ = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+
+        let rendered = handle.render();
+        let route = "route=\"/v1/responses\"";
+        let method = "http_request_method=\"POST\"";
+        let worker = format!("worker=\"{worker_url}\"");
+
+        assert_metric_line(
+            &rendered,
+            "vllm_router_backend_http_responses_total{",
+            &[
+                route,
+                worker.as_str(),
+                "vllm_request_phase=\"inference\"",
+                method,
+                "http_response_status_code=\"429\"",
+                "http_response_status_class=\"4xx\"",
+            ],
+            " 1",
+        );
+        assert_metric_line(
+            &rendered,
+            "vllm_router_http_responses_total{",
+            &[
+                route,
+                method,
+                "http_response_status_code=\"429\"",
+                "http_response_status_class=\"4xx\"",
+            ],
+            " 1",
+        );
+        assert_metric_line(
+            &rendered,
+            "vllm_router_http_response_duration_seconds_count{",
+            &[
+                route,
+                method,
+                "http_response_status_code=\"429\"",
+                "http_response_status_class=\"4xx\"",
+            ],
+            " 1",
+        );
+
+        server_handle.abort();
     }
 }

--- a/src/routers/http/router.rs
+++ b/src/routers/http/router.rs
@@ -547,74 +547,89 @@ impl Router {
         let start = Instant::now();
         let is_stream = typed_req.is_stream();
         let text = typed_req.extract_text_for_routing();
+        let last_error_type = Arc::new(std::sync::Mutex::new(None::<&'static str>));
 
         let response = RetryExecutor::execute_response_with_retry(
             &self.retry_config,
             // operation per attempt
-            |_: u32| async {
-                let worker = match self.select_worker_for_model(model_id, Some(&text), headers) {
-                    Some(w) => w,
-                    None => {
-                        RouterMetrics::record_request_error(route, "no_available_workers");
-                        return (
-                            StatusCode::SERVICE_UNAVAILABLE,
-                            "No available workers (all circuits open or unhealthy)",
-                        )
-                            .into_response();
-                    }
-                };
+            {
+                let last_error_type = Arc::clone(&last_error_type);
+                move |_: u32| {
+                    let last_error_type = Arc::clone(&last_error_type);
+                    let text = text.clone();
+                    async move {
+                        let worker =
+                            match self.select_worker_for_model(model_id, Some(&text), headers) {
+                                Some(w) => w,
+                                None => {
+                                    *last_error_type
+                                        .lock()
+                                        .expect("request error mutex poisoned") =
+                                        Some("no_available_workers");
+                                    return (
+                                        StatusCode::SERVICE_UNAVAILABLE,
+                                        "No available workers (all circuits open or unhealthy)",
+                                    )
+                                        .into_response();
+                                }
+                            };
+                        *last_error_type
+                            .lock()
+                            .expect("request error mutex poisoned") = None;
 
-                // Optional load tracking for cache-aware policy
-                // Get the policy for this model to check if it's cache-aware
-                let policy = match model_id {
-                    Some(model) => self.policy_registry.get_policy_or_default(model),
-                    None => self.policy_registry.get_default_policy(),
-                };
+                        // Optional load tracking for cache-aware policy
+                        // Get the policy for this model to check if it's cache-aware
+                        let policy = match model_id {
+                            Some(model) => self.policy_registry.get_policy_or_default(model),
+                            None => self.policy_registry.get_default_policy(),
+                        };
 
-                let load_incremented = if policy.name() == "cache_aware" {
-                    worker.increment_load();
-                    RouterMetrics::set_running_requests(worker.url(), worker.load());
-                    true
-                } else {
-                    false
-                };
+                        let load_incremented = if policy.name() == "cache_aware" {
+                            worker.increment_load();
+                            RouterMetrics::set_running_requests(worker.url(), worker.load());
+                            true
+                        } else {
+                            false
+                        };
 
-                // Keep a clone for potential cleanup on retry
-                let worker_for_cleanup = if load_incremented {
-                    Some(worker.clone())
-                } else {
-                    None
-                };
+                        // Keep a clone for potential cleanup on retry
+                        let worker_for_cleanup = if load_incremented {
+                            Some(worker.clone())
+                        } else {
+                            None
+                        };
 
-                let response = self
-                    .send_typed_request(
-                        headers,
-                        typed_req,
-                        route,
-                        worker.url(),
-                        is_stream,
-                        load_incremented,
-                    )
-                    .await;
+                        let response = self
+                            .send_typed_request(
+                                headers,
+                                typed_req,
+                                route,
+                                worker.url(),
+                                is_stream,
+                                load_incremented,
+                            )
+                            .await;
 
-                // Client errors (4xx) are not worker failures - only server errors (5xx)
-                // should count against the circuit breaker. This matches pd_router.rs behavior.
-                let status = response.status();
-                worker.record_outcome(status.is_success() || status.is_client_error());
+                        // Client errors (4xx) are not worker failures - only server errors (5xx)
+                        // should count against the circuit breaker. This matches pd_router.rs behavior.
+                        let status = response.status();
+                        worker.record_outcome(status.is_success() || status.is_client_error());
 
-                // For retryable failures, we need to decrement load since send_typed_request
-                // won't have done it (it only decrements on success or non-retryable failures)
-                if is_retryable_status(response.status()) && load_incremented {
-                    if let Some(cleanup_worker) = worker_for_cleanup {
-                        cleanup_worker.decrement_load();
-                        RouterMetrics::set_running_requests(
-                            cleanup_worker.url(),
-                            cleanup_worker.load(),
-                        );
+                        // For retryable failures, we need to decrement load since send_typed_request
+                        // won't have done it (it only decrements on success or non-retryable failures)
+                        if is_retryable_status(response.status()) && load_incremented {
+                            if let Some(cleanup_worker) = worker_for_cleanup {
+                                cleanup_worker.decrement_load();
+                                RouterMetrics::set_running_requests(
+                                    cleanup_worker.url(),
+                                    cleanup_worker.load(),
+                                );
+                            }
+                        }
+
+                        response
                     }
                 }
-
-                response
             },
             // should_retry predicate
             |res, _attempt| is_retryable_status(res.status()),
@@ -628,12 +643,17 @@ impl Router {
         )
         .await;
 
-        if response.status().is_success() {
-            let duration = start.elapsed();
-            RouterMetrics::record_request(route);
-            RouterMetrics::record_generate_duration(duration);
-        } else if !is_retryable_status(response.status()) {
-            RouterMetrics::record_request_error(route, "non_retryable_error");
+        let status = response.status();
+        if status.is_success() {
+            RouterMetrics::record_generate_duration(start.elapsed());
+        } else if let Some(error_type) = last_error_type
+            .lock()
+            .expect("request error mutex poisoned")
+            .take()
+        {
+            RouterMetrics::record_request_error(route, "POST", status, error_type);
+        } else if !is_retryable_status(status) {
+            RouterMetrics::record_request_error(route, "POST", status, "non_retryable_error");
         }
 
         response
@@ -1505,8 +1525,7 @@ impl RouterTrait for Router {
             RouterMetrics::record_embeddings_request();
             RouterMetrics::record_embeddings_duration(start.elapsed());
         } else {
-            let error_type = format!("http_{}", res.status().as_u16());
-            RouterMetrics::record_embeddings_error(&error_type);
+            RouterMetrics::record_embeddings_error(res.status());
         }
 
         res

--- a/src/routers/http/router.rs
+++ b/src/routers/http/router.rs
@@ -423,13 +423,14 @@ impl Router {
 
     // Helper method to proxy GET requests to the first available worker
     async fn proxy_get_request(&self, req: Request<Body>, endpoint: &str) -> Response {
+        let start_time = Instant::now();
         let incoming_headers = req.headers();
         let headers = header_utils::copy_request_headers(&req);
+        let route_name = format!("/{}", endpoint);
 
-        match self.select_first_worker() {
+        let response = match self.select_first_worker() {
             Ok(worker_url) => {
                 let url = format!("{}/{}", worker_url, endpoint);
-                let route_name = format!("/{}", endpoint);
                 let mut request_builder = self.client.get(&url);
                 for (name, value) in headers {
                     let name_lc = name.to_lowercase();
@@ -441,6 +442,7 @@ impl Router {
                     }
                 }
 
+                let request_start = Instant::now();
                 match otel_http::send_client_request(
                     request_builder,
                     Some(incoming_headers),
@@ -456,6 +458,13 @@ impl Router {
                     Ok(res) => {
                         let status = StatusCode::from_u16(res.status().as_u16())
                             .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+                        Self::observe_backend_response(
+                            &route_name,
+                            &worker_url,
+                            "GET",
+                            status,
+                            request_start.elapsed(),
+                        );
 
                         // Preserve headers from backend
                         let response_headers =
@@ -483,7 +492,9 @@ impl Router {
                 }
             }
             Err(e) => (StatusCode::SERVICE_UNAVAILABLE, e).into_response(),
-        }
+        };
+
+        Self::finish_regular_request(&route_name, "GET", start_time, response)
     }
 
     /// Convert axum HeaderMap to policy RequestHeaders (HashMap<String, String>)
@@ -2414,6 +2425,81 @@ mod tests {
         );
 
         health_checker.shutdown().await;
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_proxy_get_request_records_status_metrics_for_client_and_backend() {
+        let (worker_url, server_handle) =
+            start_status_sequence_server("/v1/models", vec![StatusCode::OK]).await;
+        let router = create_router_with_worker_urls(&[worker_url.clone()], RetryConfig::default());
+
+        let recorder = build_test_recorder();
+        let handle = recorder.handle();
+        let _recorder_guard = set_default_local_recorder(&recorder);
+
+        let request = Request::builder()
+            .uri("/v1/models")
+            .body(Body::empty())
+            .unwrap();
+        let response = router.get_models(request).await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let _ = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+
+        let rendered = handle.render();
+        let route = "route=\"/v1/models\"";
+        let method = "http_request_method=\"GET\"";
+        let worker = format!("worker=\"{worker_url}\"");
+
+        assert_metric_line(
+            &rendered,
+            "vllm_router_backend_http_responses_total{",
+            &[
+                route,
+                worker.as_str(),
+                "vllm_request_phase=\"inference\"",
+                method,
+                "http_response_status_code=\"200\"",
+                "http_response_status_class=\"2xx\"",
+            ],
+            " 1",
+        );
+        assert_metric_line(
+            &rendered,
+            "vllm_router_backend_http_response_duration_seconds_count{",
+            &[
+                route,
+                worker.as_str(),
+                "vllm_request_phase=\"inference\"",
+                method,
+                "http_response_status_code=\"200\"",
+                "http_response_status_class=\"2xx\"",
+            ],
+            " 1",
+        );
+        assert_metric_line(
+            &rendered,
+            "vllm_router_http_responses_total{",
+            &[
+                route,
+                method,
+                "http_response_status_code=\"200\"",
+                "http_response_status_class=\"2xx\"",
+            ],
+            " 1",
+        );
+        assert_metric_line(
+            &rendered,
+            "vllm_router_http_response_duration_seconds_count{",
+            &[
+                route,
+                method,
+                "http_response_status_code=\"200\"",
+                "http_response_status_class=\"2xx\"",
+            ],
+            " 1",
+        );
+
+        server_handle.abort();
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/src/routers/http/router.rs
+++ b/src/routers/http/router.rs
@@ -2431,7 +2431,10 @@ mod tests {
     async fn test_proxy_get_request_records_status_metrics_for_client_and_backend() {
         let (worker_url, server_handle) =
             start_status_sequence_server("/v1/models", vec![StatusCode::OK]).await;
-        let router = create_router_with_worker_urls(&[worker_url.clone()], RetryConfig::default());
+        let router = create_router_with_worker_urls(
+            std::slice::from_ref(&worker_url),
+            RetryConfig::default(),
+        );
 
         let recorder = build_test_recorder();
         let handle = recorder.handle();
@@ -2516,7 +2519,8 @@ mod tests {
             backoff_multiplier: 1.0,
             jitter_factor: 0.0,
         };
-        let router = create_router_with_worker_urls(&[worker_url.clone()], retry_config);
+        let router =
+            create_router_with_worker_urls(std::slice::from_ref(&worker_url), retry_config);
 
         let recorder = build_test_recorder();
         let handle = recorder.handle();
@@ -2626,7 +2630,10 @@ mod tests {
     async fn test_get_response_uses_normalized_route_label_for_status_metrics() {
         let (worker_url, server_handle) =
             start_status_sequence_server("/v1/responses/{response_id}", vec![StatusCode::OK]).await;
-        let router = create_router_with_worker_urls(&[worker_url.clone()], RetryConfig::default());
+        let router = create_router_with_worker_urls(
+            std::slice::from_ref(&worker_url),
+            RetryConfig::default(),
+        );
 
         let recorder = build_test_recorder();
         let handle = recorder.handle();
@@ -2679,7 +2686,10 @@ mod tests {
         let (worker_url, server_handle) =
             start_status_sequence_server("/v1/responses", vec![StatusCode::TOO_MANY_REQUESTS])
                 .await;
-        let router = create_router_with_worker_urls(&[worker_url.clone()], RetryConfig::default());
+        let router = create_router_with_worker_urls(
+            std::slice::from_ref(&worker_url),
+            RetryConfig::default(),
+        );
 
         let recorder = build_test_recorder();
         let handle = recorder.handle();

--- a/src/routers/http/vllm_pd_router.rs
+++ b/src/routers/http/vllm_pd_router.rs
@@ -229,6 +229,26 @@ impl VllmPDRouter {
         policy.select_worker(&workers, request_text)
     }
 
+    fn server_selection_error_response(route: &str, message: impl Into<String>) -> Response {
+        RouterMetrics::record_pd_error(
+            route,
+            "POST",
+            StatusCode::SERVICE_UNAVAILABLE,
+            "server_selection",
+        );
+        (StatusCode::SERVICE_UNAVAILABLE, message.into()).into_response()
+    }
+
+    fn finish_pd_request(
+        route: &str,
+        method: &str,
+        start_time: Instant,
+        response: Response,
+    ) -> Response {
+        RouterMetrics::observe_pd_request(route, method, response.status(), start_time.elapsed());
+        response
+    }
+
     /// Process vLLM request using pure service discovery
     async fn process_vllm_request(
         &self,
@@ -253,16 +273,14 @@ impl VllmPDRouter {
         );
 
         if prefill_instances.is_empty() || decode_instances.is_empty() {
-            RouterMetrics::record_pd_error("server_selection");
-            return (
-                axum::http::StatusCode::SERVICE_UNAVAILABLE,
+            return Self::server_selection_error_response(
+                path,
                 format!(
                     "No workers available via service discovery: {} prefill, {} decode",
                     prefill_instances.len(),
                     decode_instances.len()
                 ),
-            )
-                .into_response();
+            );
         }
 
         // Use policy-based load balancing to select prefill and decode workers
@@ -273,12 +291,10 @@ impl VllmPDRouter {
             match self.select_worker_with_policy(&prefill_instances, true, request_str) {
                 Some(idx) => idx,
                 None => {
-                    RouterMetrics::record_pd_error("server_selection");
-                    return (
-                        axum::http::StatusCode::SERVICE_UNAVAILABLE,
-                        "Prefill policy failed to select a worker".to_string(),
-                    )
-                        .into_response();
+                    return Self::server_selection_error_response(
+                        path,
+                        "Prefill policy failed to select a worker",
+                    );
                 }
             };
 
@@ -286,12 +302,10 @@ impl VllmPDRouter {
         {
             Some(idx) => idx,
             None => {
-                RouterMetrics::record_pd_error("server_selection");
-                return (
-                    axum::http::StatusCode::SERVICE_UNAVAILABLE,
-                    "Decode policy failed to select a worker".to_string(),
-                )
-                    .into_response();
+                return Self::server_selection_error_response(
+                    path,
+                    "Decode policy failed to select a worker",
+                );
             }
         };
 
@@ -350,7 +364,6 @@ impl VllmPDRouter {
         let (decode_http, decode_zmq) = decode_instance;
 
         debug!("ENTERED process_vllm_two_stage_request_discovered method");
-        let start_time = Instant::now();
         debug!(
             "Prefill: HTTP={}, ZMQ={}, Decode: HTTP={}, ZMQ={}, Path: {}",
             prefill_http, prefill_zmq, decode_http, decode_zmq, path
@@ -436,10 +449,7 @@ impl VllmPDRouter {
             Ok(resp) => resp,
             Err(e) => {
                 let full_error = error_chain(&e);
-                let duration = start_time.elapsed();
-                RouterMetrics::record_pd_prefill_error(prefill_http);
-                RouterMetrics::record_pd_request(path);
-                RouterMetrics::record_pd_request_duration(path, duration);
+                RouterMetrics::record_pd_prefill_error(prefill_http, "transport", None);
                 return Err(format!(
                     "Prefill request failed to {}: {}",
                     prefill_http, full_error
@@ -449,12 +459,14 @@ impl VllmPDRouter {
 
         let prefill_status = prefill_response.status();
         debug!("Prefill server responded with status: {}", prefill_status);
+        RouterMetrics::record_pd_prefill_request(prefill_http, prefill_status);
 
         if !prefill_status.is_success() {
-            let duration = start_time.elapsed();
-            RouterMetrics::record_pd_prefill_error(prefill_http);
-            RouterMetrics::record_pd_request(path);
-            RouterMetrics::record_pd_request_duration(path, duration);
+            RouterMetrics::record_pd_prefill_error(
+                prefill_http,
+                "http_response",
+                Some(prefill_status),
+            );
             let error_body = prefill_response.text().await.unwrap_or_default();
             return Err(format!(
                 "Prefill server error {}: {}",
@@ -463,18 +475,29 @@ impl VllmPDRouter {
         }
 
         // Extract kv_transfer_params from prefill response
-        let prefill_response_text = prefill_response.text().await.map_err(|e| {
-            let full_error = error_chain(&e);
-            format!(
-                "Failed to read prefill response from {}: {}",
-                prefill_http, full_error
-            )
-        })?;
+        let prefill_response_text = match prefill_response.text().await {
+            Ok(text) => text,
+            Err(e) => {
+                let full_error = error_chain(&e);
+                RouterMetrics::record_pd_prefill_error(
+                    prefill_http,
+                    "body_read",
+                    Some(prefill_status),
+                );
+                return Err(format!(
+                    "Failed to read prefill response from {}: {}",
+                    prefill_http, full_error
+                ));
+            }
+        };
 
         debug!("Prefill response body: {}", prefill_response_text);
 
-        let prefill_response_json: Value = serde_json::from_str(&prefill_response_text)
-            .map_err(|e| format!("Failed to parse prefill response as JSON: {}", e))?;
+        let prefill_response_json: Value =
+            serde_json::from_str(&prefill_response_text).map_err(|e| {
+                RouterMetrics::record_pd_prefill_error(prefill_http, "parse", Some(prefill_status));
+                format!("Failed to parse prefill response as JSON: {}", e)
+            })?;
 
         // Extract kv_transfer_params from prefill response if present
         let kv_transfer_params = prefill_response_json.get("kv_transfer_params").cloned();
@@ -554,11 +577,7 @@ impl VllmPDRouter {
             Ok(resp) => resp,
             Err(e) => {
                 let full_error = error_chain(&e);
-                let duration = start_time.elapsed();
-                RouterMetrics::record_pd_decode_error(decode_http);
-                RouterMetrics::record_pd_request(path);
-                RouterMetrics::record_pd_request_duration(path, duration);
-                RouterMetrics::record_pd_prefill_request(prefill_http);
+                RouterMetrics::record_pd_decode_error(decode_http, "transport", None);
                 return Err(format!(
                     "Decode request failed to {}: {}",
                     decode_http, full_error
@@ -570,20 +589,19 @@ impl VllmPDRouter {
             "Decode server responded with status: {}",
             decode_response.status()
         );
+        let decode_status = decode_response.status();
+        RouterMetrics::record_pd_decode_request(decode_http, decode_status);
 
         // Stop profiling on decode server after response received
         self.stop_profiling(&format!("http://{}", decode_base_http))
             .await;
 
-        // Record PD metrics
-        let duration = start_time.elapsed();
-        RouterMetrics::record_pd_request(path);
-        RouterMetrics::record_pd_request_duration(path, duration);
-        RouterMetrics::record_pd_prefill_request(prefill_http);
-        RouterMetrics::record_pd_decode_request(decode_http);
-
-        if !decode_response.status().is_success() {
-            RouterMetrics::record_pd_decode_error(decode_http);
+        if !decode_status.is_success() {
+            RouterMetrics::record_pd_decode_error(
+                decode_http,
+                "http_response",
+                Some(decode_status),
+            );
         }
 
         // Check if logprobs merging is needed
@@ -676,7 +694,6 @@ impl VllmPDRouter {
         headers: Option<&HeaderMap>,
     ) -> Result<Response, PDRouterError> {
         debug!("ENTERED process_vllm_two_stage_request method");
-        let start_time = Instant::now();
         debug!(
             "Prefill worker: {}, Decode worker: {}, Path: {}",
             prefill_worker.url(),
@@ -777,17 +794,16 @@ impl VllmPDRouter {
             Err(e) => {
                 prefill_worker.decrement_load();
                 let full_error = error_chain(&e);
-                let duration = start_time.elapsed();
-                RouterMetrics::record_pd_prefill_error(&prefill_base_url);
-                RouterMetrics::record_pd_request(path);
-                RouterMetrics::record_pd_request_duration(path, duration);
+                RouterMetrics::record_pd_prefill_error(&prefill_base_url, "transport", None);
                 return Err(PDRouterError::NetworkError {
                     message: format!("Prefill request failed to {}: {}", prefill_url, full_error),
                 });
             }
         };
 
-        debug!("📥 Prefill response status: {}", prefill_response.status());
+        let prefill_status = prefill_response.status();
+        RouterMetrics::record_pd_prefill_request(&prefill_base_url, prefill_status);
+        debug!("📥 Prefill response status: {}", prefill_status);
         debug!(
             "📥 Prefill response headers: {:?}",
             prefill_response.headers()
@@ -799,10 +815,11 @@ impl VllmPDRouter {
             Err(e) => {
                 prefill_worker.decrement_load();
                 let full_error = error_chain(&e);
-                let duration = start_time.elapsed();
-                RouterMetrics::record_pd_prefill_error(&prefill_base_url);
-                RouterMetrics::record_pd_request(path);
-                RouterMetrics::record_pd_request_duration(path, duration);
+                RouterMetrics::record_pd_prefill_error(
+                    &prefill_base_url,
+                    "body_read",
+                    Some(prefill_status),
+                );
                 return Err(PDRouterError::NetworkError {
                     message: format!(
                         "Failed to read prefill response from {}: {}",
@@ -811,6 +828,22 @@ impl VllmPDRouter {
                 });
             }
         };
+
+        if !prefill_status.is_success() {
+            prefill_worker.decrement_load();
+            RouterMetrics::record_pd_prefill_error(
+                &prefill_base_url,
+                "http_response",
+                Some(prefill_status),
+            );
+            return Err(PDRouterError::NetworkError {
+                message: format!(
+                    "Prefill server error {}: {}",
+                    prefill_status,
+                    String::from_utf8_lossy(&prefill_bytes)
+                ),
+            });
+        }
 
         debug!(
             "📥 Prefill response body size: {} bytes",
@@ -828,10 +861,11 @@ impl VllmPDRouter {
             Ok(json) => json,
             Err(e) => {
                 prefill_worker.decrement_load();
-                let duration = start_time.elapsed();
-                RouterMetrics::record_pd_prefill_error(&prefill_base_url);
-                RouterMetrics::record_pd_request(path);
-                RouterMetrics::record_pd_request_duration(path, duration);
+                RouterMetrics::record_pd_prefill_error(
+                    &prefill_base_url,
+                    "parse",
+                    Some(prefill_status),
+                );
                 return Err(PDRouterError::NetworkError {
                     message: format!("Failed to parse prefill response as JSON: {}", e),
                 });
@@ -926,11 +960,7 @@ impl VllmPDRouter {
             Err(e) => {
                 decode_worker.decrement_load();
                 let full_error = error_chain(&e);
-                let duration = start_time.elapsed();
-                RouterMetrics::record_pd_decode_error(&decode_base_url);
-                RouterMetrics::record_pd_request(path);
-                RouterMetrics::record_pd_request_duration(path, duration);
-                RouterMetrics::record_pd_prefill_request(&prefill_base_url);
+                RouterMetrics::record_pd_decode_error(&decode_base_url, "transport", None);
                 return Err(PDRouterError::NetworkError {
                     message: format!("Decode request failed to {}: {}", decode_url, full_error),
                 });
@@ -944,20 +974,14 @@ impl VllmPDRouter {
         decode_worker.decrement_load();
 
         let status = decode_response.status();
+        RouterMetrics::record_pd_decode_request(&decode_base_url, status);
         let headers = decode_response.headers().clone();
 
         info!("📥 Decode response status: {}", status);
         info!("📥 Decode response headers: {:?}", headers);
 
-        // Record PD metrics
-        let duration = start_time.elapsed();
-        RouterMetrics::record_pd_request(path);
-        RouterMetrics::record_pd_request_duration(path, duration);
-        RouterMetrics::record_pd_prefill_request(&prefill_base_url);
-        RouterMetrics::record_pd_decode_request(&decode_base_url);
-
         if !status.is_success() {
-            RouterMetrics::record_pd_decode_error(&decode_base_url);
+            RouterMetrics::record_pd_decode_error(&decode_base_url, "http_response", Some(status));
         }
 
         // Check if logprobs merging is needed
@@ -1209,6 +1233,7 @@ impl RouterTrait for VllmPDRouter {
         body: &crate::protocols::spec::ChatCompletionRequest,
         _model_id: Option<&str>,
     ) -> Response {
+        let start_time = Instant::now();
         info!(
             "vLLM route_chat called, use_discovery={}",
             self.use_discovery
@@ -1228,17 +1253,27 @@ impl RouterTrait for VllmPDRouter {
                     json
                 }
                 Err(e) => {
-                    return (
-                        axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                        format!("Serialization error: {}", e),
+                    return Self::finish_pd_request(
+                        "/v1/chat/completions",
+                        "POST",
+                        start_time,
+                        (
+                            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                            format!("Serialization error: {}", e),
+                        )
+                            .into_response(),
                     )
-                        .into_response()
                 }
             };
 
             // Process vLLM two-stage request with service discovery
-            self.process_vllm_request(request_json, "/v1/chat/completions", headers)
-                .await
+            return Self::finish_pd_request(
+                "/v1/chat/completions",
+                "POST",
+                start_time,
+                self.process_vllm_request(request_json, "/v1/chat/completions", headers)
+                    .await,
+            );
         } else {
             // Direct URL mode - implement routing logic here (not delegating to PDRouter)
             info!("Using direct URL mode with VllmPDRouter's own routing logic");
@@ -1253,11 +1288,16 @@ impl RouterTrait for VllmPDRouter {
                     json
                 }
                 Err(e) => {
-                    return (
-                        axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                        format!("Serialization error: {}", e),
+                    return Self::finish_pd_request(
+                        "/v1/chat/completions",
+                        "POST",
+                        start_time,
+                        (
+                            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                            format!("Serialization error: {}", e),
+                        )
+                            .into_response(),
                     )
-                        .into_response()
                 }
             };
 
@@ -1272,16 +1312,19 @@ impl RouterTrait for VllmPDRouter {
             );
 
             if prefill_workers.is_empty() || decode_workers.is_empty() {
-                RouterMetrics::record_pd_error("server_selection");
-                return (
-                    axum::http::StatusCode::SERVICE_UNAVAILABLE,
-                    format!(
-                        "No workers available: {} prefill, {} decode",
-                        prefill_workers.len(),
-                        decode_workers.len()
+                return Self::finish_pd_request(
+                    "/v1/chat/completions",
+                    "POST",
+                    start_time,
+                    Self::server_selection_error_response(
+                        "/v1/chat/completions",
+                        format!(
+                            "No workers available: {} prefill, {} decode",
+                            prefill_workers.len(),
+                            decode_workers.len()
+                        ),
                     ),
-                )
-                    .into_response();
+                );
             }
 
             // Select workers using policy with headers for consistent hash
@@ -1308,12 +1351,15 @@ impl RouterTrait for VllmPDRouter {
             ) {
                 Some(idx) => idx,
                 None => {
-                    RouterMetrics::record_pd_error("server_selection");
-                    return (
-                        axum::http::StatusCode::SERVICE_UNAVAILABLE,
-                        "Prefill policy failed to select a worker".to_string(),
-                    )
-                        .into_response();
+                    return Self::finish_pd_request(
+                        "/v1/chat/completions",
+                        "POST",
+                        start_time,
+                        Self::server_selection_error_response(
+                            "/v1/chat/completions",
+                            "Prefill policy failed to select a worker",
+                        ),
+                    );
                 }
             };
 
@@ -1324,12 +1370,15 @@ impl RouterTrait for VllmPDRouter {
             ) {
                 Some(idx) => idx,
                 None => {
-                    RouterMetrics::record_pd_error("server_selection");
-                    return (
-                        axum::http::StatusCode::SERVICE_UNAVAILABLE,
-                        "Decode policy failed to select a worker".to_string(),
-                    )
-                        .into_response();
+                    return Self::finish_pd_request(
+                        "/v1/chat/completions",
+                        "POST",
+                        start_time,
+                        Self::server_selection_error_response(
+                            "/v1/chat/completions",
+                            "Decode policy failed to select a worker",
+                        ),
+                    );
                 }
             };
 
@@ -1370,7 +1419,7 @@ impl RouterTrait for VllmPDRouter {
                         .into_response()
                 }
             };
-            resp
+            Self::finish_pd_request("/v1/chat/completions", "POST", start_time, resp)
         }
     }
 
@@ -1380,6 +1429,7 @@ impl RouterTrait for VllmPDRouter {
         body: &crate::protocols::spec::CompletionRequest,
         _model_id: Option<&str>,
     ) -> Response {
+        let start_time = Instant::now();
         info!(
             "vLLM route_completion called, use_discovery={}",
             self.use_discovery
@@ -1399,17 +1449,27 @@ impl RouterTrait for VllmPDRouter {
                     json
                 }
                 Err(e) => {
-                    return (
-                        axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                        format!("Serialization error: {}", e),
+                    return Self::finish_pd_request(
+                        "/v1/completions",
+                        "POST",
+                        start_time,
+                        (
+                            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                            format!("Serialization error: {}", e),
+                        )
+                            .into_response(),
                     )
-                        .into_response()
                 }
             };
 
             // Process vLLM two-stage request with service discovery
-            self.process_vllm_request(request_json, "/v1/completions", headers)
-                .await
+            return Self::finish_pd_request(
+                "/v1/completions",
+                "POST",
+                start_time,
+                self.process_vllm_request(request_json, "/v1/completions", headers)
+                    .await,
+            );
         } else {
             // Direct URL mode - implement routing logic here (not delegating to PDRouter)
             info!("Using direct URL mode with VllmPDRouter's own routing logic");
@@ -1424,11 +1484,16 @@ impl RouterTrait for VllmPDRouter {
                     json
                 }
                 Err(e) => {
-                    return (
-                        axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                        format!("Serialization error: {}", e),
+                    return Self::finish_pd_request(
+                        "/v1/completions",
+                        "POST",
+                        start_time,
+                        (
+                            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                            format!("Serialization error: {}", e),
+                        )
+                            .into_response(),
                     )
-                        .into_response()
                 }
             };
 
@@ -1443,16 +1508,19 @@ impl RouterTrait for VllmPDRouter {
             );
 
             if prefill_workers.is_empty() || decode_workers.is_empty() {
-                RouterMetrics::record_pd_error("server_selection");
-                return (
-                    axum::http::StatusCode::SERVICE_UNAVAILABLE,
-                    format!(
-                        "No workers available: {} prefill, {} decode",
-                        prefill_workers.len(),
-                        decode_workers.len()
+                return Self::finish_pd_request(
+                    "/v1/completions",
+                    "POST",
+                    start_time,
+                    Self::server_selection_error_response(
+                        "/v1/completions",
+                        format!(
+                            "No workers available: {} prefill, {} decode",
+                            prefill_workers.len(),
+                            decode_workers.len()
+                        ),
                     ),
-                )
-                    .into_response();
+                );
             }
 
             // Select workers using policy with headers for consistent hash
@@ -1479,12 +1547,15 @@ impl RouterTrait for VllmPDRouter {
             ) {
                 Some(idx) => idx,
                 None => {
-                    RouterMetrics::record_pd_error("server_selection");
-                    return (
-                        axum::http::StatusCode::SERVICE_UNAVAILABLE,
-                        "Prefill policy failed to select a worker".to_string(),
-                    )
-                        .into_response();
+                    return Self::finish_pd_request(
+                        "/v1/completions",
+                        "POST",
+                        start_time,
+                        Self::server_selection_error_response(
+                            "/v1/completions",
+                            "Prefill policy failed to select a worker",
+                        ),
+                    );
                 }
             };
 
@@ -1495,12 +1566,15 @@ impl RouterTrait for VllmPDRouter {
             ) {
                 Some(idx) => idx,
                 None => {
-                    RouterMetrics::record_pd_error("server_selection");
-                    return (
-                        axum::http::StatusCode::SERVICE_UNAVAILABLE,
-                        "Decode policy failed to select a worker".to_string(),
-                    )
-                        .into_response();
+                    return Self::finish_pd_request(
+                        "/v1/completions",
+                        "POST",
+                        start_time,
+                        Self::server_selection_error_response(
+                            "/v1/completions",
+                            "Decode policy failed to select a worker",
+                        ),
+                    );
                 }
             };
 
@@ -1541,7 +1615,7 @@ impl RouterTrait for VllmPDRouter {
                         .into_response()
                 }
             };
-            resp
+            Self::finish_pd_request("/v1/completions", "POST", start_time, resp)
         }
     }
 
@@ -1618,13 +1692,19 @@ impl RouterTrait for VllmPDRouter {
         method: &Method,
         body: serde_json::Value,
     ) -> Response {
+        let start_time = Instant::now();
         // Only handle POST requests for inference
         if *method != Method::POST {
-            return (
-                StatusCode::METHOD_NOT_ALLOWED,
-                "Only POST requests are supported for transparent proxy",
-            )
-                .into_response();
+            return Self::finish_pd_request(
+                path,
+                method.as_str(),
+                start_time,
+                (
+                    StatusCode::METHOD_NOT_ALLOWED,
+                    "Only POST requests are supported for transparent proxy",
+                )
+                    .into_response(),
+            );
         }
 
         debug!(
@@ -1637,7 +1717,12 @@ impl RouterTrait for VllmPDRouter {
 
         if self.use_discovery {
             // Discovery mode - use vLLM-specific two-stage processing
-            self.process_vllm_request(request_json, path, headers).await
+            Self::finish_pd_request(
+                path,
+                method.as_str(),
+                start_time,
+                self.process_vllm_request(request_json, path, headers).await,
+            )
         } else {
             // Direct URL mode - use worker registry, filtered by availability
             let all_prefill = self.pd_router.worker_registry.get_prefill_workers();
@@ -1654,16 +1739,19 @@ impl RouterTrait for VllmPDRouter {
                 .collect();
 
             if prefill_workers.is_empty() || decode_workers.is_empty() {
-                RouterMetrics::record_pd_error("server_selection");
-                return (
-                    StatusCode::SERVICE_UNAVAILABLE,
-                    format!(
-                        "No available workers: {} prefill, {} decode",
-                        prefill_workers.len(),
-                        decode_workers.len()
+                return Self::finish_pd_request(
+                    path,
+                    method.as_str(),
+                    start_time,
+                    Self::server_selection_error_response(
+                        path,
+                        format!(
+                            "No available workers: {} prefill, {} decode",
+                            prefill_workers.len(),
+                            decode_workers.len()
+                        ),
                     ),
-                )
-                    .into_response();
+                );
             }
 
             // Select workers using policy with headers for consistent hash
@@ -1690,12 +1778,15 @@ impl RouterTrait for VllmPDRouter {
             ) {
                 Some(idx) => idx,
                 None => {
-                    RouterMetrics::record_pd_error("server_selection");
-                    return (
-                        StatusCode::SERVICE_UNAVAILABLE,
-                        "Prefill policy failed to select a worker".to_string(),
-                    )
-                        .into_response();
+                    return Self::finish_pd_request(
+                        path,
+                        method.as_str(),
+                        start_time,
+                        Self::server_selection_error_response(
+                            path,
+                            "Prefill policy failed to select a worker",
+                        ),
+                    );
                 }
             };
 
@@ -1706,12 +1797,15 @@ impl RouterTrait for VllmPDRouter {
             ) {
                 Some(idx) => idx,
                 None => {
-                    RouterMetrics::record_pd_error("server_selection");
-                    return (
-                        StatusCode::SERVICE_UNAVAILABLE,
-                        "Decode policy failed to select a worker".to_string(),
-                    )
-                        .into_response();
+                    return Self::finish_pd_request(
+                        path,
+                        method.as_str(),
+                        start_time,
+                        Self::server_selection_error_response(
+                            path,
+                            "Decode policy failed to select a worker",
+                        ),
+                    );
                 }
             };
 
@@ -1735,7 +1829,9 @@ impl RouterTrait for VllmPDRouter {
                 )
                 .await
             {
-                Ok(response) => response,
+                Ok(response) => {
+                    Self::finish_pd_request(path, method.as_str(), start_time, response)
+                }
                 Err(e) => {
                     error!(
                         "Transparent proxy request failed: prefill={}, decode={}, error={}",
@@ -1743,11 +1839,16 @@ impl RouterTrait for VllmPDRouter {
                         decode_worker.url(),
                         e
                     );
-                    (
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        format!("Transparent proxy request failed: {}", e),
+                    Self::finish_pd_request(
+                        path,
+                        method.as_str(),
+                        start_time,
+                        (
+                            StatusCode::INTERNAL_SERVER_ERROR,
+                            format!("Transparent proxy request failed: {}", e),
+                        )
+                            .into_response(),
                     )
-                        .into_response()
                 }
             }
         }

--- a/src/routers/http/vllm_pd_router.rs
+++ b/src/routers/http/vllm_pd_router.rs
@@ -20,7 +20,7 @@ use axum::{
 use serde_json::{json, Value};
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 use tokio::sync::Mutex;
 use tracing::{debug, error, info, warn};
 use uuid::Uuid;
@@ -245,8 +245,28 @@ impl VllmPDRouter {
         start_time: Instant,
         response: Response,
     ) -> Response {
-        RouterMetrics::observe_pd_request(route, method, response.status(), start_time.elapsed());
+        let duration = start_time.elapsed();
+        RouterMetrics::observe_http_response(route, method, response.status(), duration);
+        RouterMetrics::observe_pd_request(route, method, response.status(), duration);
         response
+    }
+
+    fn observe_backend_response(
+        route: &str,
+        worker: &str,
+        request_phase: &str,
+        method: &str,
+        status: StatusCode,
+        duration: Duration,
+    ) {
+        RouterMetrics::observe_backend_http_response(
+            route,
+            worker,
+            request_phase,
+            method,
+            status,
+            duration,
+        );
     }
 
     /// Process vLLM request using pure service discovery
@@ -434,6 +454,7 @@ impl VllmPDRouter {
         }
 
         let prefill_request_url = format!("http://{}{}", prefill_base_http, path);
+        let prefill_request_start = Instant::now();
         let prefill_response = match otel_http::send_client_request(
             prefill_request_builder.body(prefill_request_str),
             headers,
@@ -459,6 +480,14 @@ impl VllmPDRouter {
 
         let prefill_status = prefill_response.status();
         debug!("Prefill server responded with status: {}", prefill_status);
+        Self::observe_backend_response(
+            path,
+            prefill_http,
+            "prefill",
+            "POST",
+            prefill_status,
+            prefill_request_start.elapsed(),
+        );
         RouterMetrics::record_pd_prefill_request(prefill_http, prefill_status);
 
         if !prefill_status.is_success() {
@@ -562,6 +591,7 @@ impl VllmPDRouter {
         }
 
         let decode_request_url = format!("http://{}{}", decode_base_http, path);
+        let decode_request_start = Instant::now();
         let decode_response = match otel_http::send_client_request(
             decode_request_builder.body(decode_request_str),
             headers,
@@ -590,6 +620,14 @@ impl VllmPDRouter {
             decode_response.status()
         );
         let decode_status = decode_response.status();
+        Self::observe_backend_response(
+            path,
+            decode_http,
+            "decode",
+            "POST",
+            decode_status,
+            decode_request_start.elapsed(),
+        );
         RouterMetrics::record_pd_decode_request(decode_http, decode_status);
 
         // Stop profiling on decode server after response received
@@ -778,6 +816,7 @@ impl VllmPDRouter {
         prefill_request_builder =
             dp_utils::add_dp_rank_header(prefill_request_builder, prefill_dp_rank);
 
+        let prefill_request_start = Instant::now();
         let prefill_response = match otel_http::send_client_request(
             prefill_request_builder.json(&prefill_request),
             headers,
@@ -802,6 +841,14 @@ impl VllmPDRouter {
         };
 
         let prefill_status = prefill_response.status();
+        Self::observe_backend_response(
+            path,
+            &prefill_base_url,
+            "prefill",
+            "POST",
+            prefill_status,
+            prefill_request_start.elapsed(),
+        );
         RouterMetrics::record_pd_prefill_request(&prefill_base_url, prefill_status);
         debug!("📥 Prefill response status: {}", prefill_status);
         debug!(
@@ -944,6 +991,7 @@ impl VllmPDRouter {
         decode_request_builder =
             dp_utils::add_dp_rank_header(decode_request_builder, decode_dp_rank);
 
+        let decode_request_start = Instant::now();
         let decode_response = match otel_http::send_client_request(
             decode_request_builder.json(&decode_request),
             headers,
@@ -974,6 +1022,14 @@ impl VllmPDRouter {
         decode_worker.decrement_load();
 
         let status = decode_response.status();
+        Self::observe_backend_response(
+            path,
+            &decode_base_url,
+            "decode",
+            "POST",
+            status,
+            decode_request_start.elapsed(),
+        );
         RouterMetrics::record_pd_decode_request(&decode_base_url, status);
         let headers = decode_response.headers().clone();
 
@@ -1874,7 +1930,106 @@ impl WorkerManagement for VllmPDRouter {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use axum::response::IntoResponse;
+    use metrics::with_local_recorder;
+    use metrics_exporter_prometheus::PrometheusBuilder;
     use serde_json::json;
+    use std::time::Duration;
+
+    fn build_test_recorder() -> metrics_exporter_prometheus::PrometheusRecorder {
+        PrometheusBuilder::new().build_recorder()
+    }
+
+    #[test]
+    fn test_finish_pd_request_emits_final_http_response_metrics_once() {
+        let recorder = build_test_recorder();
+        let handle = recorder.handle();
+
+        with_local_recorder(&recorder, || {
+            let response = VllmPDRouter::finish_pd_request(
+                "/v1/chat/completions",
+                "POST",
+                Instant::now(),
+                (StatusCode::TOO_MANY_REQUESTS, "rate limited").into_response(),
+            );
+            assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+        });
+
+        let rendered = handle.render();
+
+        assert!(rendered.lines().any(|line| {
+            line.starts_with("vllm_router_http_responses_total{")
+                && line.contains("route=\"/v1/chat/completions\"")
+                && line.contains("http_request_method=\"POST\"")
+                && line.contains("http_response_status_code=\"429\"")
+                && line.contains("http_response_status_class=\"4xx\"")
+                && line.ends_with(" 1")
+        }));
+        assert!(rendered.lines().any(|line| {
+            line.starts_with("vllm_router_http_response_duration_seconds_count{")
+                && line.contains("route=\"/v1/chat/completions\"")
+                && line.contains("http_request_method=\"POST\"")
+                && line.contains("http_response_status_code=\"429\"")
+                && line.contains("http_response_status_class=\"4xx\"")
+                && line.ends_with(" 1")
+        }));
+    }
+
+    #[test]
+    fn test_observe_backend_response_emits_phase_and_status_labels() {
+        let recorder = build_test_recorder();
+        let handle = recorder.handle();
+
+        with_local_recorder(&recorder, || {
+            VllmPDRouter::observe_backend_response(
+                "/v1/chat/completions",
+                "http://prefill1",
+                "prefill",
+                "POST",
+                StatusCode::SERVICE_UNAVAILABLE,
+                Duration::from_millis(5),
+            );
+            VllmPDRouter::observe_backend_response(
+                "/v1/chat/completions",
+                "http://decode1",
+                "decode",
+                "POST",
+                StatusCode::TOO_MANY_REQUESTS,
+                Duration::from_millis(10),
+            );
+        });
+
+        let rendered = handle.render();
+
+        assert!(rendered.lines().any(|line| {
+            line.starts_with("vllm_router_backend_http_responses_total{")
+                && line.contains("route=\"/v1/chat/completions\"")
+                && line.contains("worker=\"http://prefill1\"")
+                && line.contains("vllm_request_phase=\"prefill\"")
+                && line.contains("http_request_method=\"POST\"")
+                && line.contains("http_response_status_code=\"503\"")
+                && line.contains("http_response_status_class=\"5xx\"")
+                && line.ends_with(" 1")
+        }));
+        assert!(rendered.lines().any(|line| {
+            line.starts_with("vllm_router_backend_http_responses_total{")
+                && line.contains("route=\"/v1/chat/completions\"")
+                && line.contains("worker=\"http://decode1\"")
+                && line.contains("vllm_request_phase=\"decode\"")
+                && line.contains("http_request_method=\"POST\"")
+                && line.contains("http_response_status_code=\"429\"")
+                && line.contains("http_response_status_class=\"4xx\"")
+                && line.ends_with(" 1")
+        }));
+        assert!(rendered.lines().any(|line| {
+            line.starts_with("vllm_router_backend_http_response_duration_seconds_count{")
+                && line.contains("worker=\"http://prefill1\"")
+                && line.contains("vllm_request_phase=\"prefill\"")
+                && line.contains("http_response_status_code=\"503\"")
+                && line.contains("http_response_status_class=\"5xx\"")
+                && line.ends_with(" 1")
+        }));
+    }
 
     // --- OpenAI-style endpoint tests (chat/completions, completions) ---
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -784,6 +784,9 @@ pub fn build_app_with_request_tracing(
         .layer(DefaultBodyLimit::max(max_payload_size))
         .layer(tower_http::limit::RequestBodyLimitLayer::new(
             max_payload_size,
+        ))
+        .layer(axum::middleware::from_fn(
+            middleware::http_metrics_middleware,
         ));
 
     let base_app = if enable_request_tracing {

--- a/src/service_discovery.rs
+++ b/src/service_discovery.rs
@@ -1,3 +1,4 @@
+use crate::metrics::RouterMetrics;
 use crate::routers::RouterTrait;
 
 use futures::{StreamExt, TryStreamExt};
@@ -430,6 +431,7 @@ async fn handle_pod_event(
 
             match result {
                 Ok(_) => {
+                    RouterMetrics::record_discovery_update(1, 0);
                     debug!("Worker added: {}", worker_url);
                 }
                 Err(e) => {
@@ -520,6 +522,8 @@ async fn handle_pod_deletion(
             // Regular mode removal
             router.remove_worker(&worker_url);
         }
+
+        RouterMetrics::record_discovery_update(0, 1);
     } else {
         // This case might occur if a pod is deleted before it was ever marked healthy and added.
         // Or if the event is duplicated. No action needed on the router if it wasn't tracked (and thus not added).

--- a/src/tokenizer/README.md
+++ b/src/tokenizer/README.md
@@ -14,7 +14,7 @@ The VLLM Router tokenizer layer provides a unified interface for text tokenizati
 - **Stop Sequences**: Complex pattern matching for stop tokens and sequences with "jail" buffering
 - **Sequence Management**: Stateful token sequence tracking with incremental text generation
 - **Chat Templates**: Jinja2-based conversation formatting with HuggingFace compatibility
-- **Metrics Integration**: Comprehensive performance and error tracking across all operations
+- **Router-Level Observability**: Production Prometheus coverage lives above the tokenizer layer today
 
 **Data Flow:**
 1. Request → Factory (type detection/HF download) → Concrete Tokenizer Creation
@@ -27,7 +27,7 @@ The VLLM Router tokenizer layer provides a unified interface for text tokenizati
 
 - **Extended Backend Support**: HuggingFace, Tiktoken (GPT models), and Mock for testing
 - **HuggingFace Hub Integration**: Automatic tokenizer downloads with caching
-- **Comprehensive Metrics**: Full TokenizerMetrics integration for observability
+- **No Dedicated Tokenizer Metrics**: Production Prometheus exporters do not emit tokenizer-only series today
 - **Unified Dependencies**: All tokenizer backends included by default (no feature gates)
 - **Stop Sequence Detection**: Sophisticated partial matching with jail buffer
 - **Chat Template Support**: Full Jinja2 rendering with HuggingFace compatibility
@@ -73,14 +73,6 @@ graph TB
         SQ --> ITXT[Incremental Text]
         SD --> SO[Stop Output]
     end
-
-    subgraph Metrics
-        M[TokenizerMetrics]
-        E -.-> M
-        D -.-> M
-        DS -.-> M
-        SD -.-> M
-    end
 ```
 
 ### Sequence Flow Diagram
@@ -92,7 +84,6 @@ sequenceDiagram
     participant T as Tokenizer
     participant DS as DecodeStream
     participant SD as StopDecoder
-    participant M as Metrics
 
     C->>F: create_tokenizer(path_or_model_id)
     F->>F: detect_type()
@@ -102,13 +93,10 @@ sequenceDiagram
         F->>F: download_tokenizer_from_hf()
         F->>T: new from downloaded files
     end
-    F->>M: record_factory_load()
     F-->>C: Arc<dyn Tokenizer>
 
     C->>T: encode(text)
-    T->>M: record_encode_request()
     T->>T: tokenize
-    T->>M: record_tokens_per_encode()
     T-->>C: Encoding
 
     C->>DS: new(tokenizer, tokens)
@@ -117,10 +105,8 @@ sequenceDiagram
         DS->>T: decode(partial)
         DS->>DS: check UTF-8 boundary
         alt complete char
-            DS->>M: record_stream_token()
             DS-->>C: Some(text)
         else incomplete
-            DS->>M: record_incomplete_utf8()
             DS-->>C: None
         end
     end
@@ -128,10 +114,8 @@ sequenceDiagram
     C->>SD: process_token(id)
     SD->>SD: check stop conditions
     alt stop token
-        SD->>M: record_stop_detected()
         SD-->>C: Stopped
     else partial match
-        SD->>M: record_partial_match()
         SD-->>C: Held
     else no match
         SD->>T: decode incremental
@@ -945,19 +929,10 @@ The `Encoding` enum must:
 
 ### Metrics
 
-**Metric Names (via TokenizerMetrics):**
-- `vllm_tokenizer_encode_duration_seconds`
-- `vllm_tokenizer_decode_duration_seconds`
-- `vllm_tokenizer_tokens_per_encode`
-- `vllm_tokenizer_chars_per_encode`
-- `vllm_tokenizer_factory_load_duration_seconds`
-- `vllm_tokenizer_stop_sequence_detected`
-- `vllm_tokenizer_stream_incomplete_utf8_total`
+The tokenizer layer does not currently export dedicated Prometheus metrics in production.
+Observability today comes from the router-level request, policy, and discovery metrics.
 
-**Labels:**
-- `tokenizer_type`: huggingface, tiktoken, mock
-- `operation`: encode, decode, factory_load
-- `error_type`: Various error conditions
+If tokenizer-specific metrics are added later, document the concrete emitters and test coverage here.
 
 ### Failure Modes
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -893,12 +893,18 @@ impl Tree {
         self.tenant_char_count.remove(tenant_id.as_ref());
     }
 
-    #[allow(dead_code)]
     pub fn get_tenant_char_count(&self) -> HashMap<String, usize> {
         self.tenant_char_count
             .iter()
             .map(|entry| (entry.key().to_string(), *entry.value()))
             .collect()
+    }
+
+    pub fn tenant_size(&self, tenant: &str) -> usize {
+        self.tenant_char_count
+            .get(tenant)
+            .map(|entry| *entry.value())
+            .unwrap_or(0)
     }
 
     #[allow(dead_code)]

--- a/tests/common/mock_worker.rs
+++ b/tests/common/mock_worker.rs
@@ -42,6 +42,27 @@ pub enum HealthStatus {
     Degraded,
 }
 
+/// Supported deterministic response modes for router integration tests.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum MockHttpResponseMode {
+    #[default]
+    Default,
+    Ok,
+    TooManyRequests,
+    ServiceUnavailable,
+}
+
+impl MockHttpResponseMode {
+    fn forced_http_status(self) -> Option<StatusCode> {
+        match self {
+            Self::Default => None,
+            Self::Ok => Some(StatusCode::OK),
+            Self::TooManyRequests => Some(StatusCode::TOO_MANY_REQUESTS),
+            Self::ServiceUnavailable => Some(StatusCode::SERVICE_UNAVAILABLE),
+        }
+    }
+}
+
 #[derive(Clone)]
 struct MockWorkerState {
     config: Arc<RwLock<MockWorkerConfig>>,
@@ -59,6 +80,13 @@ pub struct MockWorker {
 impl MockWorker {
     pub fn new(config: MockWorkerConfig) -> Self {
         Self::new_with_forced_http_status(config, None)
+    }
+
+    pub fn with_http_response_mode(
+        config: MockWorkerConfig,
+        response_mode: MockHttpResponseMode,
+    ) -> Self {
+        Self::new_with_forced_http_status(config, response_mode.forced_http_status())
     }
 
     pub fn with_forced_http_status(config: MockWorkerConfig, status: StatusCode) -> Self {
@@ -79,6 +107,16 @@ impl MockWorker {
 
     pub async fn set_forced_http_status(&self, status: Option<StatusCode>) {
         *self.forced_http_status.write().await = status;
+    }
+
+    pub async fn set_http_response_mode(&self, response_mode: MockHttpResponseMode) {
+        self.set_forced_http_status(response_mode.forced_http_status())
+            .await;
+    }
+
+    pub async fn clear_http_response_mode(&self) {
+        self.set_http_response_mode(MockHttpResponseMode::Default)
+            .await;
     }
 
     /// Start the mock worker server
@@ -1049,12 +1087,18 @@ mod tests {
 
     #[tokio::test]
     async fn forced_http_status_returns_deterministic_retryable_errors() {
-        for status in [
-            StatusCode::TOO_MANY_REQUESTS,
-            StatusCode::SERVICE_UNAVAILABLE,
+        for (response_mode, status) in [
+            (
+                MockHttpResponseMode::TooManyRequests,
+                StatusCode::TOO_MANY_REQUESTS,
+            ),
+            (
+                MockHttpResponseMode::ServiceUnavailable,
+                StatusCode::SERVICE_UNAVAILABLE,
+            ),
         ] {
             let mut worker =
-                MockWorker::with_forced_http_status(MockWorkerConfig::default(), status);
+                MockWorker::with_http_response_mode(MockWorkerConfig::default(), response_mode);
             let url = worker.start().await.expect("mock worker should start");
 
             let response = post_chat_completion(&url).await;
@@ -1072,12 +1116,12 @@ mod tests {
 
     #[tokio::test]
     async fn forced_http_status_ok_disables_random_failures() {
-        let mut worker = MockWorker::with_forced_http_status(
+        let mut worker = MockWorker::with_http_response_mode(
             MockWorkerConfig {
                 fail_rate: 1.0,
                 ..Default::default()
             },
-            StatusCode::OK,
+            MockHttpResponseMode::Ok,
         );
         let url = worker.start().await.expect("mock worker should start");
 

--- a/tests/common/mock_worker.rs
+++ b/tests/common/mock_worker.rs
@@ -1067,7 +1067,6 @@ pub fn clear_captured_requests(port: u16) {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use serde_json::json;
 
     async fn post_chat_completion(url: &str) -> reqwest::Response {
@@ -1089,16 +1088,18 @@ mod tests {
     async fn forced_http_status_returns_deterministic_retryable_errors() {
         for (response_mode, status) in [
             (
-                MockHttpResponseMode::TooManyRequests,
-                StatusCode::TOO_MANY_REQUESTS,
+                super::MockHttpResponseMode::TooManyRequests,
+                axum::http::StatusCode::TOO_MANY_REQUESTS,
             ),
             (
-                MockHttpResponseMode::ServiceUnavailable,
-                StatusCode::SERVICE_UNAVAILABLE,
+                super::MockHttpResponseMode::ServiceUnavailable,
+                axum::http::StatusCode::SERVICE_UNAVAILABLE,
             ),
         ] {
-            let mut worker =
-                MockWorker::with_http_response_mode(MockWorkerConfig::default(), response_mode);
+            let mut worker = super::MockWorker::with_http_response_mode(
+                super::MockWorkerConfig::default(),
+                response_mode,
+            );
             let url = worker.start().await.expect("mock worker should start");
 
             let response = post_chat_completion(&url).await;
@@ -1116,17 +1117,17 @@ mod tests {
 
     #[tokio::test]
     async fn forced_http_status_ok_disables_random_failures() {
-        let mut worker = MockWorker::with_http_response_mode(
-            MockWorkerConfig {
+        let mut worker = super::MockWorker::with_http_response_mode(
+            super::MockWorkerConfig {
                 fail_rate: 1.0,
                 ..Default::default()
             },
-            MockHttpResponseMode::Ok,
+            super::MockHttpResponseMode::Ok,
         );
         let url = worker.start().await.expect("mock worker should start");
 
         let response = post_chat_completion(&url).await;
-        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(response.status(), axum::http::StatusCode::OK);
 
         let body: serde_json::Value = response
             .json()

--- a/tests/common/mock_worker.rs
+++ b/tests/common/mock_worker.rs
@@ -42,26 +42,53 @@ pub enum HealthStatus {
     Degraded,
 }
 
+#[derive(Clone)]
+struct MockWorkerState {
+    config: Arc<RwLock<MockWorkerConfig>>,
+    forced_http_status: Arc<RwLock<Option<StatusCode>>>,
+}
+
 /// Mock worker server for testing
 pub struct MockWorker {
     config: Arc<RwLock<MockWorkerConfig>>,
+    forced_http_status: Arc<RwLock<Option<StatusCode>>>,
     shutdown_handle: Option<tokio::task::JoinHandle<()>>,
     shutdown_tx: Option<tokio::sync::oneshot::Sender<()>>,
 }
 
 impl MockWorker {
     pub fn new(config: MockWorkerConfig) -> Self {
+        Self::new_with_forced_http_status(config, None)
+    }
+
+    pub fn with_forced_http_status(config: MockWorkerConfig, status: StatusCode) -> Self {
+        Self::new_with_forced_http_status(config, Some(status))
+    }
+
+    fn new_with_forced_http_status(
+        config: MockWorkerConfig,
+        forced_http_status: Option<StatusCode>,
+    ) -> Self {
         Self {
             config: Arc::new(RwLock::new(config)),
+            forced_http_status: Arc::new(RwLock::new(forced_http_status)),
             shutdown_handle: None,
             shutdown_tx: None,
         }
+    }
+
+    pub async fn set_forced_http_status(&self, status: Option<StatusCode>) {
+        *self.forced_http_status.write().await = status;
     }
 
     /// Start the mock worker server
     pub async fn start(&mut self) -> Result<String, Box<dyn std::error::Error>> {
         let config = self.config.clone();
         let port = config.read().await.port;
+        let state = MockWorkerState {
+            config: self.config.clone(),
+            forced_http_status: self.forced_http_status.clone(),
+        };
 
         // If port is 0, find an available port
         let port = if port == 0 {
@@ -91,7 +118,7 @@ impl MockWorker {
             )
             .route("/flush_cache", post(flush_cache_handler))
             .route("/v1/models", get(v1_models_handler))
-            .with_state(config);
+            .with_state(state);
 
         let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
         self.shutdown_tx = Some(shutdown_tx);
@@ -148,13 +175,41 @@ impl Drop for MockWorker {
 
 // Handler implementations
 
-/// Check if request should fail based on configured fail_rate
-async fn should_fail(config: &MockWorkerConfig) -> bool {
-    rand::random::<f32>() < config.fail_rate
+async fn forced_http_status(state: &MockWorkerState) -> Option<StatusCode> {
+    *state.forced_http_status.read().await
 }
 
-async fn health_handler(State(config): State<Arc<RwLock<MockWorkerConfig>>>) -> Response {
-    let config = config.read().await;
+/// Keep legacy randomized failures unless a deterministic forced status is configured.
+fn should_fail(config: &MockWorkerConfig, forced_http_status: Option<StatusCode>) -> bool {
+    forced_http_status.is_none() && rand::random::<f32>() < config.fail_rate
+}
+
+fn forced_json_error_response(status: StatusCode) -> Response {
+    (
+        status,
+        Json(json!({
+            "error": format!("Forced {} response for testing", status.as_u16())
+        })),
+    )
+        .into_response()
+}
+
+fn forced_openai_error_response(status: StatusCode) -> Response {
+    (
+        status,
+        Json(json!({
+            "error": {
+                "message": format!("Forced {} response for testing", status.as_u16()),
+                "type": status.canonical_reason().unwrap_or("error").to_ascii_lowercase(),
+                "code": status.as_u16().to_string(),
+            }
+        })),
+    )
+        .into_response()
+}
+
+async fn health_handler(State(state): State<MockWorkerState>) -> Response {
+    let config = state.config.read().await;
 
     match config.health_status {
         HealthStatus::Healthy => Json(json!({
@@ -179,10 +234,10 @@ async fn health_handler(State(config): State<Arc<RwLock<MockWorkerConfig>>>) -> 
     }
 }
 
-async fn health_generate_handler(State(config): State<Arc<RwLock<MockWorkerConfig>>>) -> Response {
-    let config = config.read().await;
+async fn health_generate_handler(State(state): State<MockWorkerState>) -> Response {
+    let config = state.config.read().await;
 
-    if should_fail(&config).await {
+    if should_fail(&config, None) {
         return (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(json!({
@@ -210,10 +265,10 @@ async fn health_generate_handler(State(config): State<Arc<RwLock<MockWorkerConfi
     }
 }
 
-async fn server_info_handler(State(config): State<Arc<RwLock<MockWorkerConfig>>>) -> Response {
-    let config = config.read().await;
+async fn server_info_handler(State(state): State<MockWorkerState>) -> Response {
+    let config = state.config.read().await;
 
-    if should_fail(&config).await {
+    if should_fail(&config, None) {
         return (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(json!({
@@ -262,10 +317,10 @@ async fn server_info_handler(State(config): State<Arc<RwLock<MockWorkerConfig>>>
     .into_response()
 }
 
-async fn model_info_handler(State(config): State<Arc<RwLock<MockWorkerConfig>>>) -> Response {
-    let config = config.read().await;
+async fn model_info_handler(State(state): State<MockWorkerState>) -> Response {
+    let config = state.config.read().await;
 
-    if should_fail(&config).await {
+    if should_fail(&config, None) {
         return (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(json!({
@@ -290,16 +345,21 @@ async fn model_info_handler(State(config): State<Arc<RwLock<MockWorkerConfig>>>)
 }
 
 async fn generate_handler(
-    State(config): State<Arc<RwLock<MockWorkerConfig>>>,
+    State(state): State<MockWorkerState>,
     headers: axum::http::HeaderMap,
     Json(payload): Json<serde_json::Value>,
 ) -> Response {
-    let config = config.read().await;
+    let forced_http_status = forced_http_status(&state).await;
+    let config = state.config.read().await;
 
     // Capture request for test inspection
     capture_request(config.port, "/generate", &headers);
 
-    if should_fail(&config).await {
+    if let Some(status) = forced_http_status.filter(|status| *status != StatusCode::OK) {
+        return forced_json_error_response(status);
+    }
+
+    if should_fail(&config, forced_http_status) {
         return (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(json!({
@@ -398,16 +458,21 @@ async fn generate_handler(
 }
 
 async fn chat_completions_handler(
-    State(config): State<Arc<RwLock<MockWorkerConfig>>>,
+    State(state): State<MockWorkerState>,
     headers: axum::http::HeaderMap,
     Json(payload): Json<serde_json::Value>,
 ) -> Response {
-    let config = config.read().await;
+    let forced_http_status = forced_http_status(&state).await;
+    let config = state.config.read().await;
 
     // Capture request for test inspection
     capture_request(config.port, "/v1/chat/completions", &headers);
 
-    if should_fail(&config).await {
+    if let Some(status) = forced_http_status.filter(|status| *status != StatusCode::OK) {
+        return forced_openai_error_response(status);
+    }
+
+    if should_fail(&config, forced_http_status) {
         return (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(json!({
@@ -485,16 +550,21 @@ async fn chat_completions_handler(
 }
 
 async fn completions_handler(
-    State(config): State<Arc<RwLock<MockWorkerConfig>>>,
+    State(state): State<MockWorkerState>,
     headers: axum::http::HeaderMap,
     Json(payload): Json<serde_json::Value>,
 ) -> Response {
-    let config = config.read().await;
+    let forced_http_status = forced_http_status(&state).await;
+    let config = state.config.read().await;
 
     // Capture request for test inspection
     capture_request(config.port, "/v1/completions", &headers);
 
-    if should_fail(&config).await {
+    if let Some(status) = forced_http_status.filter(|status| *status != StatusCode::OK) {
+        return forced_openai_error_response(status);
+    }
+
+    if should_fail(&config, forced_http_status) {
         return (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(json!({
@@ -569,12 +639,17 @@ async fn completions_handler(
 }
 
 async fn responses_handler(
-    State(config): State<Arc<RwLock<MockWorkerConfig>>>,
+    State(state): State<MockWorkerState>,
     Json(payload): Json<serde_json::Value>,
 ) -> Response {
-    let config = config.read().await;
+    let forced_http_status = forced_http_status(&state).await;
+    let config = state.config.read().await;
 
-    if should_fail(&config).await {
+    if let Some(status) = forced_http_status.filter(|status| *status != StatusCode::OK) {
+        return forced_openai_error_response(status);
+    }
+
+    if should_fail(&config, forced_http_status) {
         return (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(json!({
@@ -680,10 +755,15 @@ async fn responses_handler(
     }
 }
 
-async fn flush_cache_handler(State(config): State<Arc<RwLock<MockWorkerConfig>>>) -> Response {
-    let config = config.read().await;
+async fn flush_cache_handler(State(state): State<MockWorkerState>) -> Response {
+    let forced_http_status = forced_http_status(&state).await;
+    let config = state.config.read().await;
 
-    if should_fail(&config).await {
+    if let Some(status) = forced_http_status.filter(|status| *status != StatusCode::OK) {
+        return forced_json_error_response(status);
+    }
+
+    if should_fail(&config, forced_http_status) {
         return (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(json!({
@@ -699,10 +779,15 @@ async fn flush_cache_handler(State(config): State<Arc<RwLock<MockWorkerConfig>>>
     .into_response()
 }
 
-async fn v1_models_handler(State(config): State<Arc<RwLock<MockWorkerConfig>>>) -> Response {
-    let config = config.read().await;
+async fn v1_models_handler(State(state): State<MockWorkerState>) -> Response {
+    let forced_http_status = forced_http_status(&state).await;
+    let config = state.config.read().await;
 
-    if should_fail(&config).await {
+    if let Some(status) = forced_http_status.filter(|status| *status != StatusCode::OK) {
+        return forced_openai_error_response(status);
+    }
+
+    if should_fail(&config, forced_http_status) {
         return (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(json!({
@@ -734,11 +819,15 @@ async fn v1_models_handler(State(config): State<Arc<RwLock<MockWorkerConfig>>>) 
 }
 
 async fn responses_get_handler(
-    State(config): State<Arc<RwLock<MockWorkerConfig>>>,
+    State(state): State<MockWorkerState>,
     Path(response_id): Path<String>,
 ) -> Response {
-    let config = config.read().await;
-    if should_fail(&config).await {
+    let forced_http_status = forced_http_status(&state).await;
+    let config = state.config.read().await;
+    if let Some(status) = forced_http_status.filter(|status| *status != StatusCode::OK) {
+        return forced_json_error_response(status);
+    }
+    if should_fail(&config, forced_http_status) {
         return (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(json!({ "error": "Random failure for testing" })),
@@ -771,11 +860,15 @@ async fn responses_get_handler(
 }
 
 async fn responses_cancel_handler(
-    State(config): State<Arc<RwLock<MockWorkerConfig>>>,
+    State(state): State<MockWorkerState>,
     Path(response_id): Path<String>,
 ) -> Response {
-    let config = config.read().await;
-    if should_fail(&config).await {
+    let forced_http_status = forced_http_status(&state).await;
+    let config = state.config.read().await;
+    if let Some(status) = forced_http_status.filter(|status| *status != StatusCode::OK) {
+        return forced_json_error_response(status);
+    }
+    if should_fail(&config, forced_http_status) {
         return (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(json!({ "error": "Random failure for testing" })),
@@ -823,18 +916,23 @@ fn response_exists_for_port(port: u16, response_id: &str) -> bool {
 
 // Minimal rerank handler returning mock results; router shapes final response
 async fn rerank_handler(
-    State(config): State<Arc<RwLock<MockWorkerConfig>>>,
+    State(state): State<MockWorkerState>,
     Json(payload): Json<serde_json::Value>,
 ) -> impl IntoResponse {
-    let config = config.read().await;
+    let forced_http_status = forced_http_status(&state).await;
+    let config = state.config.read().await;
 
     // Simulate response delay
     if config.response_delay_ms > 0 {
         tokio::time::sleep(tokio::time::Duration::from_millis(config.response_delay_ms)).await;
     }
 
+    if let Some(status) = forced_http_status.filter(|status| *status != StatusCode::OK) {
+        return forced_json_error_response(status);
+    }
+
     // Simulate failure rate
-    if rand::random::<f32>() < config.fail_rate {
+    if should_fail(&config, forced_http_status) {
         return (StatusCode::INTERNAL_SERVER_ERROR, "Simulated failure").into_response();
     }
 
@@ -927,4 +1025,71 @@ pub fn get_captured_requests(port: u16) -> Vec<CapturedRequest> {
 pub fn clear_captured_requests(port: u16) {
     let mut store = get_capture_store().lock().unwrap();
     store.remove(&port);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    async fn post_chat_completion(url: &str) -> reqwest::Response {
+        reqwest::Client::new()
+            .post(format!("{}/v1/chat/completions", url))
+            .json(&json!({
+                "model": "mock-model",
+                "messages": [{
+                    "role": "user",
+                    "content": "hello"
+                }]
+            }))
+            .send()
+            .await
+            .expect("mock worker request should succeed")
+    }
+
+    #[tokio::test]
+    async fn forced_http_status_returns_deterministic_retryable_errors() {
+        for status in [
+            StatusCode::TOO_MANY_REQUESTS,
+            StatusCode::SERVICE_UNAVAILABLE,
+        ] {
+            let mut worker =
+                MockWorker::with_forced_http_status(MockWorkerConfig::default(), status);
+            let url = worker.start().await.expect("mock worker should start");
+
+            let response = post_chat_completion(&url).await;
+            assert_eq!(response.status(), status);
+
+            let body: serde_json::Value = response
+                .json()
+                .await
+                .expect("forced error body should be valid json");
+            assert_eq!(body["error"]["code"], status.as_u16().to_string());
+
+            worker.stop().await;
+        }
+    }
+
+    #[tokio::test]
+    async fn forced_http_status_ok_disables_random_failures() {
+        let mut worker = MockWorker::with_forced_http_status(
+            MockWorkerConfig {
+                fail_rate: 1.0,
+                ..Default::default()
+            },
+            StatusCode::OK,
+        );
+        let url = worker.start().await.expect("mock worker should start");
+
+        let response = post_chat_completion(&url).await;
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body: serde_json::Value = response
+            .json()
+            .await
+            .expect("forced success body should be valid json");
+        assert_eq!(body["object"], "chat.completion");
+
+        worker.stop().await;
+    }
 }

--- a/tests/pd_http_metrics_status_test.rs
+++ b/tests/pd_http_metrics_status_test.rs
@@ -1,0 +1,245 @@
+mod common;
+
+use axum::{
+    body::Body,
+    extract::Request,
+    http::{header::CONTENT_TYPE, StatusCode},
+};
+use common::mock_worker::{HealthStatus, MockWorker, MockWorkerConfig, WorkerType};
+use common::test_app::create_test_app;
+use metrics::set_default_local_recorder;
+use metrics_exporter_prometheus::PrometheusBuilder;
+use serde_json::json;
+use std::sync::Arc;
+use tower::ServiceExt;
+use vllm_router_rs::{
+    config::{PolicyConfig, RouterConfig, RoutingMode},
+    routers::RouterFactory,
+};
+
+fn build_test_recorder() -> metrics_exporter_prometheus::PrometheusRecorder {
+    PrometheusBuilder::new().build_recorder()
+}
+
+fn vllm_pd_router_config(prefill_url: &str, decode_url: &str) -> RouterConfig {
+    RouterConfig {
+        mode: RoutingMode::VllmPrefillDecode {
+            prefill_urls: vec![(prefill_url.to_string(), None)],
+            decode_urls: vec![decode_url.to_string()],
+            prefill_policy: None,
+            decode_policy: None,
+            discovery_address: None,
+        },
+        policy: PolicyConfig::RoundRobin,
+        host: "127.0.0.1".to_string(),
+        port: 0,
+        request_timeout_secs: 10,
+        worker_startup_timeout_secs: 5,
+        worker_startup_check_interval_secs: 1,
+        ..Default::default()
+    }
+}
+
+fn assert_metric_line(rendered: &str, prefix: &str, fragments: &[&str], suffix: &str) {
+    assert!(
+        rendered.lines().any(|line| {
+            line.starts_with(prefix)
+                && fragments.iter().all(|fragment| line.contains(fragment))
+                && line.ends_with(suffix)
+        }),
+        "missing metric line: prefix={prefix}, fragments={fragments:?}, suffix={suffix}\n{rendered}"
+    );
+}
+
+async fn send_chat_completion_request(
+    app: axum::Router,
+    prompt: &str,
+) -> axum::http::Response<Body> {
+    let payload = json!({
+        "model": "mock-model",
+        "messages": [
+            {
+                "role": "user",
+                "content": prompt,
+            }
+        ],
+        "stream": false,
+    });
+
+    let request = Request::builder()
+        .method("POST")
+        .uri("/v1/chat/completions")
+        .header(CONTENT_TYPE, "application/json")
+        .body(Body::from(serde_json::to_vec(&payload).unwrap()))
+        .unwrap();
+
+    app.oneshot(request).await.unwrap()
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn test_vllm_pd_http_status_metrics_cover_prefill_decode_and_final_response() {
+    let mut prefill_worker = MockWorker::new(MockWorkerConfig {
+        port: 0,
+        worker_type: WorkerType::Prefill,
+        health_status: HealthStatus::Healthy,
+        response_delay_ms: 0,
+        fail_rate: 0.0,
+    });
+    let prefill_url = prefill_worker
+        .start()
+        .await
+        .expect("failed to start prefill worker");
+
+    let mut decode_worker = MockWorker::new(MockWorkerConfig {
+        port: 0,
+        worker_type: WorkerType::Decode,
+        health_status: HealthStatus::Healthy,
+        response_delay_ms: 0,
+        fail_rate: 0.0,
+    });
+    let decode_url = decode_worker
+        .start()
+        .await
+        .expect("failed to start decode worker");
+
+    let config = vllm_pd_router_config(&prefill_url, &decode_url);
+    let app_context = common::create_test_context(config.clone());
+    let router = RouterFactory::create_router(&app_context)
+        .await
+        .expect("failed to create vLLM PD router");
+    let app = create_test_app(Arc::from(router), reqwest::Client::new(), &config);
+
+    let recorder = build_test_recorder();
+    let handle = recorder.handle();
+    // Use a thread-local recorder so this binary never contends for the global recorder.
+    let _recorder_guard = set_default_local_recorder(&recorder);
+
+    let success_response = send_chat_completion_request(app.clone(), "successful decode").await;
+    assert_eq!(success_response.status(), StatusCode::OK);
+    let _ = axum::body::to_bytes(success_response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+
+    decode_worker
+        .set_forced_http_status(Some(StatusCode::TOO_MANY_REQUESTS))
+        .await;
+
+    let downstream_error_response =
+        send_chat_completion_request(app.clone(), "decode should return 429").await;
+    assert_eq!(
+        downstream_error_response.status(),
+        StatusCode::TOO_MANY_REQUESTS
+    );
+    let _ = axum::body::to_bytes(downstream_error_response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+
+    let rendered = handle.render();
+    let route = "route=\"/v1/chat/completions\"";
+    let method = "http_request_method=\"POST\"";
+    let prefill_worker_label = format!("worker=\"{prefill_url}\"");
+    let decode_worker_label = format!("worker=\"{decode_url}\"");
+
+    assert_metric_line(
+        &rendered,
+        "vllm_router_backend_http_responses_total{",
+        &[
+            route,
+            prefill_worker_label.as_str(),
+            "vllm_request_phase=\"prefill\"",
+            method,
+            "http_response_status_code=\"200\"",
+            "http_response_status_class=\"2xx\"",
+        ],
+        " 2",
+    );
+    assert_metric_line(
+        &rendered,
+        "vllm_router_backend_http_response_duration_seconds_count{",
+        &[
+            route,
+            prefill_worker_label.as_str(),
+            "vllm_request_phase=\"prefill\"",
+            method,
+            "http_response_status_code=\"200\"",
+            "http_response_status_class=\"2xx\"",
+        ],
+        " 2",
+    );
+    assert_metric_line(
+        &rendered,
+        "vllm_router_backend_http_responses_total{",
+        &[
+            route,
+            decode_worker_label.as_str(),
+            "vllm_request_phase=\"decode\"",
+            method,
+            "http_response_status_code=\"200\"",
+            "http_response_status_class=\"2xx\"",
+        ],
+        " 1",
+    );
+    assert_metric_line(
+        &rendered,
+        "vllm_router_backend_http_responses_total{",
+        &[
+            route,
+            decode_worker_label.as_str(),
+            "vllm_request_phase=\"decode\"",
+            method,
+            "http_response_status_code=\"429\"",
+            "http_response_status_class=\"4xx\"",
+        ],
+        " 1",
+    );
+    assert_metric_line(
+        &rendered,
+        "vllm_router_backend_http_response_duration_seconds_count{",
+        &[
+            route,
+            decode_worker_label.as_str(),
+            "vllm_request_phase=\"decode\"",
+            method,
+            "http_response_status_code=\"429\"",
+            "http_response_status_class=\"4xx\"",
+        ],
+        " 1",
+    );
+    assert_metric_line(
+        &rendered,
+        "vllm_router_http_responses_total{",
+        &[
+            route,
+            method,
+            "http_response_status_code=\"200\"",
+            "http_response_status_class=\"2xx\"",
+        ],
+        " 1",
+    );
+    assert_metric_line(
+        &rendered,
+        "vllm_router_http_responses_total{",
+        &[
+            route,
+            method,
+            "http_response_status_code=\"429\"",
+            "http_response_status_class=\"4xx\"",
+        ],
+        " 1",
+    );
+    assert_metric_line(
+        &rendered,
+        "vllm_router_http_response_duration_seconds_count{",
+        &[
+            route,
+            method,
+            "http_response_status_code=\"429\"",
+            "http_response_status_class=\"4xx\"",
+        ],
+        " 1",
+    );
+
+    decode_worker.set_forced_http_status(None).await;
+    prefill_worker.stop().await;
+    decode_worker.stop().await;
+}

--- a/tests/pd_http_metrics_status_test.rs
+++ b/tests/pd_http_metrics_status_test.rs
@@ -5,7 +5,9 @@ use axum::{
     extract::Request,
     http::{header::CONTENT_TYPE, StatusCode},
 };
-use common::mock_worker::{HealthStatus, MockWorker, MockWorkerConfig, WorkerType};
+use common::mock_worker::{
+    HealthStatus, MockHttpResponseMode, MockWorker, MockWorkerConfig, WorkerType,
+};
 use common::test_app::create_test_app;
 use metrics::set_default_local_recorder;
 use metrics_exporter_prometheus::PrometheusBuilder;
@@ -121,7 +123,7 @@ async fn test_vllm_pd_http_status_metrics_cover_prefill_decode_and_final_respons
         .unwrap();
 
     decode_worker
-        .set_forced_http_status(Some(StatusCode::TOO_MANY_REQUESTS))
+        .set_http_response_mode(MockHttpResponseMode::TooManyRequests)
         .await;
 
     let downstream_error_response =
@@ -239,7 +241,7 @@ async fn test_vllm_pd_http_status_metrics_cover_prefill_decode_and_final_respons
         " 1",
     );
 
-    decode_worker.set_forced_http_status(None).await;
+    decode_worker.clear_http_response_mode().await;
     prefill_worker.stop().await;
     decode_worker.stop().await;
 }

--- a/tests/pd_http_metrics_status_test.rs
+++ b/tests/pd_http_metrics_status_test.rs
@@ -10,9 +10,10 @@ use common::mock_worker::{
 };
 use common::test_app::create_test_app;
 use metrics::set_default_local_recorder;
-use metrics_exporter_prometheus::PrometheusBuilder;
+use metrics_exporter_prometheus::{PrometheusBuilder, PrometheusHandle};
 use serde_json::json;
 use std::sync::Arc;
+use tokio::time::{sleep, Duration, Instant};
 use tower::ServiceExt;
 use vllm_router_rs::{
     config::{PolicyConfig, RouterConfig, RoutingMode},
@@ -23,34 +24,100 @@ fn build_test_recorder() -> metrics_exporter_prometheus::PrometheusRecorder {
     PrometheusBuilder::new().build_recorder()
 }
 
-fn vllm_pd_router_config(prefill_url: &str, decode_url: &str) -> RouterConfig {
-    RouterConfig {
-        mode: RoutingMode::VllmPrefillDecode {
-            prefill_urls: vec![(prefill_url.to_string(), None)],
-            decode_urls: vec![decode_url.to_string()],
-            prefill_policy: None,
-            decode_policy: None,
-            discovery_address: None,
-        },
-        policy: PolicyConfig::RoundRobin,
-        host: "127.0.0.1".to_string(),
-        port: 0,
-        request_timeout_secs: 10,
-        worker_startup_timeout_secs: 5,
-        worker_startup_check_interval_secs: 1,
-        ..Default::default()
+#[derive(Clone, Copy, Debug)]
+enum PdModeUnderTest {
+    PrefillDecode,
+    VllmPrefillDecode,
+}
+
+impl PdModeUnderTest {
+    fn router_config(self, prefill_url: &str, decode_url: &str) -> RouterConfig {
+        let mode = match self {
+            Self::PrefillDecode => RoutingMode::PrefillDecode {
+                prefill_urls: vec![(prefill_url.to_string(), None)],
+                decode_urls: vec![decode_url.to_string()],
+                prefill_policy: None,
+                decode_policy: None,
+            },
+            Self::VllmPrefillDecode => RoutingMode::VllmPrefillDecode {
+                prefill_urls: vec![(prefill_url.to_string(), None)],
+                decode_urls: vec![decode_url.to_string()],
+                prefill_policy: None,
+                decode_policy: None,
+                discovery_address: None,
+            },
+        };
+
+        RouterConfig {
+            mode,
+            policy: PolicyConfig::RoundRobin,
+            host: "127.0.0.1".to_string(),
+            port: 0,
+            request_timeout_secs: 10,
+            worker_startup_timeout_secs: 5,
+            worker_startup_check_interval_secs: 1,
+            ..Default::default()
+        }
     }
+
+    fn name(self) -> &'static str {
+        match self {
+            Self::PrefillDecode => "PrefillDecode",
+            Self::VllmPrefillDecode => "VllmPrefillDecode",
+        }
+    }
+
+    fn prefill_success_count(self) -> usize {
+        match self {
+            Self::PrefillDecode => 6,
+            Self::VllmPrefillDecode => 2,
+        }
+    }
+
+    fn decode_error_count(self) -> usize {
+        match self {
+            Self::PrefillDecode => 5,
+            Self::VllmPrefillDecode => 1,
+        }
+    }
+}
+
+fn has_metric_line(rendered: &str, prefix: &str, fragments: &[&str], suffix: &str) -> bool {
+    rendered.lines().any(|line| {
+        line.starts_with(prefix)
+            && fragments.iter().all(|fragment| line.contains(fragment))
+            && line.ends_with(suffix)
+    })
 }
 
 fn assert_metric_line(rendered: &str, prefix: &str, fragments: &[&str], suffix: &str) {
     assert!(
-        rendered.lines().any(|line| {
-            line.starts_with(prefix)
-                && fragments.iter().all(|fragment| line.contains(fragment))
-                && line.ends_with(suffix)
-        }),
+        has_metric_line(rendered, prefix, fragments, suffix),
         "missing metric line: prefix={prefix}, fragments={fragments:?}, suffix={suffix}\n{rendered}"
     );
+}
+
+async fn assert_metric_line_eventually(
+    handle: &PrometheusHandle,
+    prefix: &str,
+    fragments: &[&str],
+    suffix: &str,
+) {
+    let deadline = Instant::now() + Duration::from_secs(2);
+    let mut rendered = handle.render();
+
+    loop {
+        if has_metric_line(&rendered, prefix, fragments, suffix) {
+            return;
+        }
+
+        if Instant::now() >= deadline {
+            assert_metric_line(&rendered, prefix, fragments, suffix);
+        }
+
+        sleep(Duration::from_millis(10)).await;
+        rendered = handle.render();
+    }
 }
 
 async fn send_chat_completion_request(
@@ -78,8 +145,7 @@ async fn send_chat_completion_request(
     app.oneshot(request).await.unwrap()
 }
 
-#[tokio::test(flavor = "current_thread")]
-async fn test_vllm_pd_http_status_metrics_cover_prefill_decode_and_final_response() {
+async fn run_pd_http_status_metrics_test(mode: PdModeUnderTest) {
     let mut prefill_worker = MockWorker::new(MockWorkerConfig {
         port: 0,
         worker_type: WorkerType::Prefill,
@@ -104,11 +170,11 @@ async fn test_vllm_pd_http_status_metrics_cover_prefill_decode_and_final_respons
         .await
         .expect("failed to start decode worker");
 
-    let config = vllm_pd_router_config(&prefill_url, &decode_url);
+    let config = mode.router_config(&prefill_url, &decode_url);
     let app_context = common::create_test_context(config.clone());
     let router = RouterFactory::create_router(&app_context)
         .await
-        .expect("failed to create vLLM PD router");
+        .unwrap_or_else(|error| panic!("failed to create {} router: {error}", mode.name()));
     let app = create_test_app(Arc::from(router), reqwest::Client::new(), &config);
 
     let recorder = build_test_recorder();
@@ -136,14 +202,15 @@ async fn test_vllm_pd_http_status_metrics_cover_prefill_decode_and_final_respons
         .await
         .unwrap();
 
-    let rendered = handle.render();
     let route = "route=\"/v1/chat/completions\"";
     let method = "http_request_method=\"POST\"";
     let prefill_worker_label = format!("worker=\"{prefill_url}\"");
     let decode_worker_label = format!("worker=\"{decode_url}\"");
+    let prefill_success_count = format!(" {}", mode.prefill_success_count());
+    let decode_error_count = format!(" {}", mode.decode_error_count());
 
-    assert_metric_line(
-        &rendered,
+    assert_metric_line_eventually(
+        &handle,
         "vllm_router_backend_http_responses_total{",
         &[
             route,
@@ -153,10 +220,11 @@ async fn test_vllm_pd_http_status_metrics_cover_prefill_decode_and_final_respons
             "http_response_status_code=\"200\"",
             "http_response_status_class=\"2xx\"",
         ],
-        " 2",
-    );
-    assert_metric_line(
-        &rendered,
+        prefill_success_count.as_str(),
+    )
+    .await;
+    assert_metric_line_eventually(
+        &handle,
         "vllm_router_backend_http_response_duration_seconds_count{",
         &[
             route,
@@ -166,10 +234,11 @@ async fn test_vllm_pd_http_status_metrics_cover_prefill_decode_and_final_respons
             "http_response_status_code=\"200\"",
             "http_response_status_class=\"2xx\"",
         ],
-        " 2",
-    );
-    assert_metric_line(
-        &rendered,
+        prefill_success_count.as_str(),
+    )
+    .await;
+    assert_metric_line_eventually(
+        &handle,
         "vllm_router_backend_http_responses_total{",
         &[
             route,
@@ -180,9 +249,10 @@ async fn test_vllm_pd_http_status_metrics_cover_prefill_decode_and_final_respons
             "http_response_status_class=\"2xx\"",
         ],
         " 1",
-    );
-    assert_metric_line(
-        &rendered,
+    )
+    .await;
+    assert_metric_line_eventually(
+        &handle,
         "vllm_router_backend_http_responses_total{",
         &[
             route,
@@ -192,10 +262,11 @@ async fn test_vllm_pd_http_status_metrics_cover_prefill_decode_and_final_respons
             "http_response_status_code=\"429\"",
             "http_response_status_class=\"4xx\"",
         ],
-        " 1",
-    );
-    assert_metric_line(
-        &rendered,
+        decode_error_count.as_str(),
+    )
+    .await;
+    assert_metric_line_eventually(
+        &handle,
         "vllm_router_backend_http_response_duration_seconds_count{",
         &[
             route,
@@ -205,10 +276,11 @@ async fn test_vllm_pd_http_status_metrics_cover_prefill_decode_and_final_respons
             "http_response_status_code=\"429\"",
             "http_response_status_class=\"4xx\"",
         ],
-        " 1",
-    );
-    assert_metric_line(
-        &rendered,
+        decode_error_count.as_str(),
+    )
+    .await;
+    assert_metric_line_eventually(
+        &handle,
         "vllm_router_http_responses_total{",
         &[
             route,
@@ -217,9 +289,10 @@ async fn test_vllm_pd_http_status_metrics_cover_prefill_decode_and_final_respons
             "http_response_status_class=\"2xx\"",
         ],
         " 1",
-    );
-    assert_metric_line(
-        &rendered,
+    )
+    .await;
+    assert_metric_line_eventually(
+        &handle,
         "vllm_router_http_responses_total{",
         &[
             route,
@@ -228,9 +301,10 @@ async fn test_vllm_pd_http_status_metrics_cover_prefill_decode_and_final_respons
             "http_response_status_class=\"4xx\"",
         ],
         " 1",
-    );
-    assert_metric_line(
-        &rendered,
+    )
+    .await;
+    assert_metric_line_eventually(
+        &handle,
         "vllm_router_http_response_duration_seconds_count{",
         &[
             route,
@@ -239,9 +313,20 @@ async fn test_vllm_pd_http_status_metrics_cover_prefill_decode_and_final_respons
             "http_response_status_class=\"4xx\"",
         ],
         " 1",
-    );
+    )
+    .await;
 
     decode_worker.clear_http_response_mode().await;
     prefill_worker.stop().await;
     decode_worker.stop().await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn test_pd_http_status_metrics_cover_prefill_decode_and_final_response() {
+    run_pd_http_status_metrics_test(PdModeUnderTest::PrefillDecode).await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn test_vllm_pd_http_status_metrics_cover_prefill_decode_and_final_response() {
+    run_pd_http_status_metrics_test(PdModeUnderTest::VllmPrefillDecode).await;
 }

--- a/tests/pd_http_metrics_status_test.rs
+++ b/tests/pd_http_metrics_status_test.rs
@@ -145,6 +145,222 @@ async fn send_chat_completion_request(
     app.oneshot(request).await.unwrap()
 }
 
+fn prefill_decode_router_config_without_retries(
+    prefill_url: &str,
+    decode_url: &str,
+) -> RouterConfig {
+    let mut config = PdModeUnderTest::PrefillDecode.router_config(prefill_url, decode_url);
+    config.disable_retries = true;
+    config
+}
+
+async fn run_prefill_decode_http_status_metrics_single_attempt_test() {
+    let mut prefill_worker = MockWorker::with_http_response_mode(
+        MockWorkerConfig {
+            port: 0,
+            worker_type: WorkerType::Prefill,
+            health_status: HealthStatus::Healthy,
+            response_delay_ms: 0,
+            fail_rate: 0.0,
+        },
+        MockHttpResponseMode::Ok,
+    );
+    let prefill_url = prefill_worker
+        .start()
+        .await
+        .expect("failed to start prefill worker");
+
+    let mut decode_worker = MockWorker::with_http_response_mode(
+        MockWorkerConfig {
+            port: 0,
+            worker_type: WorkerType::Decode,
+            health_status: HealthStatus::Healthy,
+            response_delay_ms: 0,
+            fail_rate: 0.0,
+        },
+        MockHttpResponseMode::Ok,
+    );
+    let decode_url = decode_worker
+        .start()
+        .await
+        .expect("failed to start decode worker");
+
+    let config = prefill_decode_router_config_without_retries(&prefill_url, &decode_url);
+    let app_context = common::create_test_context(config.clone());
+    let router = RouterFactory::create_router(&app_context)
+        .await
+        .unwrap_or_else(|error| panic!("failed to create PrefillDecode router: {error}"));
+    let app = create_test_app(Arc::from(router), reqwest::Client::new(), &config);
+
+    let recorder = build_test_recorder();
+    let handle = recorder.handle();
+    // Use a thread-local recorder so this binary never contends for the global recorder.
+    let _recorder_guard = set_default_local_recorder(&recorder);
+
+    let success_response = send_chat_completion_request(app.clone(), "successful decode").await;
+    assert_eq!(success_response.status(), StatusCode::OK);
+    let _ = axum::body::to_bytes(success_response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+
+    decode_worker
+        .set_http_response_mode(MockHttpResponseMode::TooManyRequests)
+        .await;
+
+    let downstream_error_response =
+        send_chat_completion_request(app.clone(), "decode should return 429").await;
+    assert_eq!(
+        downstream_error_response.status(),
+        StatusCode::TOO_MANY_REQUESTS
+    );
+    let _ = axum::body::to_bytes(downstream_error_response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+
+    let route = "route=\"/v1/chat/completions\"";
+    let method = "http_request_method=\"POST\"";
+    let prefill_worker_label = format!("worker=\"{prefill_url}\"");
+    let decode_worker_label = format!("worker=\"{decode_url}\"");
+
+    assert_metric_line_eventually(
+        &handle,
+        "vllm_router_backend_http_responses_total{",
+        &[
+            route,
+            prefill_worker_label.as_str(),
+            "vllm_request_phase=\"prefill\"",
+            method,
+            "http_response_status_code=\"200\"",
+            "http_response_status_class=\"2xx\"",
+        ],
+        " 2",
+    )
+    .await;
+    assert_metric_line_eventually(
+        &handle,
+        "vllm_router_backend_http_response_duration_seconds_count{",
+        &[
+            route,
+            prefill_worker_label.as_str(),
+            "vllm_request_phase=\"prefill\"",
+            method,
+            "http_response_status_code=\"200\"",
+            "http_response_status_class=\"2xx\"",
+        ],
+        " 2",
+    )
+    .await;
+    assert_metric_line_eventually(
+        &handle,
+        "vllm_router_backend_http_responses_total{",
+        &[
+            route,
+            decode_worker_label.as_str(),
+            "vllm_request_phase=\"decode\"",
+            method,
+            "http_response_status_code=\"200\"",
+            "http_response_status_class=\"2xx\"",
+        ],
+        " 1",
+    )
+    .await;
+    assert_metric_line_eventually(
+        &handle,
+        "vllm_router_backend_http_response_duration_seconds_count{",
+        &[
+            route,
+            decode_worker_label.as_str(),
+            "vllm_request_phase=\"decode\"",
+            method,
+            "http_response_status_code=\"200\"",
+            "http_response_status_class=\"2xx\"",
+        ],
+        " 1",
+    )
+    .await;
+    assert_metric_line_eventually(
+        &handle,
+        "vllm_router_backend_http_responses_total{",
+        &[
+            route,
+            decode_worker_label.as_str(),
+            "vllm_request_phase=\"decode\"",
+            method,
+            "http_response_status_code=\"429\"",
+            "http_response_status_class=\"4xx\"",
+        ],
+        " 1",
+    )
+    .await;
+    assert_metric_line_eventually(
+        &handle,
+        "vllm_router_backend_http_response_duration_seconds_count{",
+        &[
+            route,
+            decode_worker_label.as_str(),
+            "vllm_request_phase=\"decode\"",
+            method,
+            "http_response_status_code=\"429\"",
+            "http_response_status_class=\"4xx\"",
+        ],
+        " 1",
+    )
+    .await;
+    assert_metric_line_eventually(
+        &handle,
+        "vllm_router_http_responses_total{",
+        &[
+            route,
+            method,
+            "http_response_status_code=\"200\"",
+            "http_response_status_class=\"2xx\"",
+        ],
+        " 1",
+    )
+    .await;
+    assert_metric_line_eventually(
+        &handle,
+        "vllm_router_http_response_duration_seconds_count{",
+        &[
+            route,
+            method,
+            "http_response_status_code=\"200\"",
+            "http_response_status_class=\"2xx\"",
+        ],
+        " 1",
+    )
+    .await;
+    assert_metric_line_eventually(
+        &handle,
+        "vllm_router_http_responses_total{",
+        &[
+            route,
+            method,
+            "http_response_status_code=\"429\"",
+            "http_response_status_class=\"4xx\"",
+        ],
+        " 1",
+    )
+    .await;
+    assert_metric_line_eventually(
+        &handle,
+        "vllm_router_http_response_duration_seconds_count{",
+        &[
+            route,
+            method,
+            "http_response_status_code=\"429\"",
+            "http_response_status_class=\"4xx\"",
+        ],
+        " 1",
+    )
+    .await;
+
+    decode_worker.clear_http_response_mode().await;
+    prefill_worker.clear_http_response_mode().await;
+    prefill_worker.stop().await;
+    decode_worker.stop().await;
+}
+
 async fn run_pd_http_status_metrics_test(mode: PdModeUnderTest) {
     let mut prefill_worker = MockWorker::new(MockWorkerConfig {
         port: 0,
@@ -324,6 +540,12 @@ async fn run_pd_http_status_metrics_test(mode: PdModeUnderTest) {
 #[tokio::test(flavor = "current_thread")]
 async fn test_pd_http_status_metrics_cover_prefill_decode_and_final_response() {
     run_pd_http_status_metrics_test(PdModeUnderTest::PrefillDecode).await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn test_pd_http_status_metrics_cover_single_attempt_prefill_decode_backend_and_final_response(
+) {
+    run_prefill_decode_http_status_metrics_single_attempt_test().await;
 }
 
 #[tokio::test(flavor = "current_thread")]


### PR DESCRIPTION
## Purpose

Improve Prometheus observability for HTTP routing (regular, PD, and transparent proxy) by recording client-visible responses, downstream backend responses, cache behavior, and service-discovery events with structured, status-aware labels.

## Overview Of Changes

- Add client-visible response metrics:
  - `vllm_router_http_responses_total`
  - `vllm_router_http_response_duration_seconds`
- Add backend response metrics for downstream workers, with request phase and status labels:
  - `vllm_router_backend_http_responses_total`
  - `vllm_router_backend_http_response_duration_seconds`
- Extend existing request and error metrics with structured HTTP method/status context across regular routes, PD routes, and embeddings error tracking.
- Add cache-aware routing metrics, kept in sync as worker trees change:
  - `vllm_router_cache_hits_total`
  - `vllm_router_cache_misses_total`
  - `vllm_router_tree_size`
- Add service-discovery worker churn metrics:
  - `vllm_router_discovery_updates_total`
  - `vllm_router_discovery_workers_added`
  - `vllm_router_discovery_workers_removed`
- Update tokenizer docs to reflect current state: router-level observability exists, but tokenizer-specific Prometheus series do not.

## Breaking Changes

No request/response API changes. There are observability-only breaking changes:

- Several existing metric families now include richer HTTP labels. Dashboards, alerts, and recording rules that depend on the old label sets will need updates.
- Affected families: `vllm_router_request_errors_total`, `vllm_router_pd_requests_total`, `vllm_router_pd_prefill_requests_total`, `vllm_router_pd_decode_requests_total`, `vllm_router_pd_errors_total`, `vllm_router_pd_prefill_errors_total`, `vllm_router_pd_decode_errors_total`, and `vllm_router_embeddings_errors_total`.
- Dormant metric families are no longer emitted: `vllm_router_worker_load` and `vllm_tokenizer_*`.
- Middleware-level HTTP metrics live under new `vllm_router_http_*` families to avoid changing the legacy meaning of `vllm_router_requests_total`.

## How To Use This

- Use `vllm_router_http_responses_total` and `vllm_router_http_response_duration_seconds` for client-facing SLOs and error-rate dashboards.
- Use `vllm_router_backend_http_responses_total{vllm_request_phase="prefill|decode|inference"}` and the matching duration histogram to separate router-visible failures from downstream worker failures.
- Use the PD metrics with status labels to alert separately on prefill and decode failures instead of treating PD as a single black box.
- Use `vllm_router_cache_hits_total`, `vllm_router_cache_misses_total`, and `vllm_router_tree_size` to evaluate cache-aware routing quality and per-worker cache pressure.
- Use discovery metrics to watch worker churn during rollouts and correlate with request failures or latency changes.

## Bugs Fixed

- Prevent Prometheus cardinality blow-ups on unmatched routes by using matched route templates with an `unmatched` fallback.
- Avoid breaking the legacy meaning of `vllm_router_requests_total` while adding middleware-level HTTP metrics.
- Normalize dynamic response routes so raw response IDs do not leak into metric labels.
- Remove stale cache/tree metric values when workers are removed or evicted.
- Record final client-visible status separately from backend retry/failure status so dashboards can distinguish recovered retries from user-visible failures.

## Reviewer Notes

- This PR changes observability schema, not request handling semantics. Please check any dashboards, alerts, or recording rules that depend on the affected metric families listed above.
- Status-aware metrics use matched route templates and bounded status/status_class labels to keep label cardinality under control.
- This branch does not modify `routers/openai_router` or `tests/test_openai_routing.rs`.

## Test Plan

- `cargo test`
- `cargo test --test test_openai_routing -- --nocapture`

All new and existing metrics tests pass, including middleware metrics, cache-aware metrics, regular-route metrics, and `tests/pd_http_metrics_status_test.rs`. The full suite passes for regular router, PD router, vLLM PD router, service discovery, API endpoint, streaming, request-format, and tracing/integration tests.

Note: two pre-existing OpenAI routing tests (`test_openai_router_health`, `test_openai_router_circuit_breaker`) are flaky due to external network dependencies and are unrelated to this change.
