### PR TITLE
Add rendezvous hashing (HRW) routing policy

### DIFF
--- a/examples/simulate_consistent_hash.rs
+++ b/examples/simulate_consistent_hash.rs
@@ -330,10 +330,7 @@ fn analyze_ring_distribution(
 
     for (w, &vnode_count) in vnodes_per_worker.iter().enumerate() {
         let pct = 100.0 * vnode_count as f64 / total_vnodes as f64;
-        println!(
-            "  decode-worker{}: {} vnodes ({:.1}%)",
-            w, vnode_count, pct
-        );
+        println!("  decode-worker{}: {} vnodes ({:.1}%)", w, vnode_count, pct);
     }
 
     let hashes: Vec<u64> = ring.keys().copied().collect();
@@ -361,12 +358,7 @@ fn analyze_ring_distribution(
 
     println!("\nHash ring arc ownership (fraction of keyspace):");
     for (w, &arc) in arc_per_worker.iter().enumerate() {
-        println!(
-            "  decode-worker{}: {:.4} ({:.2}%)",
-            w,
-            arc,
-            arc * 100.0
-        );
+        println!("  decode-worker{}: {:.4} ({:.2}%)", w, arc, arc * 100.0);
     }
     let arc_min = arc_per_worker.iter().cloned().fold(f64::INFINITY, f64::min);
     let arc_max = arc_per_worker

--- a/examples/simulate_consistent_hash.rs
+++ b/examples/simulate_consistent_hash.rs
@@ -197,7 +197,10 @@ fn run_single_trial(args: &Args, verbose: bool) -> TrialStats {
         println!("Expected per worker:  {:.1}", mean);
         println!("Min:                  {}", min_count);
         println!("Max:                  {}", max_count);
-        println!("Imbalance ratio:      {:.4} (max/expected)", worker_imbalance);
+        println!(
+            "Imbalance ratio:      {:.4} (max/expected)",
+            worker_imbalance
+        );
         println!("Std deviation:        {:.2}", std_dev);
         println!("Coeff of variation:   {:.4} (lower is better)", worker_cv);
 
@@ -366,10 +369,7 @@ fn analyze_ring_distribution(
             arc_per_worker[w] * 100.0
         );
     }
-    let arc_min = arc_per_worker
-        .iter()
-        .cloned()
-        .fold(f64::INFINITY, f64::min);
+    let arc_min = arc_per_worker.iter().cloned().fold(f64::INFINITY, f64::min);
     let arc_max = arc_per_worker
         .iter()
         .cloned()

--- a/examples/simulate_consistent_hash.rs
+++ b/examples/simulate_consistent_hash.rs
@@ -139,10 +139,10 @@ fn run_single_trial(args: &Args, verbose: bool) -> TrialStats {
 
     // Aggregate per physical worker
     let mut per_worker_count: Vec<usize> = vec![0; args.num_workers];
-    for w in 0..args.num_workers {
+    for (w, count) in per_worker_count.iter_mut().enumerate() {
         for rank in 0..args.dp_size {
             let url = format!("http://decode-worker{}:8000@{}", w, rank);
-            per_worker_count[w] += per_url_count[&url];
+            *count += per_url_count[&url];
         }
     }
 
@@ -187,9 +187,8 @@ fn run_single_trial(args: &Args, verbose: bool) -> TrialStats {
         println!("\n=== Per-Physical-Worker Distribution ===");
         println!("{:<30} {:>8} {:>8}", "Worker", "Count", "%");
         println!("{}", "-".repeat(50));
-        for w in 0..args.num_workers {
-            let count = per_worker_count[w];
-            let pct = 100.0 * count as f64 / args.num_sessions as f64;
+        for (w, count) in per_worker_count.iter().enumerate() {
+            let pct = 100.0 * *count as f64 / args.num_sessions as f64;
             println!("decode-worker{:<17} {:>8} {:>7.2}%", w, count, pct);
         }
 
@@ -315,10 +314,10 @@ fn analyze_ring_distribution(
     }
 
     let mut vnodes_per_worker: Vec<usize> = vec![0; num_workers];
-    for w in 0..num_workers {
+    for (w, count) in vnodes_per_worker.iter_mut().enumerate() {
         for rank in 0..dp_size {
             let url = format!("http://decode-worker{}:8000@{}", w, rank);
-            vnodes_per_worker[w] += vnodes_per_url[&url];
+            *count += vnodes_per_url[&url];
         }
     }
 
@@ -329,11 +328,11 @@ fn analyze_ring_distribution(
         worker_urls.len() as u32 * VIRTUAL_NODES_PER_WORKER
     );
 
-    for w in 0..num_workers {
-        let pct = 100.0 * vnodes_per_worker[w] as f64 / total_vnodes as f64;
+    for (w, &vnode_count) in vnodes_per_worker.iter().enumerate() {
+        let pct = 100.0 * vnode_count as f64 / total_vnodes as f64;
         println!(
             "  decode-worker{}: {} vnodes ({:.1}%)",
-            w, vnodes_per_worker[w], pct
+            w, vnode_count, pct
         );
     }
 
@@ -351,22 +350,22 @@ fn analyze_ring_distribution(
         };
         let arc_frac = arc as f64 / u64::MAX as f64;
         let url = &owners[i];
-        for w in 0..num_workers {
+        for (w, arc) in arc_per_worker.iter_mut().enumerate() {
             let prefix = format!("http://decode-worker{}:8000@", w);
             if url.starts_with(&prefix) {
-                arc_per_worker[w] += arc_frac;
+                *arc += arc_frac;
                 break;
             }
         }
     }
 
     println!("\nHash ring arc ownership (fraction of keyspace):");
-    for w in 0..num_workers {
+    for (w, &arc) in arc_per_worker.iter().enumerate() {
         println!(
             "  decode-worker{}: {:.4} ({:.2}%)",
             w,
-            arc_per_worker[w],
-            arc_per_worker[w] * 100.0
+            arc,
+            arc * 100.0
         );
     }
     let arc_min = arc_per_worker.iter().cloned().fold(f64::INFINITY, f64::min);

--- a/examples/simulate_consistent_hash.rs
+++ b/examples/simulate_consistent_hash.rs
@@ -7,14 +7,23 @@
 //!   cargo run --example simulate_consistent_hash
 //!   cargo run --example simulate_consistent_hash -- --num-sessions 500000 --dp-size 4
 //!   cargo run --example simulate_consistent_hash -- --trials 100
+//!   cargo run --example simulate_consistent_hash -- --mode rendezvous --trials 100
 
 use std::collections::{BTreeMap, HashMap};
 
-use clap::Parser;
+use clap::{Parser, ValueEnum};
 use uuid::Uuid;
 
 use vllm_router_rs::policies::ConsistentHashPolicy;
 use vllm_router_rs::policies::VIRTUAL_NODES_PER_WORKER;
+
+#[derive(Clone, ValueEnum)]
+enum Mode {
+    /// Ring-based consistent hashing (current router implementation)
+    Ring,
+    /// Rendezvous hashing (Highest Random Weight)
+    Rendezvous,
+}
 
 #[derive(Parser)]
 #[command(name = "simulate_consistent_hash")]
@@ -32,7 +41,7 @@ struct Args {
     #[arg(long, default_value_t = 4)]
     dp_size: usize,
 
-    /// Virtual nodes per logical worker on the hash ring
+    /// Virtual nodes per logical worker on the hash ring (only used in ring mode)
     #[arg(long, default_value_t = VIRTUAL_NODES_PER_WORKER)]
     virtual_nodes: u32,
 
@@ -40,9 +49,13 @@ struct Args {
     #[arg(long, default_value = "x-session-id")]
     header_name: String,
 
-    /// Number of independent trials to run (each with a different seed)
+    /// Number of independent trials to run
     #[arg(long, default_value_t = 1)]
     trials: usize,
+
+    /// Hashing mode: ring (consistent hash ring) or rendezvous (HRW)
+    #[arg(long, value_enum, default_value_t = Mode::Ring)]
+    mode: Mode,
 }
 
 /// Stats collected from a single trial
@@ -68,17 +81,19 @@ fn run_single_trial(args: &Args, verbose: bool) -> TrialStats {
         }
     }
 
-    // Build hash ring
+    // Build hash ring (only used in ring mode)
     let mut ring: BTreeMap<u64, String> = BTreeMap::new();
-    for url in &worker_urls {
-        for i in 0..args.virtual_nodes {
-            let virtual_key = format!("{}:{}", url, i);
-            let hash_value = ConsistentHashPolicy::fbi_hash(&virtual_key);
-            ring.insert(hash_value, url.clone());
+    if matches!(args.mode, Mode::Ring) {
+        for url in &worker_urls {
+            for i in 0..args.virtual_nodes {
+                let virtual_key = format!("{}:{}", url, i);
+                let hash_value = ConsistentHashPolicy::fbi_hash(&virtual_key);
+                ring.insert(hash_value, url.clone());
+            }
         }
     }
 
-    if verbose {
+    if verbose && matches!(args.mode, Mode::Ring) {
         analyze_ring_distribution(&ring, &worker_urls, args.num_workers, args.dp_size);
     }
 
@@ -96,14 +111,28 @@ fn run_single_trial(args: &Args, verbose: bool) -> TrialStats {
 
     for session_id in &session_ids {
         let hash_key = format!("header:{}:{}", args.header_name, session_id);
-        let hash_value = ConsistentHashPolicy::fbi_hash(&hash_key);
 
-        let selected = ring
-            .range(hash_value..)
-            .next()
-            .or_else(|| ring.iter().next())
-            .map(|(_, url)| url.clone())
-            .unwrap();
+        let selected = match args.mode {
+            Mode::Ring => {
+                let hash_value = ConsistentHashPolicy::fbi_hash(&hash_key);
+                ring.range(hash_value..)
+                    .next()
+                    .or_else(|| ring.iter().next())
+                    .map(|(_, url)| url.clone())
+                    .unwrap()
+            }
+            Mode::Rendezvous => {
+                // Rendezvous hashing: score each worker, pick highest
+                worker_urls
+                    .iter()
+                    .max_by_key(|url| {
+                        let score_key = format!("{}:{}", hash_key, url);
+                        ConsistentHashPolicy::fbi_hash(&score_key)
+                    })
+                    .unwrap()
+                    .clone()
+            }
+        };
 
         *per_url_count.get_mut(&selected).unwrap() += 1;
     }
@@ -193,15 +222,22 @@ fn main() {
     let args = Args::parse();
 
     let total_logical = args.num_workers * args.dp_size;
+    let mode_name = match args.mode {
+        Mode::Ring => "ring",
+        Mode::Rendezvous => "rendezvous",
+    };
     println!("=== Consistent Hash Balance Simulation ===");
+    println!("Mode: {}", mode_name);
     println!("Physical decode workers: {}", args.num_workers);
     println!("DP size (GPUs per worker): {}", args.dp_size);
     println!("Logical worker URLs: {}", total_logical);
-    println!("Virtual nodes per logical worker: {}", args.virtual_nodes);
-    println!(
-        "Total virtual nodes on ring: {}",
-        total_logical as u32 * args.virtual_nodes
-    );
+    if matches!(args.mode, Mode::Ring) {
+        println!("Virtual nodes per logical worker: {}", args.virtual_nodes);
+        println!(
+            "Total virtual nodes on ring: {}",
+            total_logical as u32 * args.virtual_nodes
+        );
+    }
     println!("Sessions to simulate: {}", args.num_sessions);
     println!("Trials: {}", args.trials);
     println!();
@@ -257,6 +293,7 @@ fn percentile(sorted: &[f64], pct: f64) -> f64 {
     sorted[idx.min(sorted.len() - 1)]
 }
 
+/// Compute arc ownership per URL on the ring, returning both totals and per-vnode arcs
 /// Analyze how virtual nodes are distributed on the hash ring
 fn analyze_ring_distribution(
     ring: &BTreeMap<u64, String>,

--- a/examples/simulate_consistent_hash.rs
+++ b/examples/simulate_consistent_hash.rs
@@ -1,0 +1,348 @@
+//! Simulation: Evaluate consistent hash balance for PD disagg decode workers
+//!
+//! Replicates the router's exact consistent hash algorithm to measure
+//! request distribution balance across decode workers with data parallelism.
+//!
+//! Usage:
+//!   cargo run --example simulate_consistent_hash
+//!   cargo run --example simulate_consistent_hash -- --num-sessions 500000 --dp-size 4
+//!   cargo run --example simulate_consistent_hash -- --trials 100
+
+use std::collections::{BTreeMap, HashMap};
+
+use clap::Parser;
+use uuid::Uuid;
+
+use vllm_router_rs::policies::ConsistentHashPolicy;
+use vllm_router_rs::policies::VIRTUAL_NODES_PER_WORKER;
+
+#[derive(Parser)]
+#[command(name = "simulate_consistent_hash")]
+#[command(about = "Simulate consistent hash distribution for PD disagg decode workers")]
+struct Args {
+    /// Number of random session UUIDs to simulate
+    #[arg(long, default_value_t = 256)]
+    num_sessions: usize,
+
+    /// Number of physical decode workers
+    #[arg(long, default_value_t = 2)]
+    num_workers: usize,
+
+    /// Intra-node data parallel size (GPUs per worker)
+    #[arg(long, default_value_t = 4)]
+    dp_size: usize,
+
+    /// Virtual nodes per logical worker on the hash ring
+    #[arg(long, default_value_t = VIRTUAL_NODES_PER_WORKER)]
+    virtual_nodes: u32,
+
+    /// Header name used for hash key (e.g. x-session-id, x-correlation-id)
+    #[arg(long, default_value = "x-session-id")]
+    header_name: String,
+
+    /// Number of independent trials to run (each with a different seed)
+    #[arg(long, default_value_t = 1)]
+    trials: usize,
+}
+
+/// Stats collected from a single trial
+struct TrialStats {
+    /// Coefficient of variation for physical workers
+    worker_cv: f64,
+    /// Imbalance ratio (max/min) for physical workers
+    worker_imbalance: f64,
+    /// Coefficient of variation for DP ranks
+    rank_cv: f64,
+    /// Imbalance ratio (max/min) for DP ranks
+    rank_imbalance: f64,
+}
+
+fn run_single_trial(args: &Args, verbose: bool) -> TrialStats {
+    let total_logical = args.num_workers * args.dp_size;
+
+    // Build worker URLs
+    let mut worker_urls: Vec<String> = Vec::new();
+    for w in 0..args.num_workers {
+        for rank in 0..args.dp_size {
+            worker_urls.push(format!("http://decode-worker{}:8000@{}", w, rank));
+        }
+    }
+
+    // Build hash ring
+    let mut ring: BTreeMap<u64, String> = BTreeMap::new();
+    for url in &worker_urls {
+        for i in 0..args.virtual_nodes {
+            let virtual_key = format!("{}:{}", url, i);
+            let hash_value = ConsistentHashPolicy::fbi_hash(&virtual_key);
+            ring.insert(hash_value, url.clone());
+        }
+    }
+
+    if verbose {
+        analyze_ring_distribution(&ring, &worker_urls, args.num_workers, args.dp_size);
+    }
+
+    // Generate session UUIDs using proper UUID v4
+    let mut session_ids: Vec<String> = Vec::with_capacity(args.num_sessions);
+    for _ in 0..args.num_sessions {
+        session_ids.push(Uuid::new_v4().to_string());
+    }
+
+    // Simulate routing
+    let mut per_url_count: HashMap<String, usize> = HashMap::new();
+    for url in &worker_urls {
+        per_url_count.insert(url.clone(), 0);
+    }
+
+    for session_id in &session_ids {
+        let hash_key = format!("header:{}:{}", args.header_name, session_id);
+        let hash_value = ConsistentHashPolicy::fbi_hash(&hash_key);
+
+        let selected = ring
+            .range(hash_value..)
+            .next()
+            .or_else(|| ring.iter().next())
+            .map(|(_, url)| url.clone())
+            .unwrap();
+
+        *per_url_count.get_mut(&selected).unwrap() += 1;
+    }
+
+    // Aggregate per physical worker
+    let mut per_worker_count: Vec<usize> = vec![0; args.num_workers];
+    for w in 0..args.num_workers {
+        for rank in 0..args.dp_size {
+            let url = format!("http://decode-worker{}:8000@{}", w, rank);
+            per_worker_count[w] += per_url_count[&url];
+        }
+    }
+
+    // Physical worker stats
+    let mean = args.num_sessions as f64 / args.num_workers as f64;
+    let variance: f64 = per_worker_count
+        .iter()
+        .map(|&c| (c as f64 - mean).powi(2))
+        .sum::<f64>()
+        / args.num_workers as f64;
+    let std_dev = variance.sqrt();
+    let worker_cv = std_dev / mean;
+    let min_count = *per_worker_count.iter().min().unwrap();
+    let max_count = *per_worker_count.iter().max().unwrap();
+    let worker_imbalance = max_count as f64 / mean;
+
+    // Per-DP-rank stats
+    let rank_counts: Vec<usize> = worker_urls.iter().map(|u| per_url_count[u]).collect();
+    let rank_min = *rank_counts.iter().min().unwrap();
+    let rank_max = *rank_counts.iter().max().unwrap();
+    let rank_mean = args.num_sessions as f64 / total_logical as f64;
+    let rank_variance: f64 = rank_counts
+        .iter()
+        .map(|&c| (c as f64 - rank_mean).powi(2))
+        .sum::<f64>()
+        / total_logical as f64;
+    let rank_std_dev = rank_variance.sqrt();
+    let rank_cv = rank_std_dev / rank_mean;
+    let rank_imbalance = rank_max as f64 / rank_mean;
+
+    if verbose {
+        // Print detailed per-URL distribution
+        println!("\n=== Per-DP-Rank Distribution ===");
+        println!("{:<45} {:>8} {:>8}", "Worker URL", "Count", "%");
+        println!("{}", "-".repeat(65));
+        for url in &worker_urls {
+            let count = per_url_count[url];
+            let pct = 100.0 * count as f64 / args.num_sessions as f64;
+            println!("{:<45} {:>8} {:>7.2}%", url, count, pct);
+        }
+
+        println!("\n=== Per-Physical-Worker Distribution ===");
+        println!("{:<30} {:>8} {:>8}", "Worker", "Count", "%");
+        println!("{}", "-".repeat(50));
+        for w in 0..args.num_workers {
+            let count = per_worker_count[w];
+            let pct = 100.0 * count as f64 / args.num_sessions as f64;
+            println!("decode-worker{:<17} {:>8} {:>7.2}%", w, count, pct);
+        }
+
+        println!("\n=== Balance Statistics (Physical Workers) ===");
+        println!("Expected per worker:  {:.1}", mean);
+        println!("Min:                  {}", min_count);
+        println!("Max:                  {}", max_count);
+        println!("Imbalance ratio:      {:.4} (max/expected)", worker_imbalance);
+        println!("Std deviation:        {:.2}", std_dev);
+        println!("Coeff of variation:   {:.4} (lower is better)", worker_cv);
+
+        println!("\n=== Balance Statistics (Per DP Rank) ===");
+        println!("Expected per rank:    {:.1}", rank_mean);
+        println!("Min:                  {}", rank_min);
+        println!("Max:                  {}", rank_max);
+        println!("Imbalance ratio:      {:.4} (max/expected)", rank_imbalance);
+        println!("Std deviation:        {:.2}", rank_std_dev);
+        println!("Coeff of variation:   {:.4} (lower is better)", rank_cv);
+    }
+
+    TrialStats {
+        worker_cv,
+        worker_imbalance,
+        rank_cv,
+        rank_imbalance,
+    }
+}
+
+fn main() {
+    let args = Args::parse();
+
+    let total_logical = args.num_workers * args.dp_size;
+    println!("=== Consistent Hash Balance Simulation ===");
+    println!("Physical decode workers: {}", args.num_workers);
+    println!("DP size (GPUs per worker): {}", args.dp_size);
+    println!("Logical worker URLs: {}", total_logical);
+    println!("Virtual nodes per logical worker: {}", args.virtual_nodes);
+    println!(
+        "Total virtual nodes on ring: {}",
+        total_logical as u32 * args.virtual_nodes
+    );
+    println!("Sessions to simulate: {}", args.num_sessions);
+    println!("Trials: {}", args.trials);
+    println!();
+
+    if args.trials == 1 {
+        // Single trial: verbose output
+        run_single_trial(&args, true);
+    } else {
+        // Multiple trials: collect stats and aggregate
+        let mut all_stats: Vec<TrialStats> = Vec::with_capacity(args.trials);
+
+        for _ in 0..args.trials {
+            let stats = run_single_trial(&args, false);
+            all_stats.push(stats);
+        }
+
+        // Aggregate
+        let worker_cvs: Vec<f64> = all_stats.iter().map(|s| s.worker_cv).collect();
+        let worker_imbs: Vec<f64> = all_stats.iter().map(|s| s.worker_imbalance).collect();
+        let rank_cvs: Vec<f64> = all_stats.iter().map(|s| s.rank_cv).collect();
+        let rank_imbs: Vec<f64> = all_stats.iter().map(|s| s.rank_imbalance).collect();
+
+        println!("=== Aggregated Stats over {} Trials ===", args.trials);
+        println!();
+        print_aggregated("Physical Worker CV", &worker_cvs);
+        print_aggregated("Physical Worker Imbalance (max/expected)", &worker_imbs);
+        print_aggregated("DP Rank CV", &rank_cvs);
+        print_aggregated("DP Rank Imbalance (max/expected)", &rank_imbs);
+    }
+}
+
+fn print_aggregated(label: &str, values: &[f64]) {
+    let n = values.len() as f64;
+    let mean = values.iter().sum::<f64>() / n;
+    let mut sorted = values.to_vec();
+    sorted.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    let min = sorted[0];
+    let max = sorted[sorted.len() - 1];
+    let p50 = percentile(&sorted, 50.0);
+    let p95 = percentile(&sorted, 95.0);
+    let p99 = percentile(&sorted, 99.0);
+    let std_dev = (values.iter().map(|v| (v - mean).powi(2)).sum::<f64>() / n).sqrt();
+
+    println!("  {}", label);
+    println!(
+        "    mean={:.4}  std={:.4}  min={:.4}  p50={:.4}  p95={:.4}  p99={:.4}  max={:.4}",
+        mean, std_dev, min, p50, p95, p99, max
+    );
+}
+
+fn percentile(sorted: &[f64], pct: f64) -> f64 {
+    let idx = (pct / 100.0 * (sorted.len() - 1) as f64).round() as usize;
+    sorted[idx.min(sorted.len() - 1)]
+}
+
+/// Analyze how virtual nodes are distributed on the hash ring
+fn analyze_ring_distribution(
+    ring: &BTreeMap<u64, String>,
+    worker_urls: &[String],
+    num_workers: usize,
+    dp_size: usize,
+) {
+    println!("=== Hash Ring Virtual Node Analysis ===");
+
+    let mut vnodes_per_url: HashMap<String, usize> = HashMap::new();
+    for url in worker_urls {
+        vnodes_per_url.insert(url.clone(), 0);
+    }
+    for (_, url) in ring.iter() {
+        *vnodes_per_url.get_mut(url).unwrap() += 1;
+    }
+
+    let mut vnodes_per_worker: Vec<usize> = vec![0; num_workers];
+    for w in 0..num_workers {
+        for rank in 0..dp_size {
+            let url = format!("http://decode-worker{}:8000@{}", w, rank);
+            vnodes_per_worker[w] += vnodes_per_url[&url];
+        }
+    }
+
+    let total_vnodes: usize = ring.len();
+    println!(
+        "Total virtual nodes on ring: {} (expected: {})",
+        total_vnodes,
+        worker_urls.len() as u32 * VIRTUAL_NODES_PER_WORKER
+    );
+
+    for w in 0..num_workers {
+        let pct = 100.0 * vnodes_per_worker[w] as f64 / total_vnodes as f64;
+        println!(
+            "  decode-worker{}: {} vnodes ({:.1}%)",
+            w, vnodes_per_worker[w], pct
+        );
+    }
+
+    let hashes: Vec<u64> = ring.keys().copied().collect();
+    let owners: Vec<String> = ring.values().cloned().collect();
+
+    let mut arc_per_worker: Vec<f64> = vec![0.0; num_workers];
+    let n = hashes.len();
+    for i in 0..n {
+        let next = (i + 1) % n;
+        let arc = if next > i {
+            hashes[next] - hashes[i]
+        } else {
+            (u64::MAX - hashes[i]) + hashes[next] + 1
+        };
+        let arc_frac = arc as f64 / u64::MAX as f64;
+        let url = &owners[i];
+        for w in 0..num_workers {
+            let prefix = format!("http://decode-worker{}:8000@", w);
+            if url.starts_with(&prefix) {
+                arc_per_worker[w] += arc_frac;
+                break;
+            }
+        }
+    }
+
+    println!("\nHash ring arc ownership (fraction of keyspace):");
+    for w in 0..num_workers {
+        println!(
+            "  decode-worker{}: {:.4} ({:.2}%)",
+            w,
+            arc_per_worker[w],
+            arc_per_worker[w] * 100.0
+        );
+    }
+    let arc_min = arc_per_worker
+        .iter()
+        .cloned()
+        .fold(f64::INFINITY, f64::min);
+    let arc_max = arc_per_worker
+        .iter()
+        .cloned()
+        .fold(f64::NEG_INFINITY, f64::max);
+    println!(
+        "  Arc imbalance ratio: {:.4} (max/min)",
+        if arc_min > 0.0 {
+            arc_max / arc_min
+        } else {
+            f64::INFINITY
+        }
+    );
+}

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -254,6 +254,9 @@ pub enum PolicyConfig {
         /// Number of virtual nodes per worker for better distribution
         virtual_nodes: u32,
     },
+
+    #[serde(rename = "rendezvous_hash")]
+    RendezvousHash,
 }
 
 impl PolicyConfig {
@@ -264,6 +267,7 @@ impl PolicyConfig {
             PolicyConfig::CacheAware { .. } => "cache_aware",
             PolicyConfig::PowerOfTwo { .. } => "power_of_two",
             PolicyConfig::ConsistentHash { .. } => "consistent_hash",
+            PolicyConfig::RendezvousHash => "rendezvous_hash",
         }
     }
 }

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -239,6 +239,9 @@ impl ConfigValidator {
                     });
                 }
             }
+            PolicyConfig::RendezvousHash => {
+                // No specific validation needed
+            }
         }
         Ok(())
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -123,7 +123,7 @@ struct CliArgs {
     worker_urls: Vec<String>,
 
     /// Load balancing policy to use
-    #[arg(long, default_value = "cache_aware", value_parser = ["random", "round_robin", "cache_aware", "power_of_two", "consistent_hash"])]
+    #[arg(long, default_value = "cache_aware", value_parser = ["random", "round_robin", "cache_aware", "power_of_two", "consistent_hash", "rendezvous_hash"])]
     policy: String,
 
     /// Enable PD (Prefill-Decode) disaggregated mode
@@ -144,11 +144,11 @@ struct CliArgs {
     decode: Vec<String>,
 
     /// Specific policy for prefill nodes in PD mode
-    #[arg(long, value_parser = ["random", "round_robin", "cache_aware", "power_of_two", "consistent_hash"])]
+    #[arg(long, value_parser = ["random", "round_robin", "cache_aware", "power_of_two", "consistent_hash", "rendezvous_hash"])]
     prefill_policy: Option<String>,
 
     /// Specific policy for decode nodes in PD mode
-    #[arg(long, value_parser = ["random", "round_robin", "cache_aware", "power_of_two", "consistent_hash"])]
+    #[arg(long, value_parser = ["random", "round_robin", "cache_aware", "power_of_two", "consistent_hash", "rendezvous_hash"])]
     decode_policy: Option<String>,
 
     /// Timeout in seconds for worker startup
@@ -409,6 +409,7 @@ impl CliArgs {
             "consistent_hash" => PolicyConfig::ConsistentHash {
                 virtual_nodes: 160, // Default value
             },
+            "rendezvous_hash" => PolicyConfig::RendezvousHash,
             _ => PolicyConfig::RoundRobin, // Fallback
         }
     }

--- a/src/policies/consistent_hash.rs
+++ b/src/policies/consistent_hash.rs
@@ -17,7 +17,7 @@ use crate::core::Worker;
 use crate::metrics::RouterMetrics;
 
 /// Number of virtual nodes per physical worker (for better load distribution)
-const VIRTUAL_NODES_PER_WORKER: u32 = 160;
+pub const VIRTUAL_NODES_PER_WORKER: u32 = 160;
 
 /// Consistent hashing policy
 ///
@@ -229,7 +229,7 @@ impl ConsistentHashPolicy {
     }
 
     /// Facebook-style hash function using furc_hash for consistent hashing
-    fn fbi_hash(key: &str) -> u64 {
+    pub fn fbi_hash(key: &str) -> u64 {
         // Use furc_hash with a large modulus to get good distribution
         // Then expand to u64 for our hash ring
         const LARGE_MODULUS: u32 = (1u32 << 23) - 1; // Max furc_hash modulus

--- a/src/policies/consistent_hash.rs
+++ b/src/policies/consistent_hash.rs
@@ -11,6 +11,7 @@ use tracing::debug;
 use tracing::info;
 
 use super::get_healthy_worker_indices;
+use super::hash_key;
 use super::LoadBalancingPolicy;
 use super::RequestHeaders;
 use crate::core::Worker;
@@ -312,241 +313,6 @@ impl ConsistentHashPolicy {
         selected_worker
     }
 
-    /// HTTP header names to check for session ID (case-insensitive, checked in order)
-    const SESSION_HEADER_NAMES: &'static [&'static str] = &[
-        "x-session-id",
-        "x-user-id",
-        "x-tenant-id",
-        "x-correlation-id", // per-session — check before per-request
-        "x-request-id",
-        "x-trace-id",
-    ];
-
-    /// Extract hash key from HTTP headers
-    /// Returns Some(key) if a session/user identifier is found in headers
-    fn extract_hash_key_from_headers(&self, headers: &RequestHeaders) -> Option<String> {
-        for header_name in Self::SESSION_HEADER_NAMES {
-            if let Some(value) = headers.get(*header_name) {
-                if !value.is_empty() {
-                    info!(
-                        "CONSISTENT_HASH_DEBUG: Found session key in header '{}': {}",
-                        header_name, value
-                    );
-                    return Some(format!("header:{}:{}", header_name, value));
-                }
-            }
-        }
-        None
-    }
-
-    /// Extract hash key from request text
-    /// Priority: session_params.session_id > user field > legacy session_id > legacy user_id > request content
-    fn extract_hash_key_from_body(&self, request_text: Option<&str>) -> Option<String> {
-        let text = request_text.unwrap_or("");
-        if text.is_empty() {
-            return None;
-        }
-
-        // 1. Try to extract session_params.session_id first (highest priority in body)
-        if let Some(session_id) =
-            self.extract_nested_field_value(text, "session_params", "session_id")
-        {
-            info!(
-                "CONSISTENT_HASH_DEBUG: Found session_params.session_id: {}",
-                session_id
-            );
-            return Some(format!("session:{}", session_id));
-        }
-
-        // 2. Try to extract direct user field (from OpenAI ChatCompletion/Completion requests)
-        if let Some(user) = self.extract_field_value(text, "user") {
-            info!("CONSISTENT_HASH_DEBUG: Found user field: {}", user);
-            return Some(format!("user:{}", user));
-        }
-
-        // 3. Fallback: try legacy session_id field (for backward compatibility)
-        if let Some(session_id) = self.extract_field_value(text, "session_id") {
-            return Some(format!("session:{}", session_id));
-        }
-
-        // 4. Fallback: try legacy user_id field (for backward compatibility)
-        if let Some(user_id) = self.extract_field_value(text, "user_id") {
-            return Some(format!("user:{}", user_id));
-        }
-
-        None
-    }
-
-    /// Extract hash key with priority: HTTP headers > body fields > request content hash
-    ///
-    /// Priority order:
-    /// 1. HTTP Headers: x-session-id, x-user-id, x-tenant-id, x-request-id, x-correlation-id, x-trace-id
-    /// 2. Body: session_params.session_id
-    /// 3. Body: user field (OpenAI format)
-    /// 4. Body: session_id (legacy)
-    /// 5. Body: user_id (legacy)
-    /// 6. Fallback: hash of request body
-    fn extract_hash_key(
-        &self,
-        request_text: Option<&str>,
-        headers: Option<&RequestHeaders>,
-    ) -> String {
-        // 1. First priority: HTTP headers (infrastructure level, no body parsing needed)
-        if let Some(hdrs) = headers {
-            if let Some(key) = self.extract_hash_key_from_headers(hdrs) {
-                return key;
-            }
-        }
-
-        // 2. Second priority: Body fields
-        if let Some(key) = self.extract_hash_key_from_body(request_text) {
-            return key;
-        }
-
-        // 3. Final fallback: hash of request body
-        let text = request_text.unwrap_or("");
-        if text.len() > 100 {
-            format!("request_hash:{:016x}", Self::fbi_hash(text))
-        } else {
-            format!("request:{}", text)
-        }
-    }
-
-    /// Extract nested field value like session_params.session_id from JSON text
-    fn extract_nested_field_value(
-        &self,
-        text: &str,
-        parent_field: &str,
-        child_field: &str,
-    ) -> Option<String> {
-        // Look for "session_params": { ... "session_id": "value" ... }
-        if let Some(parent_start) = self.find_field_start(text, parent_field) {
-            // Find the opening brace for the parent object
-            if let Some(obj_start) = text[parent_start..].find('{') {
-                let obj_start_pos = parent_start + obj_start;
-
-                // Find the matching closing brace
-                if let Some(obj_content) = self.extract_json_object(&text[obj_start_pos..]) {
-                    return self.extract_field_value(&obj_content, child_field);
-                }
-            }
-        }
-        None
-    }
-
-    /// Find the start position of a field in JSON text
-    fn find_field_start(&self, text: &str, field_name: &str) -> Option<usize> {
-        let patterns = [format!("\"{}\"", field_name), format!("'{}'", field_name)];
-
-        for pattern in &patterns {
-            if let Some(field_pos) = text.find(pattern) {
-                // Look for colon after the field name
-                let after_field = &text[field_pos + pattern.len()..];
-
-                // Skip whitespace and look for colon
-                for (i, ch) in after_field.char_indices() {
-                    if ch == ':' {
-                        return Some(field_pos + pattern.len() + i + 1);
-                    } else if !ch.is_whitespace() {
-                        // Found non-whitespace before colon, this match is invalid
-                        break;
-                    }
-                }
-            }
-        }
-        None
-    }
-
-    /// Extract JSON object content (simple brace matching)
-    fn extract_json_object(&self, text: &str) -> Option<String> {
-        if !text.starts_with('{') {
-            return None;
-        }
-
-        let mut brace_count = 0;
-        let mut end_pos = 0;
-
-        for (i, ch) in text.char_indices() {
-            match ch {
-                '{' => brace_count += 1,
-                '}' => {
-                    brace_count -= 1;
-                    if brace_count == 0 {
-                        end_pos = i + 1;
-                        break;
-                    }
-                }
-                _ => {}
-            }
-        }
-
-        if brace_count == 0 && end_pos > 0 {
-            Some(text[0..end_pos].to_string())
-        } else {
-            None
-        }
-    }
-
-    /// Extract field value from JSON-like text (simple parser)
-    fn extract_field_value(&self, text: &str, field_name: &str) -> Option<String> {
-        // Look for patterns like "session_id": "value" or "session_id":"value"
-        // We'll use a more flexible approach that handles whitespace better
-        let patterns = [
-            format!("\"{}\"", field_name),
-            format!("'{}'", field_name),
-            field_name.to_string(),
-        ];
-
-        for pattern in &patterns {
-            if let Some(field_pos) = text.find(pattern) {
-                // Look for colon after the field name
-                let after_field = &text[field_pos + pattern.len()..];
-
-                // Skip whitespace and look for colon
-                let mut colon_pos = None;
-                for (i, ch) in after_field.char_indices() {
-                    if ch == ':' {
-                        colon_pos = Some(i);
-                        break;
-                    } else if !ch.is_whitespace() {
-                        // Found non-whitespace before colon, this match is invalid
-                        break;
-                    }
-                }
-
-                if let Some(colon_idx) = colon_pos {
-                    let after_colon = &after_field[colon_idx + 1..];
-                    let trimmed = after_colon.trim_start();
-
-                    // Extract quoted string
-                    if trimmed.starts_with('"') {
-                        if let Some(stripped) = trimmed.strip_prefix('"') {
-                            if let Some(end_quote) = stripped.find('"') {
-                                return Some(stripped[..end_quote].to_string());
-                            }
-                        }
-                    } else if trimmed.starts_with('\'') {
-                        if let Some(stripped) = trimmed.strip_prefix('\'') {
-                            if let Some(end_quote) = stripped.find('\'') {
-                                return Some(stripped[..end_quote].to_string());
-                            }
-                        }
-                    } else {
-                        // Unquoted value - extract until delimiter
-                        let end_pos = trimmed
-                            .find(&[',', ' ', '}', ']', '\n', '\r', '\t'][..])
-                            .unwrap_or(trimmed.len());
-                        if end_pos > 0 {
-                            return Some(trimmed[..end_pos].to_string());
-                        }
-                    }
-                }
-            }
-        }
-
-        None
-    }
-
     /// Handle DP-aware routing by extracting DP rank from worker URL
     fn extract_dp_info(&self, worker_url: &str) -> (String, Option<usize>) {
         if worker_url.contains('@') {
@@ -577,8 +343,8 @@ impl LoadBalancingPolicy for ConsistentHashPolicy {
         // Update hash ring if needed
         self.update_hash_ring(workers);
 
-        // Extract hash key with new priority: headers > body > fallback
-        let hash_key = self.extract_hash_key(request_text, headers);
+        // Extract hash key with priority: headers > body > fallback
+        let hash_key = hash_key::extract_hash_key(request_text, headers);
 
         // DEBUG: Log the request text and extracted hash key
         if let Some(text) = request_text {
@@ -755,25 +521,6 @@ mod tests {
         let hash1 = ConsistentHashPolicy::fbi_hash(key);
         let hash2 = ConsistentHashPolicy::fbi_hash(key);
         assert_eq!(hash1, hash2, "Hash function should be deterministic");
-    }
-
-    #[test]
-    fn test_extract_session_id() {
-        let policy = ConsistentHashPolicy::new();
-
-        // Test JSON-style extraction
-        let request1 = r#"{"session_id": "abc123", "prompt": "hello"}"#;
-        assert_eq!(
-            policy.extract_field_value(request1, "session_id"),
-            Some("abc123".to_string())
-        );
-
-        // Test different quote styles
-        let request2 = r#"{'session_id': 'def456', 'prompt': 'world'}"#;
-        assert_eq!(
-            policy.extract_field_value(request2, "session_id"),
-            Some("def456".to_string())
-        );
     }
 
     #[test]

--- a/src/policies/factory.rs
+++ b/src/policies/factory.rs
@@ -2,7 +2,7 @@
 
 use super::{
     CacheAwareConfig, CacheAwarePolicy, ConsistentHashPolicy, LoadBalancingPolicy,
-    PowerOfTwoPolicy, RandomPolicy, RoundRobinPolicy,
+    PowerOfTwoPolicy, RandomPolicy, RendezvousHashPolicy, RoundRobinPolicy,
 };
 use crate::config::PolicyConfig;
 use std::sync::Arc;
@@ -38,6 +38,7 @@ impl PolicyFactory {
                 // The consistent hash policy uses a hardcoded value for now
                 Arc::new(ConsistentHashPolicy::new())
             }
+            PolicyConfig::RendezvousHash => Arc::new(RendezvousHashPolicy::new()),
         }
     }
 
@@ -49,6 +50,7 @@ impl PolicyFactory {
             "power_of_two" | "poweroftwo" => Some(Arc::new(PowerOfTwoPolicy::new())),
             "cache_aware" | "cacheaware" => Some(Arc::new(CacheAwarePolicy::new())),
             "consistent_hash" | "consistenthash" => Some(Arc::new(ConsistentHashPolicy::new())),
+            "rendezvous_hash" | "rendezvoushash" => Some(Arc::new(RendezvousHashPolicy::new())),
             _ => None,
         }
     }
@@ -88,6 +90,10 @@ mod tests {
         let policy =
             PolicyFactory::create_from_config(&PolicyConfig::ConsistentHash { virtual_nodes: 160 });
         assert_eq!(policy.name(), "consistent_hash");
+
+        // Test RendezvousHash
+        let policy = PolicyFactory::create_from_config(&PolicyConfig::RendezvousHash);
+        assert_eq!(policy.name(), "rendezvous_hash");
     }
 
     #[test]
@@ -102,6 +108,8 @@ mod tests {
         assert!(PolicyFactory::create_by_name("CacheAware").is_some());
         assert!(PolicyFactory::create_by_name("consistent_hash").is_some());
         assert!(PolicyFactory::create_by_name("ConsistentHash").is_some());
+        assert!(PolicyFactory::create_by_name("rendezvous_hash").is_some());
+        assert!(PolicyFactory::create_by_name("RendezvousHash").is_some());
         assert!(PolicyFactory::create_by_name("unknown").is_none());
     }
 }

--- a/src/policies/hash_key.rs
+++ b/src/policies/hash_key.rs
@@ -1,0 +1,479 @@
+//! Shared hash key extraction for consistent hashing policies
+//!
+//! Extracts routing keys from HTTP headers and request bodies.
+//! Used by both ConsistentHashPolicy and RendezvousHashPolicy.
+
+use super::RequestHeaders;
+use crate::policies::ConsistentHashPolicy;
+use tracing::debug;
+
+/// HTTP header names to check for session ID (case-insensitive, checked in order)
+pub(crate) const SESSION_HEADER_NAMES: &[&str] = &[
+    "x-session-id",
+    "x-user-id",
+    "x-tenant-id",
+    "x-correlation-id", // per-session — check before per-request
+    "x-request-id",
+    "x-trace-id",
+];
+
+/// Extract hash key with priority: HTTP headers > body fields > request content hash
+///
+/// Priority order:
+/// 1. HTTP Headers: x-session-id, x-user-id, x-tenant-id, x-correlation-id, x-request-id, x-trace-id
+/// 2. Body: session_params.session_id (nested)
+/// 3. Body: user field (OpenAI format)
+/// 4. Body: session_id (legacy)
+/// 5. Body: user_id (legacy)
+/// 6. Fallback: hash of request body (long) or raw text (short)
+pub(crate) fn extract_hash_key(
+    request_text: Option<&str>,
+    headers: Option<&RequestHeaders>,
+) -> String {
+    // 1. First priority: HTTP headers
+    if let Some(hdrs) = headers {
+        if let Some(key) = extract_hash_key_from_headers(hdrs) {
+            return key;
+        }
+    }
+
+    // 2. Second priority: Body fields
+    if let Some(key) = extract_hash_key_from_body(request_text) {
+        return key;
+    }
+
+    // 3. Final fallback: hash of request body
+    let text = request_text.unwrap_or("");
+    if text.len() > 100 {
+        format!("request_hash:{:016x}", ConsistentHashPolicy::fbi_hash(text))
+    } else {
+        format!("request:{}", text)
+    }
+}
+
+/// Extract hash key from HTTP headers
+pub(crate) fn extract_hash_key_from_headers(headers: &RequestHeaders) -> Option<String> {
+    for header_name in SESSION_HEADER_NAMES {
+        if let Some(value) = headers.get(*header_name) {
+            if !value.is_empty() {
+                debug!(
+                    "Hash key extraction: found session key in header '{}': {}",
+                    header_name, value
+                );
+                return Some(format!("header:{}:{}", header_name, value));
+            }
+        }
+    }
+    None
+}
+
+/// Extract hash key from request body fields
+///
+/// Priority: session_params.session_id > user > session_id > user_id
+pub(crate) fn extract_hash_key_from_body(request_text: Option<&str>) -> Option<String> {
+    let text = request_text.unwrap_or("");
+    if text.is_empty() {
+        return None;
+    }
+
+    // 1. Try to extract session_params.session_id first (highest priority in body)
+    if let Some(session_id) = extract_nested_field_value(text, "session_params", "session_id") {
+        debug!(
+            "Hash key extraction: found session_params.session_id: {}",
+            session_id
+        );
+        return Some(format!("session:{}", session_id));
+    }
+
+    // 2. Try to extract direct user field (from OpenAI ChatCompletion/Completion requests)
+    if let Some(user) = extract_field_value(text, "user") {
+        debug!("Hash key extraction: found user field: {}", user);
+        return Some(format!("user:{}", user));
+    }
+
+    // 3. Fallback: try legacy session_id field
+    if let Some(session_id) = extract_field_value(text, "session_id") {
+        return Some(format!("session:{}", session_id));
+    }
+
+    // 4. Fallback: try legacy user_id field
+    if let Some(user_id) = extract_field_value(text, "user_id") {
+        return Some(format!("user:{}", user_id));
+    }
+
+    None
+}
+
+/// Extract nested field value like session_params.session_id from JSON text
+pub(crate) fn extract_nested_field_value(
+    text: &str,
+    parent_field: &str,
+    child_field: &str,
+) -> Option<String> {
+    if let Some(parent_start) = find_field_start(text, parent_field) {
+        if let Some(obj_start) = text[parent_start..].find('{') {
+            let obj_start_pos = parent_start + obj_start;
+            if let Some(obj_content) = extract_json_object(&text[obj_start_pos..]) {
+                return extract_field_value(&obj_content, child_field);
+            }
+        }
+    }
+    None
+}
+
+/// Find the start position after the colon of a field in JSON text
+pub(crate) fn find_field_start(text: &str, field_name: &str) -> Option<usize> {
+    let patterns = [format!("\"{}\"", field_name), format!("'{}'", field_name)];
+
+    for pattern in &patterns {
+        if let Some(field_pos) = text.find(pattern) {
+            let after_field = &text[field_pos + pattern.len()..];
+            for (i, ch) in after_field.char_indices() {
+                if ch == ':' {
+                    return Some(field_pos + pattern.len() + i + 1);
+                } else if !ch.is_whitespace() {
+                    break;
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Extract JSON object content (simple brace matching)
+pub(crate) fn extract_json_object(text: &str) -> Option<String> {
+    if !text.starts_with('{') {
+        return None;
+    }
+
+    let mut brace_count = 0;
+    let mut end_pos = 0;
+
+    for (i, ch) in text.char_indices() {
+        match ch {
+            '{' => brace_count += 1,
+            '}' => {
+                brace_count -= 1;
+                if brace_count == 0 {
+                    end_pos = i + 1;
+                    break;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    if brace_count == 0 && end_pos > 0 {
+        Some(text[0..end_pos].to_string())
+    } else {
+        None
+    }
+}
+
+/// Extract field value from JSON-like text (simple parser)
+///
+/// Supports double-quoted, single-quoted, and unquoted values.
+pub(crate) fn extract_field_value(text: &str, field_name: &str) -> Option<String> {
+    let patterns = [
+        format!("\"{}\"", field_name),
+        format!("'{}'", field_name),
+        field_name.to_string(),
+    ];
+
+    for pattern in &patterns {
+        if let Some(field_pos) = text.find(pattern) {
+            let after_field = &text[field_pos + pattern.len()..];
+
+            // Skip whitespace and look for colon
+            let mut colon_pos = None;
+            for (i, ch) in after_field.char_indices() {
+                if ch == ':' {
+                    colon_pos = Some(i);
+                    break;
+                } else if !ch.is_whitespace() {
+                    break;
+                }
+            }
+
+            if let Some(colon_idx) = colon_pos {
+                let after_colon = &after_field[colon_idx + 1..];
+                let trimmed = after_colon.trim_start();
+
+                // Extract quoted string (double or single quotes)
+                if trimmed.starts_with('"') {
+                    if let Some(stripped) = trimmed.strip_prefix('"') {
+                        if let Some(end_quote) = stripped.find('"') {
+                            return Some(stripped[..end_quote].to_string());
+                        }
+                    }
+                } else if trimmed.starts_with('\'') {
+                    if let Some(stripped) = trimmed.strip_prefix('\'') {
+                        if let Some(end_quote) = stripped.find('\'') {
+                            return Some(stripped[..end_quote].to_string());
+                        }
+                    }
+                } else {
+                    // Unquoted value - extract until delimiter
+                    let end_pos = trimmed
+                        .find(&[',', ' ', '}', ']', '\n', '\r', '\t'][..])
+                        .unwrap_or(trimmed.len());
+                    if end_pos > 0 {
+                        return Some(trimmed[..end_pos].to_string());
+                    }
+                }
+            }
+        }
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    // === extract_field_value tests ===
+
+    #[test]
+    fn test_extract_field_value_double_quoted() {
+        let text = r#"{"session_id": "abc123", "prompt": "hello"}"#;
+        assert_eq!(
+            extract_field_value(text, "session_id"),
+            Some("abc123".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_field_value_single_quoted() {
+        let text = r#"{'session_id': 'def456', 'prompt': 'world'}"#;
+        assert_eq!(
+            extract_field_value(text, "session_id"),
+            Some("def456".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_field_value_unquoted() {
+        let text = r#"{"count": 42, "name": "test"}"#;
+        assert_eq!(extract_field_value(text, "count"), Some("42".to_string()));
+    }
+
+    #[test]
+    fn test_extract_field_value_missing() {
+        let text = r#"{"other": "val"}"#;
+        assert_eq!(extract_field_value(text, "session_id"), None);
+    }
+
+    #[test]
+    fn test_extract_field_value_no_space_after_colon() {
+        let text = r#"{"session_id":"compact_value"}"#;
+        assert_eq!(
+            extract_field_value(text, "session_id"),
+            Some("compact_value".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_field_value_multiple_fields() {
+        let text = r#"{"user": "bob", "prompt": "hi", "session_id": "sess1"}"#;
+        assert_eq!(extract_field_value(text, "user"), Some("bob".to_string()));
+        assert_eq!(
+            extract_field_value(text, "session_id"),
+            Some("sess1".to_string())
+        );
+    }
+
+    // === extract_nested_field_value tests ===
+
+    #[test]
+    fn test_extract_nested_field_value() {
+        let text = r#"{"session_params": {"session_id": "nested123"}, "prompt": "hi"}"#;
+        assert_eq!(
+            extract_nested_field_value(text, "session_params", "session_id"),
+            Some("nested123".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_nested_field_value_missing_parent() {
+        let text = r#"{"prompt": "hi"}"#;
+        assert_eq!(
+            extract_nested_field_value(text, "session_params", "session_id"),
+            None
+        );
+    }
+
+    #[test]
+    fn test_extract_nested_field_value_missing_child() {
+        let text = r#"{"session_params": {"other": "val"}, "prompt": "hi"}"#;
+        assert_eq!(
+            extract_nested_field_value(text, "session_params", "session_id"),
+            None
+        );
+    }
+
+    // === extract_json_object tests ===
+
+    #[test]
+    fn test_extract_json_object_simple() {
+        let text = r#"{"key": "value"} trailing"#;
+        assert_eq!(
+            extract_json_object(text),
+            Some(r#"{"key": "value"}"#.to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_json_object_nested() {
+        let text = r#"{"outer": {"inner": "val"}} trailing"#;
+        assert_eq!(
+            extract_json_object(text),
+            Some(r#"{"outer": {"inner": "val"}}"#.to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_json_object_not_object() {
+        assert_eq!(extract_json_object("not json"), None);
+    }
+
+    #[test]
+    fn test_extract_json_object_unclosed() {
+        assert_eq!(extract_json_object("{unclosed"), None);
+    }
+
+    // === extract_hash_key_from_headers tests ===
+
+    #[test]
+    fn test_header_extraction_priority() {
+        let mut headers = HashMap::new();
+        headers.insert("x-request-id".to_string(), "req-1".to_string());
+        headers.insert("x-session-id".to_string(), "sess-1".to_string());
+
+        // x-session-id has higher priority than x-request-id
+        let key = extract_hash_key_from_headers(&headers).unwrap();
+        assert_eq!(key, "header:x-session-id:sess-1");
+    }
+
+    #[test]
+    fn test_header_extraction_skips_empty() {
+        let mut headers = HashMap::new();
+        headers.insert("x-session-id".to_string(), "".to_string());
+        headers.insert("x-user-id".to_string(), "user-1".to_string());
+
+        let key = extract_hash_key_from_headers(&headers).unwrap();
+        assert_eq!(key, "header:x-user-id:user-1");
+    }
+
+    #[test]
+    fn test_header_extraction_no_match() {
+        let mut headers = HashMap::new();
+        headers.insert("x-custom-header".to_string(), "val".to_string());
+        assert_eq!(extract_hash_key_from_headers(&headers), None);
+    }
+
+    // === extract_hash_key_from_body tests ===
+
+    #[test]
+    fn test_body_extraction_session_params_priority() {
+        // session_params.session_id takes priority over direct session_id
+        let text = r#"{"session_params": {"session_id": "nested"}, "session_id": "direct"}"#;
+        let key = extract_hash_key_from_body(Some(text)).unwrap();
+        assert_eq!(key, "session:nested");
+    }
+
+    #[test]
+    fn test_body_extraction_user_field() {
+        let text = r#"{"user": "alice", "prompt": "hi"}"#;
+        let key = extract_hash_key_from_body(Some(text)).unwrap();
+        assert_eq!(key, "user:alice");
+    }
+
+    #[test]
+    fn test_body_extraction_legacy_session_id() {
+        let text = r#"{"session_id": "legacy123", "prompt": "hi"}"#;
+        let key = extract_hash_key_from_body(Some(text)).unwrap();
+        assert_eq!(key, "session:legacy123");
+    }
+
+    #[test]
+    fn test_body_extraction_legacy_user_id() {
+        let text = r#"{"user_id": "uid456", "prompt": "hi"}"#;
+        let key = extract_hash_key_from_body(Some(text)).unwrap();
+        assert_eq!(key, "user:uid456");
+    }
+
+    #[test]
+    fn test_body_extraction_empty() {
+        assert_eq!(extract_hash_key_from_body(None), None);
+        assert_eq!(extract_hash_key_from_body(Some("")), None);
+    }
+
+    #[test]
+    fn test_body_extraction_no_known_fields() {
+        let text = r#"{"prompt": "hello", "model": "llama"}"#;
+        assert_eq!(extract_hash_key_from_body(Some(text)), None);
+    }
+
+    // === extract_hash_key (top-level) tests ===
+
+    #[test]
+    fn test_hash_key_headers_over_body() {
+        let mut headers = HashMap::new();
+        headers.insert("x-session-id".to_string(), "from-header".to_string());
+        let body = r#"{"session_id": "from-body"}"#;
+
+        let key = extract_hash_key(Some(body), Some(&headers));
+        assert_eq!(key, "header:x-session-id:from-header");
+    }
+
+    #[test]
+    fn test_hash_key_fallback_short_text() {
+        let key = extract_hash_key(Some("short"), None);
+        assert_eq!(key, "request:short");
+    }
+
+    #[test]
+    fn test_hash_key_fallback_long_text() {
+        let long_text = "x".repeat(200);
+        let key = extract_hash_key(Some(&long_text), None);
+        assert!(key.starts_with("request_hash:"));
+        assert_eq!(key.len(), "request_hash:".len() + 16); // 16 hex chars
+
+        // Same long text should produce same hash
+        let key2 = extract_hash_key(Some(&long_text), None);
+        assert_eq!(key, key2);
+    }
+
+    #[test]
+    fn test_hash_key_fallback_none() {
+        let key = extract_hash_key(None, None);
+        assert_eq!(key, "request:");
+    }
+
+    // === find_field_start tests ===
+
+    #[test]
+    fn test_find_field_start_double_quoted() {
+        let text = r#"{"field": "value"}"#;
+        let pos = find_field_start(text, "field");
+        assert!(pos.is_some());
+        // Should point to after the colon
+        let after = &text[pos.unwrap()..];
+        assert!(after.trim_start().starts_with('"'));
+    }
+
+    #[test]
+    fn test_find_field_start_single_quoted() {
+        let text = r#"{'field': 'value'}"#;
+        let pos = find_field_start(text, "field");
+        assert!(pos.is_some());
+    }
+
+    #[test]
+    fn test_find_field_start_missing() {
+        let text = r#"{"other": "value"}"#;
+        assert_eq!(find_field_start(text, "field"), None);
+    }
+}

--- a/src/policies/mod.rs
+++ b/src/policies/mod.rs
@@ -18,6 +18,7 @@ mod round_robin;
 
 pub use cache_aware::CacheAwarePolicy;
 pub use consistent_hash::ConsistentHashPolicy;
+pub use consistent_hash::VIRTUAL_NODES_PER_WORKER;
 pub use factory::PolicyFactory;
 pub use power_of_two::PowerOfTwoPolicy;
 pub use random::RandomPolicy;

--- a/src/policies/mod.rs
+++ b/src/policies/mod.rs
@@ -14,6 +14,7 @@ mod factory;
 mod power_of_two;
 mod random;
 mod registry;
+mod rendezvous_hash;
 mod round_robin;
 
 pub use cache_aware::CacheAwarePolicy;
@@ -23,6 +24,7 @@ pub use factory::PolicyFactory;
 pub use power_of_two::PowerOfTwoPolicy;
 pub use random::RandomPolicy;
 pub use registry::PolicyRegistry;
+pub use rendezvous_hash::RendezvousHashPolicy;
 pub use round_robin::RoundRobinPolicy;
 
 /// HTTP headers passed to policies for routing decisions

--- a/src/policies/mod.rs
+++ b/src/policies/mod.rs
@@ -11,6 +11,7 @@ use std::sync::Arc;
 mod cache_aware;
 mod consistent_hash;
 mod factory;
+mod hash_key;
 mod power_of_two;
 mod random;
 mod registry;

--- a/src/policies/registry.rs
+++ b/src/policies/registry.rs
@@ -6,7 +6,7 @@
 /// When the last worker of a model is removed, the policy mapping is cleaned up.
 use super::{
     CacheAwareConfig, CacheAwarePolicy, ConsistentHashPolicy, LoadBalancingPolicy,
-    PowerOfTwoPolicy, RandomPolicy, RoundRobinPolicy,
+    PowerOfTwoPolicy, RandomPolicy, RendezvousHashPolicy, RoundRobinPolicy,
 };
 use crate::config::types::PolicyConfig;
 use std::collections::HashMap;
@@ -172,6 +172,7 @@ impl PolicyRegistry {
             "random" => Arc::new(RandomPolicy::new()),
             "cache_aware" => Arc::new(CacheAwarePolicy::new()),
             "power_of_two" => Arc::new(PowerOfTwoPolicy::new()),
+            "rendezvous_hash" => Arc::new(RendezvousHashPolicy::new()),
             _ => {
                 warn!("Unknown policy type '{}', using default", policy_type);
                 Arc::clone(&self.default_policy)
@@ -202,6 +203,7 @@ impl PolicyRegistry {
             }
             PolicyConfig::PowerOfTwo { .. } => Arc::new(PowerOfTwoPolicy::new()),
             PolicyConfig::ConsistentHash { .. } => Arc::new(ConsistentHashPolicy::new()),
+            PolicyConfig::RendezvousHash => Arc::new(RendezvousHashPolicy::new()),
         }
     }
 

--- a/src/policies/rendezvous_hash.rs
+++ b/src/policies/rendezvous_hash.rs
@@ -1,0 +1,346 @@
+//! Rendezvous hashing (Highest Random Weight) load balancing policy
+//!
+//! Routes requests to workers by scoring each worker with a hash of the
+//! session key combined with the worker URL, then picking the highest score.
+//! This provides better balance than ring-based consistent hashing with
+//! zero tuning knobs, while preserving session stickiness and minimal
+//! redistribution (~1/n) on worker add/remove.
+
+use std::sync::Arc;
+
+use tracing::debug;
+use tracing::info;
+
+use super::get_healthy_worker_indices;
+use super::LoadBalancingPolicy;
+use super::RequestHeaders;
+use crate::core::Worker;
+use crate::metrics::RouterMetrics;
+use crate::policies::ConsistentHashPolicy;
+
+/// Rendezvous hashing (Highest Random Weight) policy
+///
+/// For each request, scores every healthy worker with
+/// `fbi_hash("{hash_key}:{worker_url}")` and picks the one with the
+/// highest score. This is deterministic — the same session always maps
+/// to the same worker — and gives near-perfect balance across workers.
+#[derive(Debug)]
+pub struct RendezvousHashPolicy;
+
+impl RendezvousHashPolicy {
+    pub fn new() -> Self {
+        Self
+    }
+
+    /// HTTP header names to check for session ID (same priority as consistent_hash)
+    const SESSION_HEADER_NAMES: &'static [&'static str] = &[
+        "x-session-id",
+        "x-user-id",
+        "x-tenant-id",
+        "x-correlation-id",
+        "x-request-id",
+        "x-trace-id",
+    ];
+
+    /// Extract hash key from HTTP headers
+    fn extract_hash_key_from_headers(&self, headers: &RequestHeaders) -> Option<String> {
+        for header_name in Self::SESSION_HEADER_NAMES {
+            if let Some(value) = headers.get(*header_name) {
+                if !value.is_empty() {
+                    debug!(
+                        "Rendezvous hash: found session key in header '{}': {}",
+                        header_name, value
+                    );
+                    return Some(format!("header:{}:{}", header_name, value));
+                }
+            }
+        }
+        None
+    }
+
+    /// Extract hash key from request body fields
+    fn extract_hash_key_from_body(&self, request_text: Option<&str>) -> Option<String> {
+        let text = request_text.unwrap_or("");
+        if text.is_empty() {
+            return None;
+        }
+
+        // Try JSON field extraction in priority order
+        for (field, prefix) in &[
+            ("session_id", "session"),
+            ("user", "user"),
+            ("user_id", "user"),
+        ] {
+            if let Some(value) = extract_json_field_value(text, field) {
+                return Some(format!("{}:{}", prefix, value));
+            }
+        }
+
+        None
+    }
+
+    /// Extract hash key with priority: headers > body > fallback
+    fn extract_hash_key(
+        &self,
+        request_text: Option<&str>,
+        headers: Option<&RequestHeaders>,
+    ) -> String {
+        if let Some(hdrs) = headers {
+            if let Some(key) = self.extract_hash_key_from_headers(hdrs) {
+                return key;
+            }
+        }
+
+        if let Some(key) = self.extract_hash_key_from_body(request_text) {
+            return key;
+        }
+
+        let text = request_text.unwrap_or("");
+        if text.len() > 100 {
+            format!(
+                "request_hash:{:016x}",
+                ConsistentHashPolicy::fbi_hash(text)
+            )
+        } else {
+            format!("request:{}", text)
+        }
+    }
+}
+
+/// Extract a quoted string value for a JSON field name from text
+fn extract_json_field_value(text: &str, field_name: &str) -> Option<String> {
+    let pattern = format!("\"{}\"", field_name);
+    let field_pos = text.find(&pattern)?;
+    let after_field = &text[field_pos + pattern.len()..];
+
+    // Skip whitespace, find colon
+    let after_colon = after_field.trim_start();
+    if !after_colon.starts_with(':') {
+        return None;
+    }
+    let after_colon = after_colon[1..].trim_start();
+
+    // Extract quoted value
+    if after_colon.starts_with('"') {
+        let value_start = &after_colon[1..];
+        let end_quote = value_start.find('"')?;
+        Some(value_start[..end_quote].to_string())
+    } else {
+        None
+    }
+}
+
+impl Default for RendezvousHashPolicy {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl LoadBalancingPolicy for RendezvousHashPolicy {
+    fn select_worker_with_headers(
+        &self,
+        workers: &[Arc<dyn Worker>],
+        request_text: Option<&str>,
+        headers: Option<&RequestHeaders>,
+    ) -> Option<usize> {
+        let healthy_indices = get_healthy_worker_indices(workers);
+
+        if healthy_indices.is_empty() {
+            return None;
+        }
+
+        let hash_key = self.extract_hash_key(request_text, headers);
+
+        // Score each healthy worker and pick the highest
+        let selected_idx = healthy_indices
+            .iter()
+            .max_by_key(|&&idx| {
+                let score_key = format!("{}:{}", hash_key, workers[idx].url());
+                ConsistentHashPolicy::fbi_hash(&score_key)
+            })
+            .copied()
+            .unwrap();
+
+        let worker_url = workers[selected_idx].url();
+        info!(
+            "Rendezvous hash routing: key='{}' -> worker='{}' (index={})",
+            hash_key, worker_url, selected_idx
+        );
+
+        workers[selected_idx].increment_processed();
+        RouterMetrics::record_processed_request(worker_url);
+        RouterMetrics::record_policy_decision(self.name(), worker_url);
+
+        Some(selected_idx)
+    }
+
+    fn name(&self) -> &'static str {
+        "rendezvous_hash"
+    }
+
+    fn needs_request_text(&self) -> bool {
+        true
+    }
+
+    fn needs_headers(&self) -> bool {
+        true
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::BasicWorker;
+    use crate::core::WorkerType;
+    use std::collections::HashSet;
+
+    fn make_workers(urls: &[&str]) -> Vec<Arc<dyn Worker>> {
+        urls.iter()
+            .map(|url| {
+                Arc::new(BasicWorker::new(url.to_string(), WorkerType::Regular)) as Arc<dyn Worker>
+            })
+            .collect()
+    }
+
+    #[test]
+    fn test_rendezvous_hash_consistency() {
+        let policy = RendezvousHashPolicy::new();
+        let workers = make_workers(&[
+            "http://worker1:8000",
+            "http://worker2:8000",
+            "http://worker3:8000",
+        ]);
+
+        let request = r#"{"session_id": "consistent_test"}"#;
+        let idx1 = policy.select_worker(&workers, Some(request));
+        let idx2 = policy.select_worker(&workers, Some(request));
+        let idx3 = policy.select_worker(&workers, Some(request));
+
+        assert_eq!(idx1, idx2);
+        assert_eq!(idx2, idx3);
+        assert!(idx1.is_some());
+    }
+
+    #[test]
+    fn test_rendezvous_distribution() {
+        let policy = RendezvousHashPolicy::new();
+        let workers = make_workers(&[
+            "http://worker1:8000",
+            "http://worker2:8000",
+            "http://worker3:8000",
+        ]);
+
+        let mut selected_workers = HashSet::new();
+        for i in 0..100 {
+            let request = format!(r#"{{"session_id": "session_{}"}}"#, i);
+            if let Some(idx) = policy.select_worker(&workers, Some(&request)) {
+                selected_workers.insert(idx);
+            }
+        }
+
+        // All workers should be selected at least once with 100 different sessions
+        assert_eq!(selected_workers.len(), 3);
+    }
+
+    #[test]
+    fn test_rendezvous_with_unhealthy_workers() {
+        let policy = RendezvousHashPolicy::new();
+        let workers = make_workers(&["http://worker1:8000", "http://worker2:8000"]);
+
+        workers[0].set_healthy(false);
+
+        // Should always select the healthy worker
+        for i in 0..10 {
+            let request = format!(r#"{{"session_id": "session_{}"}}"#, i);
+            assert_eq!(policy.select_worker(&workers, Some(&request)), Some(1));
+        }
+    }
+
+    #[test]
+    fn test_rendezvous_no_healthy_workers() {
+        let policy = RendezvousHashPolicy::new();
+        let workers = make_workers(&["http://worker1:8000"]);
+
+        workers[0].set_healthy(false);
+        assert_eq!(policy.select_worker(&workers, None), None);
+    }
+
+    #[test]
+    fn test_rendezvous_minimal_redistribution() {
+        let policy = RendezvousHashPolicy::new();
+        let workers_3 = make_workers(&[
+            "http://worker1:8000",
+            "http://worker2:8000",
+            "http://worker3:8000",
+        ]);
+        let workers_2 = make_workers(&["http://worker1:8000", "http://worker2:8000"]);
+
+        let mut same_count = 0;
+        let total = 100;
+
+        for i in 0..total {
+            let request = format!(r#"{{"session_id": "session_{}"}}"#, i);
+            let idx_3 = policy.select_worker(&workers_3, Some(&request)).unwrap();
+            let idx_2 = policy.select_worker(&workers_2, Some(&request)).unwrap();
+
+            // If was on worker1 or worker2, should stay on same worker
+            let url_3 = workers_3[idx_3].url();
+            let url_2 = workers_2[idx_2].url();
+            if url_3 != "http://worker3:8000" && url_3 == url_2 {
+                same_count += 1;
+            }
+        }
+
+        // Sessions not on worker3 should mostly stay on the same worker
+        // With rendezvous hashing, sessions on worker1/worker2 should NOT move
+        // when worker3 is removed
+        let sessions_not_on_worker3 = (0..total)
+            .filter(|i| {
+                let request = format!(r#"{{"session_id": "session_{}"}}"#, i);
+                let idx = policy.select_worker(&workers_3, Some(&request)).unwrap();
+                workers_3[idx].url() != "http://worker3:8000"
+            })
+            .count();
+
+        // All sessions that were on worker1/worker2 should stay there
+        assert_eq!(same_count, sessions_not_on_worker3);
+    }
+
+    #[test]
+    fn test_rendezvous_header_routing() {
+        let policy = RendezvousHashPolicy::new();
+        let workers = make_workers(&[
+            "http://worker1:8000",
+            "http://worker2:8000",
+            "http://worker3:8000",
+        ]);
+
+        let mut headers = RequestHeaders::new();
+        headers.insert("x-session-id".to_string(), "test-session-123".to_string());
+
+        let idx1 = policy.select_worker_with_headers(&workers, None, Some(&headers));
+        let idx2 = policy.select_worker_with_headers(&workers, None, Some(&headers));
+        assert_eq!(idx1, idx2);
+        assert!(idx1.is_some());
+    }
+
+    #[test]
+    fn test_extract_json_field_value() {
+        assert_eq!(
+            extract_json_field_value(r#"{"session_id": "abc123"}"#, "session_id"),
+            Some("abc123".to_string())
+        );
+        assert_eq!(
+            extract_json_field_value(r#"{"user": "bob", "prompt": "hi"}"#, "user"),
+            Some("bob".to_string())
+        );
+        assert_eq!(
+            extract_json_field_value(r#"{"other": "val"}"#, "session_id"),
+            None
+        );
+    }
+}

--- a/src/policies/rendezvous_hash.rs
+++ b/src/policies/rendezvous_hash.rs
@@ -8,10 +8,10 @@
 
 use std::sync::Arc;
 
-use tracing::debug;
 use tracing::info;
 
 use super::get_healthy_worker_indices;
+use super::hash_key;
 use super::LoadBalancingPolicy;
 use super::RequestHeaders;
 use crate::core::Worker;
@@ -30,103 +30,6 @@ pub struct RendezvousHashPolicy;
 impl RendezvousHashPolicy {
     pub fn new() -> Self {
         Self
-    }
-
-    /// HTTP header names to check for session ID (same priority as consistent_hash)
-    const SESSION_HEADER_NAMES: &'static [&'static str] = &[
-        "x-session-id",
-        "x-user-id",
-        "x-tenant-id",
-        "x-correlation-id",
-        "x-request-id",
-        "x-trace-id",
-    ];
-
-    /// Extract hash key from HTTP headers
-    fn extract_hash_key_from_headers(&self, headers: &RequestHeaders) -> Option<String> {
-        for header_name in Self::SESSION_HEADER_NAMES {
-            if let Some(value) = headers.get(*header_name) {
-                if !value.is_empty() {
-                    debug!(
-                        "Rendezvous hash: found session key in header '{}': {}",
-                        header_name, value
-                    );
-                    return Some(format!("header:{}:{}", header_name, value));
-                }
-            }
-        }
-        None
-    }
-
-    /// Extract hash key from request body fields
-    fn extract_hash_key_from_body(&self, request_text: Option<&str>) -> Option<String> {
-        let text = request_text.unwrap_or("");
-        if text.is_empty() {
-            return None;
-        }
-
-        // Try JSON field extraction in priority order
-        for (field, prefix) in &[
-            ("session_id", "session"),
-            ("user", "user"),
-            ("user_id", "user"),
-        ] {
-            if let Some(value) = extract_json_field_value(text, field) {
-                return Some(format!("{}:{}", prefix, value));
-            }
-        }
-
-        None
-    }
-
-    /// Extract hash key with priority: headers > body > fallback
-    fn extract_hash_key(
-        &self,
-        request_text: Option<&str>,
-        headers: Option<&RequestHeaders>,
-    ) -> String {
-        if let Some(hdrs) = headers {
-            if let Some(key) = self.extract_hash_key_from_headers(hdrs) {
-                return key;
-            }
-        }
-
-        if let Some(key) = self.extract_hash_key_from_body(request_text) {
-            return key;
-        }
-
-        let text = request_text.unwrap_or("");
-        if text.len() > 100 {
-            format!(
-                "request_hash:{:016x}",
-                ConsistentHashPolicy::fbi_hash(text)
-            )
-        } else {
-            format!("request:{}", text)
-        }
-    }
-}
-
-/// Extract a quoted string value for a JSON field name from text
-fn extract_json_field_value(text: &str, field_name: &str) -> Option<String> {
-    let pattern = format!("\"{}\"", field_name);
-    let field_pos = text.find(&pattern)?;
-    let after_field = &text[field_pos + pattern.len()..];
-
-    // Skip whitespace, find colon
-    let after_colon = after_field.trim_start();
-    if !after_colon.starts_with(':') {
-        return None;
-    }
-    let after_colon = after_colon[1..].trim_start();
-
-    // Extract quoted value
-    if after_colon.starts_with('"') {
-        let value_start = &after_colon[1..];
-        let end_quote = value_start.find('"')?;
-        Some(value_start[..end_quote].to_string())
-    } else {
-        None
     }
 }
 
@@ -149,7 +52,7 @@ impl LoadBalancingPolicy for RendezvousHashPolicy {
             return None;
         }
 
-        let hash_key = self.extract_hash_key(request_text, headers);
+        let hash_key = hash_key::extract_hash_key(request_text, headers);
 
         // Score each healthy worker and pick the highest
         let selected_idx = healthy_indices
@@ -287,7 +190,6 @@ mod tests {
             let idx_3 = policy.select_worker(&workers_3, Some(&request)).unwrap();
             let idx_2 = policy.select_worker(&workers_2, Some(&request)).unwrap();
 
-            // If was on worker1 or worker2, should stay on same worker
             let url_3 = workers_3[idx_3].url();
             let url_2 = workers_2[idx_2].url();
             if url_3 != "http://worker3:8000" && url_3 == url_2 {
@@ -295,9 +197,6 @@ mod tests {
             }
         }
 
-        // Sessions not on worker3 should mostly stay on the same worker
-        // With rendezvous hashing, sessions on worker1/worker2 should NOT move
-        // when worker3 is removed
         let sessions_not_on_worker3 = (0..total)
             .filter(|i| {
                 let request = format!(r#"{{"session_id": "session_{}"}}"#, i);
@@ -326,21 +225,5 @@ mod tests {
         let idx2 = policy.select_worker_with_headers(&workers, None, Some(&headers));
         assert_eq!(idx1, idx2);
         assert!(idx1.is_some());
-    }
-
-    #[test]
-    fn test_extract_json_field_value() {
-        assert_eq!(
-            extract_json_field_value(r#"{"session_id": "abc123"}"#, "session_id"),
-            Some("abc123".to_string())
-        );
-        assert_eq!(
-            extract_json_field_value(r#"{"user": "bob", "prompt": "hi"}"#, "user"),
-            Some("bob".to_string())
-        );
-        assert_eq!(
-            extract_json_field_value(r#"{"other": "val"}"#, "session_id"),
-            None
-        );
     }
 }


### PR DESCRIPTION
## Summary

  - Add a new `rendezvous_hash` load balancing policy using Highest Random Weight (HRW) hashing. For each request, scores every healthy worker with `fbi_hash("{hash_key}:{worker_url}")` and picks the highest score. Fully deterministic, session-sticky, with ~1/n redistribution on worker add/remove.
  - Extract shared hash key extraction logic (headers, body fields, fallback) into a common `hash_key` module, eliminating duplication between `ConsistentHashPolicy` and `RendezvousHashPolicy`.

  ## Why rendezvous over ring-based consistent hashing?

  Simulation comparison (10 workers, 4 DP ranks per worker, 1000 trials):

  | Sessions/rank | Ring CV | Rendezvous CV | CV Improvement | Ring Imbalance | Rendezvous Imbalance | Imb Improvement |
  |---|---|---|---|---|---|---|
  | 16 | 0.2546 | 0.2463 | -3% | 1.604 | 1.582 | -1% |
  | 32 | 0.1873 | 0.1737 | -7% | 1.433 | 1.399 | -2% |
  | 64 | 0.1421 | 0.1229 | -14% | 1.324 | 1.281 | -3% |
  | 128 | 0.1135 | 0.0865 | -24% | 1.250 | 1.195 | -4% |
  | 256 | 0.0946 | 0.0615 | -35% | 1.201 | 1.139 | -5% |
  | 512 | 0.0841 | 0.0432 | **-49%** | 1.168 | 1.097 | **-6%** |

**CV (Coefficient of Variation)** — standard deviation divided by mean of sessions per DP rank. Lower is better. 0.0 = perfectly balanced, 0.10 = 10% typical deviation from mean.
**Imbalance (max/expected)** — ratio of the busiest DP rank's session count to the ideal even split. Lower is better. 1.0 = perfectly balanced, 1.20 = busiest rank has 20% more sessions than expected.

  The ring-based approach has a CV floor (~0.08) caused by uneven arc distribution that more sessions cannot fix. Rendezvous hashing has zero arc bias, so its CV approaches the theoretical minimum (pure binomial noise). It also requires zero tuning — no vnodes, no ring size to configure.

## When to use rendezvous hashing

  - **Session-sticky routing with many concurrent sessions** — the balance advantage grows with session count. At 128+ sessions per DP rank, rendezvous hashing is 24-49% better balanced than ring-based consistent hashing.
  - **DP-parallel serving** — when workers are grouped by DP rank, even small imbalances get amplified because the slowest rank gates the whole group. Rendezvous hashing's lower imbalance ratio (e.g. 1.097 vs 1.168 at 512 sessions/rank) directly reduces tail latency.
  - **Dynamic worker pools** — when workers are frequently added/removed (scaling, rolling deploys), rendezvous hashing redistributes only ~1/n of sessions, same as ring-based, but without needing to rebuild a hash ring or tune vnode counts.
  - **Simplicity** — no configuration needed. Ring-based consistent hashing requires choosing a vnode count (too few = poor balance, too many = memory overhead). Rendezvous hashing has no knobs.

  ## When NOT to use (use consistent hashing instead)

  - **Very large worker pools (hundreds+)** — rendezvous hashing scores every healthy worker per request (O(n) per lookup), whereas ring-based consistent hashing does an O(log n) lookup after ring construction. For small-to-medium pools (≤50 workers) the difference is negligible, but at hundreds of workers the per-request cost may become measurable.

  ## Code Level tests

  - [x] 7 unit tests for `RendezvousHashPolicy`: consistency, distribution, unhealthy workers, no healthy workers, minimal redistribution, header routing
  - [x] 19 unit tests for shared `hash_key` module: field extraction (double/single/unquoted), nested fields, JSON object parsing, header priority, body priority, fallback behavior, edge cases
  - [x] All 56 policy tests pass (`cargo test --lib -- policies`)
  - [x] Simulation example works with both `--mode ring` and `--mode rendezvous`
  - [x] Factory and registry tests updated for new policy

  ## E2E A/B Test
k8s, a large model with gb300 dp8ep decode + prefill disagg setup, 3 hours aiperf bench on both side with multi-turn long input payload. Both side with PR #149 to avoid pinning traffic to rank 0
### Performance
| Metric | consistent_hash | rendezvous_hash | Delta |
|---|---|---|---|
| **Total TPGS** | **3,650.26** | **3,892.01** | **+6.6%** |
| Prefill TPGS | 7,008.28 | 7,472.43 | +6.6% |
| Decode TPGS | 292.24 | 311.60 | +6.6% |
| **TTFT mean** | 24,011 ms | 18,869 ms | **-21.4%** |
| TTFT p50 | 759 ms | 696 ms | -8.3% |
| **TTFT p95** | 59,029 ms | 42,020 ms | **-28.8%** |
| TTFT p99 | 417,503 ms | 364,591 ms | -12.7% |
| ITL mean | 22.93 ms | 22.45 ms | -2.1% |
| ITL p50 | 23.14 ms | 22.19 ms | -4.1% |
| ITL p99 | 45.28 ms | 41.71 ms | -7.9% |
| Benchmark duration | 10,826 s | 10,828 s | same |
| Decode errors | 281 | 134 | -52% |
### Host Level Load Balance 
| Metric | consistent_hash | rendezvous_hash |
|---|---|---|
| Total routing decisions | 38,866 | 42,332 |
| Workers | 16 | 16 |
| Coefficient of Variation | 18.1% | 17.2% |
| Max/Min ratio | 1.92 | 2.16 |
| Prefill host balance | 9,761 vs 9,671 | 11,222 vs 9,943 |
| Decode host balance | 10,282 vs 9,148 | 10,451 vs 10,714 |
### Engine Level Load Balance
Per engine CV compare (on decode node) shows hrw is more balance most of the time
<img width="1336" height="411" alt="Screenshot 2026-04-16 at 2 48 29 AM" src="https://github.com/user-attachments/assets/ae43bf81-2d8f-4498-a575-6eb780da9d65" />
