### PR TITLE
[WIP][Feature] MoRI-IO compatibility

### DIFF
--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -158,18 +158,42 @@ pub enum RoutingMode {
         #[serde(skip_serializing_if = "Option::is_none")]
         discovery_address: Option<String>,
     },
+    #[serde(rename = "moriio_prefill_decode")]
+    MoriIOPrefillDecode {
+        /// Prefill worker URLs (unused when discovery_address is set)
+        #[serde(default)]
+        prefill_urls: Vec<(String, Option<u16>)>,
+        /// Decode worker URLs (unused when discovery_address is set)
+        #[serde(default)]
+        decode_urls: Vec<String>,
+        /// Optional separate policy for prefill workers
+        #[serde(skip_serializing_if = "Option::is_none")]
+        prefill_policy: Option<PolicyConfig>,
+        /// Optional separate policy for decode workers
+        #[serde(skip_serializing_if = "Option::is_none")]
+        decode_policy: Option<PolicyConfig>,
+        /// ZMQ service discovery address (e.g., "0.0.0.0:30001")
+        #[serde(skip_serializing_if = "Option::is_none")]
+        discovery_address: Option<String>,
+    },
 }
 
 impl RoutingMode {
     pub fn is_pd_mode(&self) -> bool {
         matches!(
             self,
-            RoutingMode::PrefillDecode { .. } | RoutingMode::VllmPrefillDecode { .. }
+            RoutingMode::PrefillDecode { .. }
+                | RoutingMode::VllmPrefillDecode { .. }
+                | RoutingMode::MoriIOPrefillDecode { .. }
         )
     }
 
     pub fn is_vllm_pd_mode(&self) -> bool {
         matches!(self, RoutingMode::VllmPrefillDecode { .. })
+    }
+
+    pub fn is_moriio_pd_mode(&self) -> bool {
+        matches!(self, RoutingMode::MoriIOPrefillDecode { .. })
     }
 
     pub fn worker_count(&self) -> usize {
@@ -181,6 +205,11 @@ impl RoutingMode {
                 ..
             } => prefill_urls.len() + decode_urls.len(),
             RoutingMode::VllmPrefillDecode {
+                prefill_urls,
+                decode_urls,
+                ..
+            } => prefill_urls.len() + decode_urls.len(),
+            RoutingMode::MoriIOPrefillDecode {
                 prefill_urls,
                 decode_urls,
                 ..
@@ -200,6 +229,9 @@ impl RoutingMode {
             RoutingMode::VllmPrefillDecode { prefill_policy, .. } => {
                 prefill_policy.as_ref().unwrap_or(main_policy)
             }
+            RoutingMode::MoriIOPrefillDecode { prefill_policy, .. } => {
+                prefill_policy.as_ref().unwrap_or(main_policy)
+            }
             _ => main_policy,
         }
     }
@@ -212,6 +244,9 @@ impl RoutingMode {
                 decode_policy.as_ref().unwrap_or(main_policy)
             }
             RoutingMode::VllmPrefillDecode { decode_policy, .. } => {
+                decode_policy.as_ref().unwrap_or(main_policy)
+            }
+            RoutingMode::MoriIOPrefillDecode { decode_policy, .. } => {
                 decode_policy.as_ref().unwrap_or(main_policy)
             }
             _ => main_policy,
@@ -512,6 +547,7 @@ impl RouterConfig {
             RoutingMode::Regular { .. } => "regular",
             RoutingMode::PrefillDecode { .. } => "prefill_decode",
             RoutingMode::VllmPrefillDecode { .. } => "vllm_prefill_decode",
+            RoutingMode::MoriIOPrefillDecode { .. } => "moriio_prefill_decode",
             RoutingMode::OpenAI { .. } => "openai",
         }
     }

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -160,12 +160,6 @@ pub enum RoutingMode {
     },
     #[serde(rename = "moriio_prefill_decode")]
     MoriIOPrefillDecode {
-        /// Prefill worker URLs (unused when discovery_address is set)
-        #[serde(default)]
-        prefill_urls: Vec<(String, Option<u16>)>,
-        /// Decode worker URLs (unused when discovery_address is set)
-        #[serde(default)]
-        decode_urls: Vec<String>,
         /// Optional separate policy for prefill workers
         #[serde(skip_serializing_if = "Option::is_none")]
         prefill_policy: Option<PolicyConfig>,
@@ -173,8 +167,7 @@ pub enum RoutingMode {
         #[serde(skip_serializing_if = "Option::is_none")]
         decode_policy: Option<PolicyConfig>,
         /// ZMQ service discovery address (e.g., "0.0.0.0:30001")
-        #[serde(skip_serializing_if = "Option::is_none")]
-        discovery_address: Option<String>,
+        discovery_address: String,
     },
 }
 
@@ -209,11 +202,7 @@ impl RoutingMode {
                 decode_urls,
                 ..
             } => prefill_urls.len() + decode_urls.len(),
-            RoutingMode::MoriIOPrefillDecode {
-                prefill_urls,
-                decode_urls,
-                ..
-            } => prefill_urls.len() + decode_urls.len(),
+            RoutingMode::MoriIOPrefillDecode { .. } => 0,
             // OpenAI mode represents a single upstream
             RoutingMode::OpenAI { .. } => 1,
         }

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -13,10 +13,7 @@ impl ConfigValidator {
                 RoutingMode::VllmPrefillDecode {
                     discovery_address: Some(_),
                     ..
-                } | RoutingMode::MoriIOPrefillDecode {
-                    discovery_address: Some(_),
-                    ..
-                }
+                } | RoutingMode::MoriIOPrefillDecode { .. }
             );
 
         Self::validate_mode(&config.mode, has_service_discovery)?;
@@ -160,35 +157,14 @@ impl ConfigValidator {
                 }
             }
             RoutingMode::MoriIOPrefillDecode {
-                prefill_urls,
-                decode_urls,
                 prefill_policy,
                 decode_policy,
                 discovery_address,
             } => {
-                // Require either discovery_address or both URL lists
-                let has_moriio_discovery = discovery_address.is_some();
-                if !has_moriio_discovery {
-                    if prefill_urls.is_empty() {
-                        return Err(ConfigError::ValidationFailed {
-                            reason: "MoRIIO PD mode requires either discovery_address or at least one prefill_urls entry".to_string(),
-                        });
-                    }
-                    if decode_urls.is_empty() {
-                        return Err(ConfigError::ValidationFailed {
-                            reason: "MoRIIO PD mode requires either discovery_address or at least one decode_urls entry".to_string(),
-                        });
-                    }
-                }
-
-                // Validate static URLs if provided
-                if !prefill_urls.is_empty() {
-                    let prefill_url_strings: Vec<String> =
-                        prefill_urls.iter().map(|(url, _)| url.clone()).collect();
-                    Self::validate_urls(&prefill_url_strings)?;
-                }
-                if !decode_urls.is_empty() {
-                    Self::validate_urls(decode_urls)?;
+                if discovery_address.is_empty() {
+                    return Err(ConfigError::ValidationFailed {
+                        reason: "MoRIIO PD mode requires a non-empty discovery_address".to_string(),
+                    });
                 }
 
                 // Validate optional prefill and decode policies

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -13,6 +13,9 @@ impl ConfigValidator {
                 RoutingMode::VllmPrefillDecode {
                     discovery_address: Some(_),
                     ..
+                } | RoutingMode::MoriIOPrefillDecode {
+                    discovery_address: Some(_),
+                    ..
                 }
             );
 
@@ -146,6 +149,46 @@ impl ConfigValidator {
                             });
                         }
                     }
+                }
+
+                // Validate optional prefill and decode policies
+                if let Some(p_policy) = prefill_policy {
+                    Self::validate_policy(p_policy)?;
+                }
+                if let Some(d_policy) = decode_policy {
+                    Self::validate_policy(d_policy)?;
+                }
+            }
+            RoutingMode::MoriIOPrefillDecode {
+                prefill_urls,
+                decode_urls,
+                prefill_policy,
+                decode_policy,
+                discovery_address,
+            } => {
+                // Require either discovery_address or both URL lists
+                let has_moriio_discovery = discovery_address.is_some();
+                if !has_moriio_discovery {
+                    if prefill_urls.is_empty() {
+                        return Err(ConfigError::ValidationFailed {
+                            reason: "MoRIIO PD mode requires either discovery_address or at least one prefill_urls entry".to_string(),
+                        });
+                    }
+                    if decode_urls.is_empty() {
+                        return Err(ConfigError::ValidationFailed {
+                            reason: "MoRIIO PD mode requires either discovery_address or at least one decode_urls entry".to_string(),
+                        });
+                    }
+                }
+
+                // Validate static URLs if provided
+                if !prefill_urls.is_empty() {
+                    let prefill_url_strings: Vec<String> =
+                        prefill_urls.iter().map(|(url, _)| url.clone()).collect();
+                    Self::validate_urls(&prefill_url_strings)?;
+                }
+                if !decode_urls.is_empty() {
+                    Self::validate_urls(decode_urls)?;
                 }
 
                 // Validate optional prefill and decode policies
@@ -333,6 +376,10 @@ impl ConfigValidator {
                         reason: "vLLM PD mode with service discovery requires at least one non-empty selector (prefill or decode)".to_string(),
                     });
                 }
+            }
+            RoutingMode::MoriIOPrefillDecode { .. } => {
+                // MoRIIO uses its own ZMQ discovery (discovery_address in mode config),
+                // not the Kubernetes discovery. Allow with or without k8s selectors.
             }
             RoutingMode::OpenAI { .. } => {
                 // OpenAI mode doesn't use service discovery

--- a/src/main.rs
+++ b/src/main.rs
@@ -571,15 +571,8 @@ impl CliArgs {
                 }
                 all_urls.extend(decode_urls.clone());
             }
-            RoutingMode::MoriIOPrefillDecode {
-                prefill_urls,
-                decode_urls,
-                ..
-            } => {
-                for (url, _) in prefill_urls {
-                    all_urls.push(url.clone());
-                }
-                all_urls.extend(decode_urls.clone());
+            RoutingMode::MoriIOPrefillDecode { .. } => {
+                // MoRIIO uses ZMQ service discovery; no static URLs to collect
             }
             RoutingMode::OpenAI { .. } => {
                 // For connection-mode detection, skip URLs; OpenAI forces HTTP below.

--- a/src/main.rs
+++ b/src/main.rs
@@ -571,6 +571,16 @@ impl CliArgs {
                 }
                 all_urls.extend(decode_urls.clone());
             }
+            RoutingMode::MoriIOPrefillDecode {
+                prefill_urls,
+                decode_urls,
+                ..
+            } => {
+                for (url, _) in prefill_urls {
+                    all_urls.push(url.clone());
+                }
+                all_urls.extend(decode_urls.clone());
+            }
             RoutingMode::OpenAI { .. } => {
                 // For connection-mode detection, skip URLs; OpenAI forces HTTP below.
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -104,9 +104,14 @@ Examples:
     --vllm-discovery-address 0.0.0.0:30001 \
     --policy consistent_hash
 
-  # Note: In vLLM mode, prefill/decode workers automatically register their
-  # HTTP and ZMQ addresses via service discovery. No static --prefill or
-  # --decode parameters are needed.
+  # MoRIIO (AMD) PD mode with ZMQ service discovery
+  vllm-router --moriio-pd-disaggregation \
+    --moriio-discovery-address 0.0.0.0:30001 \
+    --policy consistent_hash
+
+  # Note: In vLLM and MoRIIO modes, prefill/decode workers automatically
+  # register their HTTP and ZMQ addresses via service discovery. No static
+  # --prefill or --decode parameters are needed.
 
 "#)]
 struct CliArgs {
@@ -138,6 +143,15 @@ struct CliArgs {
     /// Required for --vllm-pd-disaggregation mode. Workers register their HTTP and ZMQ addresses here.
     #[arg(long)]
     vllm_discovery_address: Option<String>,
+
+    /// Enable MoRIIO PD (Prefill-Decode) disaggregated mode for AMD MoRIIO connector
+    #[arg(long, default_value_t = false)]
+    moriio_pd_disaggregation: bool,
+
+    /// ZMQ service discovery address for MoRIIO worker registration (e.g., "0.0.0.0:30001")
+    /// Required for --moriio-pd-disaggregation mode. Workers register their HTTP and ZMQ addresses here.
+    #[arg(long)]
+    moriio_discovery_address: Option<String>,
 
     /// Decode server URL (can be specified multiple times)
     #[arg(long, action = ArgAction::Append)]
@@ -419,10 +433,17 @@ impl CliArgs {
         prefill_urls: Vec<(String, Option<u16>)>,
     ) -> ConfigResult<RouterConfig> {
         // Validate mutually exclusive modes
-        if self.pd_disaggregation && self.vllm_pd_disaggregation {
+        let pd_mode_count = [
+            self.pd_disaggregation,
+            self.vllm_pd_disaggregation,
+            self.moriio_pd_disaggregation,
+        ]
+        .iter()
+        .filter(|&&b| b)
+        .count();
+        if pd_mode_count > 1 {
             return Err(ConfigError::ValidationFailed {
-                reason: "Cannot enable both --pd-disaggregation and --vllm-pd-disaggregation"
-                    .to_string(),
+                reason: "Only one of --pd-disaggregation, --vllm-pd-disaggregation, or --moriio-pd-disaggregation may be set at a time".to_string(),
             });
         }
 
@@ -506,6 +527,19 @@ impl CliArgs {
                 prefill_policy: self.prefill_policy.as_ref().map(|p| self.parse_policy(p)),
                 decode_policy: self.decode_policy.as_ref().map(|p| self.parse_policy(p)),
                 discovery_address: self.vllm_discovery_address.clone(),
+            }
+        } else if self.moriio_pd_disaggregation {
+            let discovery_address = self.moriio_discovery_address.clone().ok_or_else(|| {
+                ConfigError::ValidationFailed {
+                    reason: "--moriio-pd-disaggregation requires --moriio-discovery-address"
+                        .to_string(),
+                }
+            })?;
+            eprintln!("INFO: MoRIIO PD disaggregation mode. Discovery address: {}", discovery_address);
+            RoutingMode::MoriIOPrefillDecode {
+                prefill_policy: self.prefill_policy.as_ref().map(|p| self.parse_policy(p)),
+                decode_policy: self.decode_policy.as_ref().map(|p| self.parse_policy(p)),
+                discovery_address,
             }
         } else {
             // Regular mode
@@ -759,6 +793,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         "DEBUG: vllm_pd_disaggregation: {}",
         cli_args.vllm_pd_disaggregation
     );
+    println!(
+        "DEBUG: moriio_pd_disaggregation: {}",
+        cli_args.moriio_pd_disaggregation
+    );
 
     // Print startup info
     println!("VLLM Router starting...");
@@ -769,6 +807,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         "OpenAI Backend".to_string()
     } else if cli_args.vllm_pd_disaggregation {
         "vLLM PD Disaggregated".to_string()
+    } else if cli_args.moriio_pd_disaggregation {
+        "MoRIIO PD Disaggregated".to_string()
     } else if cli_args.pd_disaggregation {
         "PD Disaggregated".to_string()
     } else {

--- a/src/routers/factory.rs
+++ b/src/routers/factory.rs
@@ -2,7 +2,10 @@
 
 use super::{
     http::{
-        openai_router::OpenAIRouter, pd_router::PDRouter, router::Router,
+        moriio_pd_router::MoriIOPDRouter,
+        openai_router::OpenAIRouter,
+        pd_router::PDRouter,
+        router::Router,
         vllm_pd_router::VllmPDRouter,
     },
     RouterTrait,
@@ -49,6 +52,9 @@ impl RouterFactory {
                         decode_policy: _,
                         discovery_address: _,
                     } => Err("vLLM PD mode requires HTTP connection_mode".to_string()),
+                    RoutingMode::MoriIOPrefillDecode { .. } => {
+                        Err("MoRIIO PD mode requires HTTP connection_mode".to_string())
+                    }
                     RoutingMode::OpenAI { .. } => {
                         Err("OpenAI mode requires HTTP connection_mode".to_string())
                     }
@@ -91,6 +97,28 @@ impl RouterFactory {
                         tracing::info!("Creating VllmPDRouter with prefill_urls: {:?}, decode_urls: {:?}, discovery: {:?}",
                                       prefill_urls, decode_urls, discovery_address);
                         Self::create_vllm_pd_router(
+                            prefill_urls,
+                            decode_urls,
+                            discovery_address.clone(),
+                            prefill_policy.as_ref(),
+                            decode_policy.as_ref(),
+                            &ctx.router_config.policy,
+                            ctx,
+                        )
+                        .await
+                    }
+                    RoutingMode::MoriIOPrefillDecode {
+                        prefill_urls,
+                        decode_urls,
+                        prefill_policy,
+                        decode_policy,
+                        discovery_address,
+                    } => {
+                        tracing::info!(
+                            "Creating MoriIOPDRouter with discovery: {:?}",
+                            discovery_address
+                        );
+                        Self::create_moriio_pd_router(
                             prefill_urls,
                             decode_urls,
                             discovery_address.clone(),
@@ -189,6 +217,33 @@ impl RouterFactory {
         .await?;
         tracing::info!("VllmPDRouter instance created successfully");
 
+        Ok(Box::new(router))
+    }
+
+    /// Create a MoRIIO PD router with service discovery
+    pub async fn create_moriio_pd_router(
+        _prefill_urls: &[(String, Option<u16>)],
+        _decode_urls: &[String],
+        discovery_address: Option<String>,
+        prefill_policy_config: Option<&PolicyConfig>,
+        decode_policy_config: Option<&PolicyConfig>,
+        main_policy_config: &PolicyConfig,
+        ctx: &Arc<AppContext>,
+    ) -> Result<Box<dyn RouterTrait>, String> {
+        let prefill_policy =
+            PolicyFactory::create_from_config(prefill_policy_config.unwrap_or(main_policy_config));
+        let decode_policy =
+            PolicyFactory::create_from_config(decode_policy_config.unwrap_or(main_policy_config));
+        ctx.policy_registry.set_prefill_policy(prefill_policy);
+        ctx.policy_registry.set_decode_policy(decode_policy);
+
+        let discovery_addr = discovery_address.ok_or_else(|| {
+            "MoRIIO PD mode requires a discovery_address (static URL mode not yet supported)"
+                .to_string()
+        })?;
+
+        let router = MoriIOPDRouter::new_discovery(&discovery_addr, ctx).await?;
+        tracing::info!("MoriIOPDRouter instance created successfully");
         Ok(Box::new(router))
     }
 

--- a/src/routers/factory.rs
+++ b/src/routers/factory.rs
@@ -108,20 +108,16 @@ impl RouterFactory {
                         .await
                     }
                     RoutingMode::MoriIOPrefillDecode {
-                        prefill_urls,
-                        decode_urls,
                         prefill_policy,
                         decode_policy,
                         discovery_address,
                     } => {
                         tracing::info!(
-                            "Creating MoriIOPDRouter with discovery: {:?}",
+                            "Creating MoriIOPDRouter with discovery: {}",
                             discovery_address
                         );
                         Self::create_moriio_pd_router(
-                            prefill_urls,
-                            decode_urls,
-                            discovery_address.clone(),
+                            discovery_address,
                             prefill_policy.as_ref(),
                             decode_policy.as_ref(),
                             &ctx.router_config.policy,
@@ -222,9 +218,7 @@ impl RouterFactory {
 
     /// Create a MoRIIO PD router with service discovery
     pub async fn create_moriio_pd_router(
-        _prefill_urls: &[(String, Option<u16>)],
-        _decode_urls: &[String],
-        discovery_address: Option<String>,
+        discovery_address: &str,
         prefill_policy_config: Option<&PolicyConfig>,
         decode_policy_config: Option<&PolicyConfig>,
         main_policy_config: &PolicyConfig,
@@ -237,12 +231,7 @@ impl RouterFactory {
         ctx.policy_registry.set_prefill_policy(prefill_policy);
         ctx.policy_registry.set_decode_policy(decode_policy);
 
-        let discovery_addr = discovery_address.ok_or_else(|| {
-            "MoRIIO PD mode requires a discovery_address (static URL mode not yet supported)"
-                .to_string()
-        })?;
-
-        let router = MoriIOPDRouter::new_discovery(&discovery_addr, ctx).await?;
+        let router = MoriIOPDRouter::new_discovery(discovery_address, ctx).await?;
         tracing::info!("MoriIOPDRouter instance created successfully");
         Ok(Box::new(router))
     }

--- a/src/routers/http/mod.rs
+++ b/src/routers/http/mod.rs
@@ -2,6 +2,8 @@
 
 pub mod dp_utils;
 pub mod logprobs_merge;
+pub mod moriio_pd_router;
+pub mod moriio_service_discovery;
 pub mod openai_router;
 pub mod pd_router;
 pub mod pd_types;

--- a/src/routers/http/moriio_pd_router.rs
+++ b/src/routers/http/moriio_pd_router.rs
@@ -428,15 +428,10 @@ impl MoriIOPDRouter {
 
         // --- Stage 2: Decode ---
         let mut decode_req = request_json.clone();
-        // Decrement token limits by 1 to account for the prefill token
+        // Decrement max_tokens by 1 to account for the prefill token
         if let Some(mt) = decode_req.get("max_tokens").and_then(|v| v.as_u64()) {
             if mt > 0 {
                 decode_req["max_tokens"] = json!(mt - 1);
-            }
-        }
-        if let Some(mt) = decode_req.get("max_completion_tokens").and_then(|v| v.as_u64()) {
-            if mt > 0 {
-                decode_req["max_completion_tokens"] = json!(mt - 1);
             }
         }
         decode_req["kv_transfer_params"] = Self::build_decode_kv_params(
@@ -543,15 +538,10 @@ impl MoriIOPDRouter {
 
         // Build decode request immediately — block IDs stay null; decode waits for ZMQ notification
         let mut decode_req = request_json.clone();
-        // Decrement token limits by 1 to account for the prefill token
+        // Decrement max_tokens by 1 to account for the prefill token
         if let Some(mt) = decode_req.get("max_tokens").and_then(|v| v.as_u64()) {
             if mt > 0 {
                 decode_req["max_tokens"] = json!(mt - 1);
-            }
-        }
-        if let Some(mt) = decode_req.get("max_completion_tokens").and_then(|v| v.as_u64()) {
-            if mt > 0 {
-                decode_req["max_completion_tokens"] = json!(mt - 1);
             }
         }
         decode_req["kv_transfer_params"] =

--- a/src/routers/http/moriio_pd_router.rs
+++ b/src/routers/http/moriio_pd_router.rs
@@ -1,0 +1,1006 @@
+// MoRIIO PD (Prefill-Decode) Router Implementation
+// Handles AMD MoRIIO connector two-stage request routing in READ and WRITE transfer modes.
+
+use super::moriio_service_discovery::{MoriIOInstance, MoriIOServiceRegistry, TransferMode};
+use super::pd_types::error_chain;
+use crate::core::{BasicWorker, Worker, WorkerType};
+use crate::metrics::RouterMetrics;
+use crate::otel_http::{self, ClientRequestOptions};
+use crate::policies::PolicyRegistry;
+use crate::routers::{RouterTrait, WorkerManagement};
+use async_trait::async_trait;
+use axum::{
+    body::Body,
+    extract::Request,
+    http::{HeaderMap, Method, StatusCode},
+    response::{IntoResponse, Response},
+};
+use serde_json::{json, Value};
+use std::sync::Arc;
+use std::time::Instant;
+use tracing::{debug, error, info, warn};
+use uuid::Uuid;
+
+/// Parsed host and port extracted from a MoRIIO `request_address` URL
+fn extract_host_port(request_address: &str) -> Result<(String, u16), String> {
+    let parsed = url::Url::parse(request_address)
+        .map_err(|e| format!("Invalid request_address '{}': {}", request_address, e))?;
+
+    let host = parsed
+        .host_str()
+        .ok_or_else(|| format!("No host in request_address '{}'", request_address))?
+        .to_string();
+
+    let port = parsed
+        .port()
+        .ok_or_else(|| format!("No port in request_address '{}'", request_address))?;
+
+    Ok((host, port))
+}
+
+/// Convert a list of MoRIIO instances to Worker objects for policy selection
+fn instances_to_workers(instances: &[MoriIOInstance]) -> Vec<Arc<dyn Worker>> {
+    instances
+        .iter()
+        .map(|inst| {
+            // Strip path from request_address to get base URL for the worker
+            let base_url = match url::Url::parse(&inst.request_address) {
+                Ok(parsed) => {
+                    let scheme = parsed.scheme();
+                    let host = parsed.host_str().unwrap_or("localhost");
+                    match parsed.port() {
+                        Some(p) => format!("{}://{}:{}", scheme, host, p),
+                        None => format!("{}://{}", scheme, host),
+                    }
+                }
+                Err(_) => inst.request_address.clone(),
+            };
+            Arc::new(BasicWorker::new(base_url, WorkerType::Regular)) as Arc<dyn Worker>
+        })
+        .collect()
+}
+
+/// Select a worker index using the prefill or decode policy
+fn select_worker(
+    instances: &[MoriIOInstance],
+    policy_registry: &Arc<PolicyRegistry>,
+    is_prefill: bool,
+    request_text: Option<&str>,
+) -> Option<usize> {
+    if instances.is_empty() {
+        return None;
+    }
+    let workers = instances_to_workers(instances);
+    let policy = if is_prefill {
+        policy_registry.get_prefill_policy()
+    } else {
+        policy_registry.get_decode_policy()
+    };
+    policy.select_worker(&workers, request_text)
+}
+
+/// MoRIIO PD Router — routes requests through the MoRIIO connector in READ or WRITE mode
+#[derive(Debug)]
+pub struct MoriIOPDRouter {
+    /// Service registry (used in discovery mode)
+    service_registry: Arc<MoriIOServiceRegistry>,
+    /// HTTP client for forwarding requests
+    http_client: reqwest::Client,
+    /// Policy registry for load balancing
+    policy_registry: Arc<PolicyRegistry>,
+    /// Whether to use service discovery (true) or static instances (false)
+    use_discovery: bool,
+    /// Static prefill instances (used when use_discovery=false)
+    static_prefill: Vec<MoriIOInstance>,
+    /// Static decode instances (used when use_discovery=false)
+    static_decode: Vec<MoriIOInstance>,
+}
+
+impl MoriIOPDRouter {
+    /// Create a new MoRIIO PD router in service discovery mode
+    pub async fn new_discovery(
+        discovery_address: &str,
+        ctx: &Arc<crate::server::AppContext>,
+    ) -> Result<Self, String> {
+        info!(
+            "MoriIOPDRouter: starting service discovery on {}",
+            discovery_address
+        );
+        let mut registry = MoriIOServiceRegistry::new();
+        registry
+            .start_listener(discovery_address)
+            .await
+            .map_err(|e| format!("Failed to start MoRIIO service discovery: {}", e))?;
+
+        info!("MoriIOPDRouter created in discovery mode");
+        Ok(Self {
+            service_registry: Arc::new(registry),
+            http_client: reqwest::Client::new(),
+            policy_registry: ctx.policy_registry.clone(),
+            use_discovery: true,
+            static_prefill: vec![],
+            static_decode: vec![],
+        })
+    }
+
+    /// Prepare the prefill-stage request: cap max_tokens to 1 and force stream=false
+    fn prepare_prefill_request(mut req: Value) -> Value {
+        req["max_tokens"] = json!(1);
+        if let Some(mt) = req.get("max_completion_tokens") {
+            if mt.as_u64().map_or(true, |v| v > 1) {
+                req["max_completion_tokens"] = json!(1);
+            }
+        }
+        if let Some(min) = req.get("min_tokens").and_then(|v| v.as_u64()) {
+            if min > 1 {
+                req["min_tokens"] = json!(1);
+            }
+        }
+        req["stream"] = json!(false);
+        if let Some(obj) = req.as_object_mut() {
+            obj.remove("stream_options");
+        }
+        req
+    }
+
+    /// Build kv_transfer_params for the prefill request
+    fn build_prefill_kv_params(transfer_id: &str, decode: &MoriIOInstance) -> Value {
+        let (decode_host, decode_port) = match extract_host_port(&decode.request_address) {
+            Ok(hp) => hp,
+            Err(e) => {
+                warn!("Could not extract host/port from decode address: {}", e);
+                ("".to_string(), 0)
+            }
+        };
+
+        json!({
+            "transfer_id": transfer_id,
+            "remote_dp_size": decode.dp_size,
+            "remote_tp_size": decode.tp_size,
+            "do_remote_decode": true,
+            "do_remote_prefill": false,
+            "remote_handshake_port": decode.handshake_port,
+            "remote_notify_port": decode.notify_port,
+            "remote_engine_id": null,
+            "remote_block_ids": null,
+            "remote_host": decode_host,
+            "remote_port": decode_port,
+            "max_tokens": 1,
+            "stream": false
+        })
+    }
+
+    /// Build kv_transfer_params for the decode request
+    fn build_decode_kv_params(
+        transfer_id: &str,
+        prefill: &MoriIOInstance,
+        prefill_idx: usize,
+        remote_engine_id: Option<&Value>,
+        remote_block_ids: Option<&Value>,
+    ) -> Value {
+        let (prefill_host, prefill_port) = match extract_host_port(&prefill.request_address) {
+            Ok(hp) => hp,
+            Err(e) => {
+                warn!("Could not extract host/port from prefill address: {}", e);
+                ("".to_string(), 0)
+            }
+        };
+
+        let mut params = json!({
+            "transfer_id": transfer_id,
+            "remote_dp_size": prefill.dp_size,
+            "remote_tp_size": prefill.tp_size,
+            "do_remote_decode": false,
+            "do_remote_prefill": true,
+            "remote_handshake_port": prefill.handshake_port,
+            "remote_notify_port": prefill.notify_port,
+            "remote_engine_id": remote_engine_id.cloned().unwrap_or(Value::Null),
+            "remote_block_ids": remote_block_ids.cloned().unwrap_or(Value::Null),
+            "remote_host": prefill_host,
+            "remote_port": prefill_port,
+        });
+
+        // Add remote_dp_rank only when prefill has > 1 DP ranks
+        if prefill.dp_size > 1 {
+            params["remote_dp_rank"] = json!(prefill_idx % prefill.dp_size as usize);
+        }
+
+        params
+    }
+
+    /// Core two-stage routing: handles both READ and WRITE transfer modes
+    async fn process_moriio_request(
+        &self,
+        request_json: Value,
+        path: &str,
+        headers: Option<&HeaderMap>,
+    ) -> Response {
+        // Fetch live instances
+        let prefill_instances = if self.use_discovery {
+            self.service_registry.get_prefill_instances()
+        } else {
+            self.static_prefill.clone()
+        };
+        let decode_instances = if self.use_discovery {
+            self.service_registry.get_decode_instances()
+        } else {
+            self.static_decode.clone()
+        };
+
+        if prefill_instances.is_empty() || decode_instances.is_empty() {
+            RouterMetrics::record_pd_error("server_selection");
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                format!(
+                    "No MoRIIO workers available: {} prefill, {} decode",
+                    prefill_instances.len(),
+                    decode_instances.len()
+                ),
+            )
+                .into_response();
+        }
+
+        // Detect transfer mode (use first available instance's mode)
+        let transfer_mode = if self.use_discovery {
+            match self.service_registry.transfer_mode() {
+                Some(m) => m,
+                None => {
+                    return (
+                        StatusCode::SERVICE_UNAVAILABLE,
+                        "MoRIIO transfer_mode not yet determined (no instance registered)",
+                    )
+                        .into_response();
+                }
+            }
+        } else {
+            prefill_instances[0].transfer_mode
+        };
+
+        let request_text = serde_json::to_string(&request_json).ok();
+        let request_str = request_text.as_deref();
+
+        let prefill_idx =
+            match select_worker(&prefill_instances, &self.policy_registry, true, request_str) {
+                Some(idx) => idx,
+                None => {
+                    RouterMetrics::record_pd_error("server_selection");
+                    return (
+                        StatusCode::SERVICE_UNAVAILABLE,
+                        "Prefill policy failed to select a worker".to_string(),
+                    )
+                        .into_response();
+                }
+            };
+
+        let decode_idx =
+            match select_worker(&decode_instances, &self.policy_registry, false, request_str) {
+                Some(idx) => idx,
+                None => {
+                    RouterMetrics::record_pd_error("server_selection");
+                    return (
+                        StatusCode::SERVICE_UNAVAILABLE,
+                        "Decode policy failed to select a worker".to_string(),
+                    )
+                        .into_response();
+                }
+            };
+
+        let prefill = &prefill_instances[prefill_idx];
+        let decode = &decode_instances[decode_idx];
+        let transfer_id = format!("tx-{}", Uuid::new_v4());
+
+        info!(
+            "MoRIIO routing [mode={}]: prefill={}, decode={}, transfer_id={}",
+            transfer_mode, prefill.request_address, decode.request_address, transfer_id
+        );
+
+        match transfer_mode {
+            TransferMode::Read => {
+                self.process_read_mode(
+                    request_json,
+                    prefill,
+                    decode,
+                    prefill_idx,
+                    &transfer_id,
+                    path,
+                    headers,
+                )
+                .await
+            }
+            TransferMode::Write => {
+                self.process_write_mode(
+                    request_json,
+                    prefill,
+                    decode,
+                    prefill_idx,
+                    &transfer_id,
+                    path,
+                    headers,
+                )
+                .await
+            }
+        }
+    }
+
+    /// READ mode: send prefill first, extract block metadata, then send decode
+    async fn process_read_mode(
+        &self,
+        request_json: Value,
+        prefill: &MoriIOInstance,
+        decode: &MoriIOInstance,
+        prefill_idx: usize,
+        transfer_id: &str,
+        path: &str,
+        headers: Option<&HeaderMap>,
+    ) -> Response {
+        let start = Instant::now();
+
+        // --- Stage 1: Prefill ---
+        let mut prefill_req = Self::prepare_prefill_request(request_json.clone());
+        prefill_req["kv_transfer_params"] =
+            Self::build_prefill_kv_params(transfer_id, decode);
+
+        let prefill_body = match serde_json::to_string(&prefill_req) {
+            Ok(s) => s,
+            Err(e) => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("Failed to serialize prefill request: {}", e),
+                )
+                    .into_response()
+            }
+        };
+
+        // Construct proper prefill URL using base (scheme+host+port) + path
+        let prefill_base_url = match url::Url::parse(&prefill.request_address) {
+            Ok(u) => {
+                let host = u.host_str().unwrap_or("localhost");
+                let port = u.port().unwrap_or(8000);
+                format!("{}://{}:{}", u.scheme(), host, port)
+            }
+            Err(_) => prefill.request_address.clone(),
+        };
+        let prefill_request_url = format!("{}{}", prefill_base_url, path);
+
+        debug!("MoRIIO READ Stage 1 — prefill POST {}", prefill_request_url);
+
+        let prefill_resp = match otel_http::send_client_request(
+            self.http_client
+                .post(&prefill_request_url)
+                .header("Content-Type", "application/json")
+                .body(prefill_body),
+            headers,
+            ClientRequestOptions {
+                method: "POST",
+                url: &prefill_request_url,
+                route: Some(path),
+                request_phase: Some("prefill"),
+            },
+        )
+        .await
+        {
+            Ok(r) => r,
+            Err(e) => {
+                let duration = start.elapsed();
+                RouterMetrics::record_pd_prefill_error(&prefill.request_address);
+                RouterMetrics::record_pd_request(path);
+                RouterMetrics::record_pd_request_duration(path, duration);
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!(
+                        "Prefill request to {} failed: {}",
+                        prefill_request_url,
+                        error_chain(&e)
+                    ),
+                )
+                    .into_response();
+            }
+        };
+
+        let prefill_status = prefill_resp.status();
+        if !prefill_status.is_success() {
+            let duration = start.elapsed();
+            RouterMetrics::record_pd_prefill_error(&prefill.request_address);
+            RouterMetrics::record_pd_request(path);
+            RouterMetrics::record_pd_request_duration(path, duration);
+            let body_text = prefill_resp.text().await.unwrap_or_default();
+            return (
+                prefill_status,
+                format!("Prefill error {}: {}", prefill_status, body_text),
+            )
+                .into_response();
+        }
+
+        // Parse prefill response to extract remote_engine_id and remote_block_ids
+        let prefill_text = match prefill_resp.text().await {
+            Ok(t) => t,
+            Err(e) => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("Failed to read prefill response: {}", error_chain(&e)),
+                )
+                    .into_response()
+            }
+        };
+
+        let prefill_json: Value = match serde_json::from_str(&prefill_text) {
+            Ok(v) => v,
+            Err(e) => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("Failed to parse prefill response JSON: {}", e),
+                )
+                    .into_response()
+            }
+        };
+
+        let remote_engine_id = prefill_json
+            .get("kv_transfer_params")
+            .and_then(|kv| kv.get("remote_engine_id"));
+        let remote_block_ids = prefill_json
+            .get("kv_transfer_params")
+            .and_then(|kv| kv.get("remote_block_ids"));
+
+        debug!(
+            "MoRIIO READ: extracted remote_engine_id={:?}, remote_block_ids present={}",
+            remote_engine_id,
+            remote_block_ids.is_some()
+        );
+
+        // --- Stage 2: Decode ---
+        let mut decode_req = request_json.clone();
+        // Decrement max_tokens by 1 to account for the prefill token
+        if let Some(mt) = decode_req.get("max_tokens").and_then(|v| v.as_u64()) {
+            if mt > 0 {
+                decode_req["max_tokens"] = json!(mt - 1);
+            }
+        }
+        decode_req["kv_transfer_params"] = Self::build_decode_kv_params(
+            transfer_id,
+            prefill,
+            prefill_idx,
+            remote_engine_id,
+            remote_block_ids,
+        );
+
+        self.send_decode_request(
+            decode_req,
+            decode,
+            path,
+            headers,
+            &start,
+            &prefill.request_address,
+            &decode.request_address,
+        )
+        .await
+    }
+
+    /// WRITE mode: fire prefill in background, then send decode concurrently
+    async fn process_write_mode(
+        &self,
+        request_json: Value,
+        prefill: &MoriIOInstance,
+        decode: &MoriIOInstance,
+        prefill_idx: usize,
+        transfer_id: &str,
+        path: &str,
+        headers: Option<&HeaderMap>,
+    ) -> Response {
+        let start = Instant::now();
+
+        // Build prefill request
+        let mut prefill_req = Self::prepare_prefill_request(request_json.clone());
+        prefill_req["kv_transfer_params"] =
+            Self::build_prefill_kv_params(transfer_id, decode);
+
+        let prefill_body = match serde_json::to_string(&prefill_req) {
+            Ok(s) => s,
+            Err(e) => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("Failed to serialize prefill request: {}", e),
+                )
+                    .into_response()
+            }
+        };
+
+        let prefill_base_url = match url::Url::parse(&prefill.request_address) {
+            Ok(u) => {
+                let host = u.host_str().unwrap_or("localhost");
+                let port = u.port().unwrap_or(8000);
+                format!("{}://{}:{}", u.scheme(), host, port)
+            }
+            Err(_) => prefill.request_address.clone(),
+        };
+        let prefill_request_url = format!("{}{}", prefill_base_url, path);
+
+        // Clone what we need for the background task
+        let http_client_clone = self.http_client.clone();
+        let prefill_addr_clone = prefill.request_address.clone();
+        let prefill_url_clone = prefill_request_url.clone();
+
+        // Fire prefill in background — decode handles synchronisation via ZMQ internally
+        tokio::spawn(async move {
+            debug!(
+                "MoRIIO WRITE: firing prefill in background at {}",
+                prefill_url_clone
+            );
+            match http_client_clone
+                .post(&prefill_url_clone)
+                .header("Content-Type", "application/json")
+                .body(prefill_body)
+                .send()
+                .await
+            {
+                Ok(resp) => {
+                    debug!(
+                        "MoRIIO WRITE: prefill background response status={}",
+                        resp.status()
+                    );
+                    if !resp.status().is_success() {
+                        RouterMetrics::record_pd_prefill_error(&prefill_addr_clone);
+                        warn!(
+                            "MoRIIO WRITE: background prefill to {} returned {}",
+                            prefill_url_clone,
+                            resp.status()
+                        );
+                    }
+                }
+                Err(e) => {
+                    RouterMetrics::record_pd_prefill_error(&prefill_addr_clone);
+                    error!(
+                        "MoRIIO WRITE: background prefill to {} failed: {}",
+                        prefill_url_clone,
+                        error_chain(&e)
+                    );
+                }
+            }
+        });
+
+        // Build decode request immediately — block IDs stay null; decode waits for ZMQ notification
+        let mut decode_req = request_json.clone();
+        if let Some(mt) = decode_req.get("max_tokens").and_then(|v| v.as_u64()) {
+            if mt > 0 {
+                decode_req["max_tokens"] = json!(mt - 1);
+            }
+        }
+        decode_req["kv_transfer_params"] =
+            Self::build_decode_kv_params(transfer_id, prefill, prefill_idx, None, None);
+
+        self.send_decode_request(
+            decode_req,
+            decode,
+            path,
+            headers,
+            &start,
+            &prefill.request_address,
+            &decode.request_address,
+        )
+        .await
+    }
+
+    /// Send the decode request and forward the response to the caller
+    async fn send_decode_request(
+        &self,
+        decode_req: Value,
+        decode: &MoriIOInstance,
+        path: &str,
+        headers: Option<&HeaderMap>,
+        start: &Instant,
+        prefill_addr: &str,
+        decode_addr: &str,
+    ) -> Response {
+        let decode_base_url = match url::Url::parse(&decode.request_address) {
+            Ok(u) => {
+                let host = u.host_str().unwrap_or("localhost");
+                let port = u.port().unwrap_or(8000);
+                format!("{}://{}:{}", u.scheme(), host, port)
+            }
+            Err(_) => decode.request_address.clone(),
+        };
+        let decode_request_url = format!("{}{}", decode_base_url, path);
+
+        let decode_body = match serde_json::to_string(&decode_req) {
+            Ok(s) => s,
+            Err(e) => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("Failed to serialize decode request: {}", e),
+                )
+                    .into_response()
+            }
+        };
+
+        debug!("MoRIIO decode POST {}", decode_request_url);
+
+        let decode_resp = match otel_http::send_client_request(
+            self.http_client
+                .post(&decode_request_url)
+                .header("Content-Type", "application/json")
+                .body(decode_body),
+            headers,
+            ClientRequestOptions {
+                method: "POST",
+                url: &decode_request_url,
+                route: Some(path),
+                request_phase: Some("decode"),
+            },
+        )
+        .await
+        {
+            Ok(r) => r,
+            Err(e) => {
+                let duration = start.elapsed();
+                RouterMetrics::record_pd_decode_error(decode_addr);
+                RouterMetrics::record_pd_request(path);
+                RouterMetrics::record_pd_request_duration(path, duration);
+                RouterMetrics::record_pd_prefill_request(prefill_addr);
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!(
+                        "Decode request to {} failed: {}",
+                        decode_request_url,
+                        error_chain(&e)
+                    ),
+                )
+                    .into_response();
+            }
+        };
+
+        let duration = start.elapsed();
+        let status = decode_resp.status();
+        let resp_headers = decode_resp.headers().clone();
+
+        RouterMetrics::record_pd_request(path);
+        RouterMetrics::record_pd_request_duration(path, duration);
+        RouterMetrics::record_pd_prefill_request(prefill_addr);
+        RouterMetrics::record_pd_decode_request(decode_addr);
+        if !status.is_success() {
+            RouterMetrics::record_pd_decode_error(decode_addr);
+        }
+
+        // Stream decode response back to caller
+        let mut builder = axum::http::Response::builder().status(status);
+        for (name, value) in resp_headers.iter() {
+            if name != "transfer-encoding" && name != "content-length" {
+                builder = builder.header(name, value);
+            }
+        }
+        builder
+            .body(Body::from_stream(decode_resp.bytes_stream()))
+            .unwrap_or_else(|e| {
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("Failed to build response: {}", e),
+                )
+                    .into_response()
+            })
+    }
+}
+
+// ── RouterTrait implementation ───────────────────────────────────────────────
+
+#[async_trait]
+impl RouterTrait for MoriIOPDRouter {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    async fn health(&self, _req: Request<Body>) -> Response {
+        (StatusCode::OK, "OK").into_response()
+    }
+
+    async fn health_generate(&self, _req: Request<Body>) -> Response {
+        (StatusCode::OK, "OK").into_response()
+    }
+
+    async fn get_server_info(&self, _req: Request<Body>) -> Response {
+        (StatusCode::NOT_IMPLEMENTED, "not implemented").into_response()
+    }
+
+    async fn get_models(&self, _req: Request<Body>) -> Response {
+        (StatusCode::NOT_IMPLEMENTED, "not implemented").into_response()
+    }
+
+    async fn get_model_info(&self, _req: Request<Body>) -> Response {
+        (StatusCode::NOT_IMPLEMENTED, "not implemented").into_response()
+    }
+
+    async fn route_generate(
+        &self,
+        _headers: Option<&HeaderMap>,
+        _body: &crate::protocols::spec::GenerateRequest,
+        _model_id: Option<&str>,
+    ) -> Response {
+        (
+            StatusCode::NOT_IMPLEMENTED,
+            "MoRIIO router does not support the generate API",
+        )
+            .into_response()
+    }
+
+    async fn route_chat(
+        &self,
+        headers: Option<&HeaderMap>,
+        body: &crate::protocols::spec::ChatCompletionRequest,
+        _model_id: Option<&str>,
+    ) -> Response {
+        let request_json = match serde_json::to_value(body) {
+            Ok(v) => v,
+            Err(e) => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("Serialization error: {}", e),
+                )
+                    .into_response()
+            }
+        };
+        self.process_moriio_request(request_json, "/v1/chat/completions", headers)
+            .await
+    }
+
+    async fn route_completion(
+        &self,
+        headers: Option<&HeaderMap>,
+        body: &crate::protocols::spec::CompletionRequest,
+        _model_id: Option<&str>,
+    ) -> Response {
+        let request_json = match serde_json::to_value(body) {
+            Ok(v) => v,
+            Err(e) => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("Serialization error: {}", e),
+                )
+                    .into_response()
+            }
+        };
+        self.process_moriio_request(request_json, "/v1/completions", headers)
+            .await
+    }
+
+    async fn route_responses(
+        &self,
+        _headers: Option<&HeaderMap>,
+        _body: &crate::protocols::spec::ResponsesRequest,
+        _model_id: Option<&str>,
+    ) -> Response {
+        (
+            StatusCode::NOT_IMPLEMENTED,
+            "MoRIIO router does not support the responses API",
+        )
+            .into_response()
+    }
+
+    async fn get_response(&self, _headers: Option<&HeaderMap>, _response_id: &str) -> Response {
+        (StatusCode::NOT_IMPLEMENTED, "not implemented").into_response()
+    }
+
+    async fn cancel_response(&self, _headers: Option<&HeaderMap>, _response_id: &str) -> Response {
+        (StatusCode::NOT_IMPLEMENTED, "not implemented").into_response()
+    }
+
+    async fn route_embeddings(
+        &self,
+        _headers: Option<&HeaderMap>,
+        _body: &crate::protocols::spec::EmbeddingRequest,
+        _model_id: Option<&str>,
+    ) -> Response {
+        (
+            StatusCode::NOT_IMPLEMENTED,
+            "MoRIIO router does not support the embeddings API",
+        )
+            .into_response()
+    }
+
+    async fn route_rerank(
+        &self,
+        _headers: Option<&HeaderMap>,
+        _body: &crate::protocols::spec::RerankRequest,
+        _model_id: Option<&str>,
+    ) -> Response {
+        (
+            StatusCode::NOT_IMPLEMENTED,
+            "MoRIIO router does not support the rerank API",
+        )
+            .into_response()
+    }
+
+    async fn flush_cache(&self) -> Response {
+        (StatusCode::OK, "OK").into_response()
+    }
+
+    async fn get_worker_loads(&self) -> Response {
+        let (prefill_count, decode_count) = self.service_registry.get_instance_counts();
+        (
+            StatusCode::OK,
+            format!(
+                "{{\"prefill_instances\":{},\"decode_instances\":{}}}",
+                prefill_count, decode_count
+            ),
+        )
+            .into_response()
+    }
+
+    fn router_type(&self) -> &'static str {
+        "moriio_pd"
+    }
+
+    fn readiness(&self) -> Response {
+        if self.use_discovery {
+            let (p, d) = self.service_registry.get_instance_counts();
+            if p == 0 || d == 0 {
+                return (
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    "Waiting for MoRIIO workers to register",
+                )
+                    .into_response();
+            }
+        } else if self.static_prefill.is_empty() || self.static_decode.is_empty() {
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                "No MoRIIO static workers configured",
+            )
+                .into_response();
+        }
+        (StatusCode::OK, "OK").into_response()
+    }
+
+    async fn route_transparent(
+        &self,
+        headers: Option<&HeaderMap>,
+        path: &str,
+        method: &Method,
+        body: Value,
+    ) -> Response {
+        if *method != Method::POST {
+            return (
+                StatusCode::METHOD_NOT_ALLOWED,
+                "Only POST requests are supported",
+            )
+                .into_response();
+        }
+        self.process_moriio_request(body, path, headers).await
+    }
+}
+
+// ── WorkerManagement (stub — MoRIIO workers are managed via ZMQ discovery) ──
+
+#[async_trait]
+impl WorkerManagement for MoriIOPDRouter {
+    async fn add_worker(&self, _worker_url: &str) -> Result<String, String> {
+        Err("MoRIIO workers register via ZMQ service discovery".to_string())
+    }
+
+    fn remove_worker(&self, _worker_url: &str) {}
+
+    fn get_worker_urls(&self) -> Vec<String> {
+        let prefill: Vec<_> = self
+            .service_registry
+            .get_prefill_instances()
+            .into_iter()
+            .map(|i| i.request_address)
+            .collect();
+        let decode: Vec<_> = self
+            .service_registry
+            .get_decode_instances()
+            .into_iter()
+            .map(|i| i.request_address)
+            .collect();
+        [prefill, decode].concat()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_host_port_valid() {
+        let (host, port) =
+            extract_host_port("http://192.168.1.10:8000/v1/completions").unwrap();
+        assert_eq!(host, "192.168.1.10");
+        assert_eq!(port, 8000);
+    }
+
+    #[test]
+    fn test_extract_host_port_no_port() {
+        assert!(extract_host_port("http://myhost/v1/completions").is_err());
+    }
+
+    #[test]
+    fn test_extract_host_port_invalid_url() {
+        assert!(extract_host_port("not-a-url").is_err());
+    }
+
+    #[test]
+    fn test_prepare_prefill_request_caps_max_tokens() {
+        let req = json!({
+            "max_tokens": 512,
+            "stream": true,
+            "stream_options": {"include_usage": true}
+        });
+        let result = MoriIOPDRouter::prepare_prefill_request(req);
+        assert_eq!(result["max_tokens"], 1);
+        assert_eq!(result["stream"], false);
+        assert!(result.get("stream_options").is_none());
+    }
+
+    #[test]
+    fn test_prepare_prefill_request_clamps_min_tokens() {
+        let req = json!({"max_tokens": 512, "min_tokens": 100});
+        let result = MoriIOPDRouter::prepare_prefill_request(req);
+        assert_eq!(result["min_tokens"], 1);
+    }
+
+    fn make_instance(addr: &str, mode: TransferMode) -> MoriIOInstance {
+        MoriIOInstance {
+            request_address: addr.to_string(),
+            handshake_port: 8001,
+            notify_port: 8002,
+            dp_size: 1,
+            tp_size: 1,
+            transfer_mode: mode,
+            expires_at: u64::MAX,
+        }
+    }
+
+    #[test]
+    fn test_build_prefill_kv_params() {
+        let decode = make_instance("http://10.0.0.2:9000/v1/completions", TransferMode::Read);
+        let params = MoriIOPDRouter::build_prefill_kv_params("tx-abc", &decode);
+        assert_eq!(params["transfer_id"], "tx-abc");
+        assert_eq!(params["do_remote_decode"], true);
+        assert_eq!(params["do_remote_prefill"], false);
+        assert_eq!(params["remote_handshake_port"], 8001);
+        assert_eq!(params["remote_notify_port"], 8002);
+        assert_eq!(params["remote_host"], "10.0.0.2");
+        assert_eq!(params["remote_port"], 9000);
+        assert_eq!(params["remote_engine_id"], Value::Null);
+        assert_eq!(params["remote_block_ids"], Value::Null);
+    }
+
+    #[test]
+    fn test_build_decode_kv_params_read_mode_with_engine_id() {
+        let prefill = make_instance("http://10.0.0.1:8000/v1/completions", TransferMode::Read);
+        let engine_id = json!("engine-xyz");
+        let block_ids = json!([1, 2, 3]);
+        let params = MoriIOPDRouter::build_decode_kv_params(
+            "tx-abc",
+            &prefill,
+            0,
+            Some(&engine_id),
+            Some(&block_ids),
+        );
+        assert_eq!(params["transfer_id"], "tx-abc");
+        assert_eq!(params["do_remote_prefill"], true);
+        assert_eq!(params["do_remote_decode"], false);
+        assert_eq!(params["remote_engine_id"], engine_id);
+        assert_eq!(params["remote_block_ids"], block_ids);
+        assert_eq!(params["remote_host"], "10.0.0.1");
+        assert_eq!(params["remote_port"], 8000);
+        // dp_size == 1, so remote_dp_rank should not be present
+        assert!(params.get("remote_dp_rank").is_none());
+    }
+
+    #[test]
+    fn test_build_decode_kv_params_dp_rank_included_when_dp_gt_1() {
+        let mut prefill =
+            make_instance("http://10.0.0.1:8000/v1/completions", TransferMode::Read);
+        prefill.dp_size = 4;
+        let params =
+            MoriIOPDRouter::build_decode_kv_params("tx-abc", &prefill, 2, None, None);
+        assert!(params.get("remote_dp_rank").is_some());
+        // rank = prefill_idx % dp_size = 2 % 4 = 2
+        assert_eq!(params["remote_dp_rank"], 2);
+    }
+
+    #[test]
+    fn test_build_decode_kv_params_write_mode_null_blocks() {
+        let prefill = make_instance("http://10.0.0.1:8000/v1/completions", TransferMode::Write);
+        let params =
+            MoriIOPDRouter::build_decode_kv_params("tx-write", &prefill, 0, None, None);
+        assert_eq!(params["remote_engine_id"], Value::Null);
+        assert_eq!(params["remote_block_ids"], Value::Null);
+    }
+}

--- a/src/routers/http/moriio_pd_router.rs
+++ b/src/routers/http/moriio_pd_router.rs
@@ -82,18 +82,12 @@ fn select_worker(
 /// MoRIIO PD Router — routes requests through the MoRIIO connector in READ or WRITE mode
 #[derive(Debug)]
 pub struct MoriIOPDRouter {
-    /// Service registry (used in discovery mode)
+    /// Service registry for ZMQ-based instance discovery
     service_registry: Arc<MoriIOServiceRegistry>,
     /// HTTP client for forwarding requests
     http_client: reqwest::Client,
     /// Policy registry for load balancing
     policy_registry: Arc<PolicyRegistry>,
-    /// Whether to use service discovery (true) or static instances (false)
-    use_discovery: bool,
-    /// Static prefill instances (used when use_discovery=false)
-    static_prefill: Vec<MoriIOInstance>,
-    /// Static decode instances (used when use_discovery=false)
-    static_decode: Vec<MoriIOInstance>,
 }
 
 impl MoriIOPDRouter {
@@ -117,9 +111,6 @@ impl MoriIOPDRouter {
             service_registry: Arc::new(registry),
             http_client: reqwest::Client::new(),
             policy_registry: ctx.policy_registry.clone(),
-            use_discovery: true,
-            static_prefill: vec![],
-            static_decode: vec![],
         })
     }
 
@@ -215,17 +206,9 @@ impl MoriIOPDRouter {
         path: &str,
         headers: Option<&HeaderMap>,
     ) -> Response {
-        // Fetch live instances
-        let prefill_instances = if self.use_discovery {
-            self.service_registry.get_prefill_instances()
-        } else {
-            self.static_prefill.clone()
-        };
-        let decode_instances = if self.use_discovery {
-            self.service_registry.get_decode_instances()
-        } else {
-            self.static_decode.clone()
-        };
+        // Fetch live instances from service registry
+        let prefill_instances = self.service_registry.get_prefill_instances();
+        let decode_instances = self.service_registry.get_decode_instances();
 
         if prefill_instances.is_empty() || decode_instances.is_empty() {
             RouterMetrics::record_pd_error("server_selection");
@@ -240,20 +223,16 @@ impl MoriIOPDRouter {
                 .into_response();
         }
 
-        // Detect transfer mode (use first available instance's mode)
-        let transfer_mode = if self.use_discovery {
-            match self.service_registry.transfer_mode() {
-                Some(m) => m,
-                None => {
-                    return (
-                        StatusCode::SERVICE_UNAVAILABLE,
-                        "MoRIIO transfer_mode not yet determined (no instance registered)",
-                    )
-                        .into_response();
-                }
+        // Detect transfer mode from service registry
+        let transfer_mode = match self.service_registry.transfer_mode() {
+            Some(m) => m,
+            None => {
+                return (
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    "MoRIIO transfer_mode not yet determined (no instance registered)",
+                )
+                    .into_response();
             }
-        } else {
-            prefill_instances[0].transfer_mode
         };
 
         let request_text = serde_json::to_string(&request_json).ok();
@@ -449,10 +428,15 @@ impl MoriIOPDRouter {
 
         // --- Stage 2: Decode ---
         let mut decode_req = request_json.clone();
-        // Decrement max_tokens by 1 to account for the prefill token
+        // Decrement token limits by 1 to account for the prefill token
         if let Some(mt) = decode_req.get("max_tokens").and_then(|v| v.as_u64()) {
             if mt > 0 {
                 decode_req["max_tokens"] = json!(mt - 1);
+            }
+        }
+        if let Some(mt) = decode_req.get("max_completion_tokens").and_then(|v| v.as_u64()) {
+            if mt > 0 {
+                decode_req["max_completion_tokens"] = json!(mt - 1);
             }
         }
         decode_req["kv_transfer_params"] = Self::build_decode_kv_params(
@@ -559,9 +543,15 @@ impl MoriIOPDRouter {
 
         // Build decode request immediately — block IDs stay null; decode waits for ZMQ notification
         let mut decode_req = request_json.clone();
+        // Decrement token limits by 1 to account for the prefill token
         if let Some(mt) = decode_req.get("max_tokens").and_then(|v| v.as_u64()) {
             if mt > 0 {
                 decode_req["max_tokens"] = json!(mt - 1);
+            }
+        }
+        if let Some(mt) = decode_req.get("max_completion_tokens").and_then(|v| v.as_u64()) {
+            if mt > 0 {
+                decode_req["max_completion_tokens"] = json!(mt - 1);
             }
         }
         decode_req["kv_transfer_params"] =
@@ -812,14 +802,11 @@ impl RouterTrait for MoriIOPDRouter {
 
     async fn get_worker_loads(&self) -> Response {
         let (prefill_count, decode_count) = self.service_registry.get_instance_counts();
-        (
-            StatusCode::OK,
-            format!(
-                "{{\"prefill_instances\":{},\"decode_instances\":{}}}",
-                prefill_count, decode_count
-            ),
-        )
-            .into_response()
+        let body = serde_json::json!({
+            "prefill_instances": prefill_count,
+            "decode_instances": decode_count,
+        });
+        (StatusCode::OK, body.to_string()).into_response()
     }
 
     fn router_type(&self) -> &'static str {
@@ -827,19 +814,11 @@ impl RouterTrait for MoriIOPDRouter {
     }
 
     fn readiness(&self) -> Response {
-        if self.use_discovery {
-            let (p, d) = self.service_registry.get_instance_counts();
-            if p == 0 || d == 0 {
-                return (
-                    StatusCode::SERVICE_UNAVAILABLE,
-                    "Waiting for MoRIIO workers to register",
-                )
-                    .into_response();
-            }
-        } else if self.static_prefill.is_empty() || self.static_decode.is_empty() {
+        let (p, d) = self.service_registry.get_instance_counts();
+        if p == 0 || d == 0 {
             return (
                 StatusCode::SERVICE_UNAVAILABLE,
-                "No MoRIIO static workers configured",
+                "Waiting for MoRIIO workers to register",
             )
                 .into_response();
         }
@@ -933,21 +912,20 @@ mod tests {
         assert_eq!(result["min_tokens"], 1);
     }
 
-    fn make_instance(addr: &str, mode: TransferMode) -> MoriIOInstance {
+    fn make_instance(addr: &str) -> MoriIOInstance {
         MoriIOInstance {
             request_address: addr.to_string(),
             handshake_port: 8001,
             notify_port: 8002,
             dp_size: 1,
             tp_size: 1,
-            transfer_mode: mode,
             expires_at: u64::MAX,
         }
     }
 
     #[test]
     fn test_build_prefill_kv_params() {
-        let decode = make_instance("http://10.0.0.2:9000/v1/completions", TransferMode::Read);
+        let decode = make_instance("http://10.0.0.2:9000/v1/completions");
         let params = MoriIOPDRouter::build_prefill_kv_params("tx-abc", &decode);
         assert_eq!(params["transfer_id"], "tx-abc");
         assert_eq!(params["do_remote_decode"], true);
@@ -962,7 +940,7 @@ mod tests {
 
     #[test]
     fn test_build_decode_kv_params_read_mode_with_engine_id() {
-        let prefill = make_instance("http://10.0.0.1:8000/v1/completions", TransferMode::Read);
+        let prefill = make_instance("http://10.0.0.1:8000/v1/completions");
         let engine_id = json!("engine-xyz");
         let block_ids = json!([1, 2, 3]);
         let params = MoriIOPDRouter::build_decode_kv_params(
@@ -986,7 +964,7 @@ mod tests {
     #[test]
     fn test_build_decode_kv_params_dp_rank_included_when_dp_gt_1() {
         let mut prefill =
-            make_instance("http://10.0.0.1:8000/v1/completions", TransferMode::Read);
+            make_instance("http://10.0.0.1:8000/v1/completions");
         prefill.dp_size = 4;
         let params =
             MoriIOPDRouter::build_decode_kv_params("tx-abc", &prefill, 2, None, None);
@@ -997,7 +975,7 @@ mod tests {
 
     #[test]
     fn test_build_decode_kv_params_write_mode_null_blocks() {
-        let prefill = make_instance("http://10.0.0.1:8000/v1/completions", TransferMode::Write);
+        let prefill = make_instance("http://10.0.0.1:8000/v1/completions");
         let params =
             MoriIOPDRouter::build_decode_kv_params("tx-write", &prefill, 0, None, None);
         assert_eq!(params["remote_engine_id"], Value::Null);

--- a/src/routers/http/moriio_service_discovery.rs
+++ b/src/routers/http/moriio_service_discovery.rs
@@ -68,7 +68,6 @@ pub struct MoriIOInstance {
     pub notify_port: u16,
     pub dp_size: u32,
     pub tp_size: u32,
-    pub transfer_mode: TransferMode,
     /// Unix timestamp after which this entry is considered stale
     pub expires_at: u64,
 }
@@ -127,6 +126,7 @@ impl MoriIOServiceRegistry {
             info!("MoRIIO ZMQ service discovery bound to tcp://{}", bind_addr);
             socket.set_rcvtimeo(1000).unwrap();
 
+            let mut cleanup_counter: u32 = 0;
             loop {
                 if shutdown_rx.try_recv().is_ok() {
                     info!("MoRIIO service discovery shutting down");
@@ -134,18 +134,17 @@ impl MoriIOServiceRegistry {
                 }
 
                 match socket.recv_multipart(zmq::DONTWAIT) {
-                    Ok(parts) if parts.len() >= 2 => {
-                        let message_data = &parts[1];
+                    Ok(parts) if parts.len() >= 3 => {
+                        let message_data = &parts[2];
                         Self::handle_registration(
                             message_data,
                             &prefill_instances,
                             &decode_instances,
                             &global_transfer_mode,
-                        )
-                        .await;
+                        );
                     }
                     Ok(_) => {
-                        warn!("MoRIIO ZMQ received malformed multipart message (< 2 parts)");
+                        warn!("MoRIIO ZMQ received malformed multipart message (< 3 parts)");
                     }
                     Err(zmq::Error::EAGAIN) => {
                         tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
@@ -156,14 +155,18 @@ impl MoriIOServiceRegistry {
                     }
                 }
 
-                Self::cleanup_expired(&prefill_instances, &decode_instances).await;
+                cleanup_counter += 1;
+                if cleanup_counter >= 500 {
+                    cleanup_counter = 0;
+                    Self::cleanup_expired(&prefill_instances, &decode_instances, &global_transfer_mode).await;
+                }
             }
         });
 
         Ok(())
     }
 
-    async fn handle_registration(
+    fn handle_registration(
         message_data: &[u8],
         prefill_instances: &Arc<Mutex<HashMap<String, MoriIOInstance>>>,
         decode_instances: &Arc<Mutex<HashMap<String, MoriIOInstance>>>,
@@ -215,7 +218,6 @@ impl MoriIOServiceRegistry {
             notify_port: reg.notify_port,
             dp_size: reg.dp_size,
             tp_size: reg.tp_size,
-            transfer_mode: mode,
             expires_at: now + DEFAULT_PING_SECONDS,
         };
 
@@ -265,12 +267,14 @@ impl MoriIOServiceRegistry {
     async fn cleanup_expired(
         prefill_instances: &Arc<Mutex<HashMap<String, MoriIOInstance>>>,
         decode_instances: &Arc<Mutex<HashMap<String, MoriIOInstance>>>,
+        global_mode: &Arc<Mutex<Option<TransferMode>>>,
     ) {
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap()
             .as_secs();
 
+        let prefill_empty;
         {
             let mut map = prefill_instances.lock().unwrap();
             let expired: Vec<_> = map
@@ -282,8 +286,10 @@ impl MoriIOServiceRegistry {
                 info!("Remove MoRIIO Prefill [addr={}, expired]", key);
                 map.remove(&key);
             }
+            prefill_empty = map.is_empty();
         }
 
+        let decode_empty;
         {
             let mut map = decode_instances.lock().unwrap();
             let expired: Vec<_> = map
@@ -295,6 +301,12 @@ impl MoriIOServiceRegistry {
                 info!("Remove MoRIIO Decode [addr={}, expired]", key);
                 map.remove(&key);
             }
+            decode_empty = map.is_empty();
+        }
+
+        if prefill_empty && decode_empty {
+            *global_mode.lock().unwrap() = None;
+            info!("All MoRIIO instances expired; transfer_mode reset");
         }
     }
 
@@ -360,8 +372,8 @@ mod tests {
         assert_eq!(TransferMode::Write.to_string(), "WRITE");
     }
 
-    #[tokio::test]
-    async fn test_handle_registration_mode_mismatch() {
+    #[test]
+    fn test_handle_registration_mode_mismatch() {
         let prefill = Arc::new(Mutex::new(HashMap::new()));
         let decode = Arc::new(Mutex::new(HashMap::new()));
         let global = Arc::new(Mutex::new(Some(TransferMode::Read)));
@@ -379,7 +391,7 @@ mod tests {
         };
         let data = rmp_serde::to_vec_named(&reg).unwrap();
 
-        MoriIOServiceRegistry::handle_registration(&data, &prefill, &decode, &global).await;
+        MoriIOServiceRegistry::handle_registration(&data, &prefill, &decode, &global);
 
         // Should have been rejected — no prefill instance added
         assert!(prefill.lock().unwrap().is_empty());
@@ -387,8 +399,8 @@ mod tests {
         assert_eq!(*global.lock().unwrap(), Some(TransferMode::Read));
     }
 
-    #[tokio::test]
-    async fn test_handle_registration_sets_global_mode() {
+    #[test]
+    fn test_handle_registration_sets_global_mode() {
         let prefill = Arc::new(Mutex::new(HashMap::new()));
         let decode = Arc::new(Mutex::new(HashMap::new()));
         let global = Arc::new(Mutex::new(None));
@@ -405,7 +417,7 @@ mod tests {
         };
         let data = rmp_serde::to_vec_named(&reg).unwrap();
 
-        MoriIOServiceRegistry::handle_registration(&data, &prefill, &decode, &global).await;
+        MoriIOServiceRegistry::handle_registration(&data, &prefill, &decode, &global);
 
         assert_eq!(*global.lock().unwrap(), Some(TransferMode::Read));
         assert_eq!(prefill.lock().unwrap().len(), 1);

--- a/src/routers/http/moriio_service_discovery.rs
+++ b/src/routers/http/moriio_service_discovery.rs
@@ -1,0 +1,413 @@
+// MoRIIO Service Discovery Implementation
+// This module implements ZMQ-based service discovery for MoRIIO (AMD) P/D connector
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::{SystemTime, UNIX_EPOCH};
+use tokio::sync::broadcast;
+use tracing::{debug, error, info, warn};
+
+/// Default ping timeout in seconds (heartbeat TTL)
+const DEFAULT_PING_SECONDS: u64 = 5;
+
+/// KV transfer mode for MoRIIO connector
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum TransferMode {
+    /// Prefill runs first; router waits for its response to get remote_engine_id + remote_block_ids
+    Read,
+    /// Prefill and decode fire concurrently; decode waits for ZMQ notification from prefill
+    Write,
+}
+
+impl std::fmt::Display for TransferMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TransferMode::Read => write!(f, "READ"),
+            TransferMode::Write => write!(f, "WRITE"),
+        }
+    }
+}
+
+impl std::str::FromStr for TransferMode {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_uppercase().as_str() {
+            "READ" => Ok(TransferMode::Read),
+            "WRITE" => Ok(TransferMode::Write),
+            other => Err(format!("Unknown transfer_mode '{}'; expected READ or WRITE", other)),
+        }
+    }
+}
+
+/// Registration message sent by a MoRIIO vLLM instance over ZMQ
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MoriIORegistration {
+    /// Message type: "register" or "HELLO"
+    #[serde(rename = "type")]
+    pub message_type: String,
+    /// Role: "P" (prefill) or "D" (decode)
+    pub role: String,
+    /// Full HTTP URL including path, e.g. "http://1.2.3.4:8000/v1/completions"
+    pub request_address: String,
+    pub handshake_port: u16,
+    pub notify_port: u16,
+    pub dp_size: u32,
+    pub tp_size: u32,
+    /// Transfer mode string: "READ" or "WRITE"
+    pub transfer_mode: String,
+}
+
+/// A live MoRIIO instance with its metadata
+#[derive(Debug, Clone)]
+pub struct MoriIOInstance {
+    /// Full HTTP URL, e.g. "http://1.2.3.4:8000/v1/completions"
+    pub request_address: String,
+    pub handshake_port: u16,
+    pub notify_port: u16,
+    pub dp_size: u32,
+    pub tp_size: u32,
+    pub transfer_mode: TransferMode,
+    /// Unix timestamp after which this entry is considered stale
+    pub expires_at: u64,
+}
+
+/// Registry that tracks live prefill and decode MoRIIO instances
+#[derive(Debug)]
+pub struct MoriIOServiceRegistry {
+    /// keyed by request_address (the canonical identity of a worker)
+    prefill_instances: Arc<Mutex<HashMap<String, MoriIOInstance>>>,
+    decode_instances: Arc<Mutex<HashMap<String, MoriIOInstance>>>,
+    /// The agreed-upon transfer mode for the whole cluster (set on first registration)
+    global_transfer_mode: Arc<Mutex<Option<TransferMode>>>,
+    shutdown_tx: Option<broadcast::Sender<()>>,
+}
+
+impl Default for MoriIOServiceRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl MoriIOServiceRegistry {
+    pub fn new() -> Self {
+        Self {
+            prefill_instances: Arc::new(Mutex::new(HashMap::new())),
+            decode_instances: Arc::new(Mutex::new(HashMap::new())),
+            global_transfer_mode: Arc::new(Mutex::new(None)),
+            shutdown_tx: None,
+        }
+    }
+
+    /// Start the ZMQ ROUTER socket listener for MoRIIO registration messages
+    pub async fn start_listener(&mut self, bind_address: &str) -> Result<(), String> {
+        info!(
+            "Starting MoRIIO service discovery listener on {}",
+            bind_address
+        );
+
+        let (shutdown_tx, mut shutdown_rx) = broadcast::channel(1);
+        self.shutdown_tx = Some(shutdown_tx);
+
+        let prefill_instances = Arc::clone(&self.prefill_instances);
+        let decode_instances = Arc::clone(&self.decode_instances);
+        let global_transfer_mode = Arc::clone(&self.global_transfer_mode);
+        let bind_addr = bind_address.to_string();
+
+        tokio::spawn(async move {
+            let context = zmq::Context::new();
+            let socket = context.socket(zmq::ROUTER).unwrap();
+
+            if let Err(e) = socket.bind(&format!("tcp://{}", bind_addr)) {
+                error!("Failed to bind MoRIIO ZMQ socket to {}: {}", bind_addr, e);
+                return;
+            }
+
+            info!("MoRIIO ZMQ service discovery bound to tcp://{}", bind_addr);
+            socket.set_rcvtimeo(1000).unwrap();
+
+            loop {
+                if shutdown_rx.try_recv().is_ok() {
+                    info!("MoRIIO service discovery shutting down");
+                    break;
+                }
+
+                match socket.recv_multipart(zmq::DONTWAIT) {
+                    Ok(parts) if parts.len() >= 2 => {
+                        let message_data = &parts[1];
+                        Self::handle_registration(
+                            message_data,
+                            &prefill_instances,
+                            &decode_instances,
+                            &global_transfer_mode,
+                        )
+                        .await;
+                    }
+                    Ok(_) => {
+                        warn!("MoRIIO ZMQ received malformed multipart message (< 2 parts)");
+                    }
+                    Err(zmq::Error::EAGAIN) => {
+                        tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
+                    }
+                    Err(e) => {
+                        warn!("MoRIIO ZMQ receive error: {}", e);
+                        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+                    }
+                }
+
+                Self::cleanup_expired(&prefill_instances, &decode_instances).await;
+            }
+        });
+
+        Ok(())
+    }
+
+    async fn handle_registration(
+        message_data: &[u8],
+        prefill_instances: &Arc<Mutex<HashMap<String, MoriIOInstance>>>,
+        decode_instances: &Arc<Mutex<HashMap<String, MoriIOInstance>>>,
+        global_transfer_mode: &Arc<Mutex<Option<TransferMode>>>,
+    ) {
+        let reg: MoriIORegistration = match rmp_serde::from_slice(message_data) {
+            Ok(r) => r,
+            Err(e) => {
+                warn!("Failed to parse MoRIIO registration message: {}", e);
+                return;
+            }
+        };
+
+        let mode: TransferMode = match reg.transfer_mode.parse() {
+            Ok(m) => m,
+            Err(e) => {
+                warn!("Invalid transfer_mode in MoRIIO registration: {}", e);
+                return;
+            }
+        };
+
+        // Enforce cluster-wide transfer_mode consistency
+        {
+            let mut global = global_transfer_mode.lock().unwrap();
+            match *global {
+                None => {
+                    info!("MoRIIO cluster transfer_mode set to {}", mode);
+                    *global = Some(mode);
+                }
+                Some(existing) if existing != mode => {
+                    error!(
+                        "MoRIIO transfer_mode mismatch: cluster is {}, but {} sent {}. Rejecting registration.",
+                        existing, reg.request_address, mode
+                    );
+                    return;
+                }
+                Some(_) => {} // consistent, proceed
+            }
+        }
+
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+
+        let instance = MoriIOInstance {
+            request_address: reg.request_address.clone(),
+            handshake_port: reg.handshake_port,
+            notify_port: reg.notify_port,
+            dp_size: reg.dp_size,
+            tp_size: reg.tp_size,
+            transfer_mode: mode,
+            expires_at: now + DEFAULT_PING_SECONDS,
+        };
+
+        match reg.role.as_str() {
+            "P" => {
+                let mut map = prefill_instances.lock().unwrap();
+                let is_new = !map.contains_key(&reg.request_address);
+                map.insert(reg.request_address.clone(), instance);
+                if is_new {
+                    info!(
+                        "Add MoRIIO Prefill [addr={}, handshake={}, notify={}, dp={}, tp={}, mode={}]",
+                        reg.request_address,
+                        reg.handshake_port,
+                        reg.notify_port,
+                        reg.dp_size,
+                        reg.tp_size,
+                        mode
+                    );
+                } else {
+                    debug!("Update MoRIIO Prefill [addr={}]", reg.request_address);
+                }
+            }
+            "D" => {
+                let mut map = decode_instances.lock().unwrap();
+                let is_new = !map.contains_key(&reg.request_address);
+                map.insert(reg.request_address.clone(), instance);
+                if is_new {
+                    info!(
+                        "Add MoRIIO Decode [addr={}, handshake={}, notify={}, dp={}, tp={}, mode={}]",
+                        reg.request_address,
+                        reg.handshake_port,
+                        reg.notify_port,
+                        reg.dp_size,
+                        reg.tp_size,
+                        mode
+                    );
+                } else {
+                    debug!("Update MoRIIO Decode [addr={}]", reg.request_address);
+                }
+            }
+            other => {
+                warn!("Unknown MoRIIO role '{}' from {}", other, reg.request_address);
+            }
+        }
+    }
+
+    async fn cleanup_expired(
+        prefill_instances: &Arc<Mutex<HashMap<String, MoriIOInstance>>>,
+        decode_instances: &Arc<Mutex<HashMap<String, MoriIOInstance>>>,
+    ) {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+
+        {
+            let mut map = prefill_instances.lock().unwrap();
+            let expired: Vec<_> = map
+                .iter()
+                .filter(|(_, i)| i.expires_at <= now)
+                .map(|(k, _)| k.clone())
+                .collect();
+            for key in expired {
+                info!("Remove MoRIIO Prefill [addr={}, expired]", key);
+                map.remove(&key);
+            }
+        }
+
+        {
+            let mut map = decode_instances.lock().unwrap();
+            let expired: Vec<_> = map
+                .iter()
+                .filter(|(_, i)| i.expires_at <= now)
+                .map(|(k, _)| k.clone())
+                .collect();
+            for key in expired {
+                info!("Remove MoRIIO Decode [addr={}, expired]", key);
+                map.remove(&key);
+            }
+        }
+    }
+
+    pub fn get_prefill_instances(&self) -> Vec<MoriIOInstance> {
+        self.prefill_instances
+            .lock()
+            .unwrap()
+            .values()
+            .cloned()
+            .collect()
+    }
+
+    pub fn get_decode_instances(&self) -> Vec<MoriIOInstance> {
+        self.decode_instances
+            .lock()
+            .unwrap()
+            .values()
+            .cloned()
+            .collect()
+    }
+
+    /// Returns the cluster-wide transfer mode, or None if no instance has registered yet
+    pub fn transfer_mode(&self) -> Option<TransferMode> {
+        *self.global_transfer_mode.lock().unwrap()
+    }
+
+    pub fn get_instance_counts(&self) -> (usize, usize) {
+        (
+            self.prefill_instances.lock().unwrap().len(),
+            self.decode_instances.lock().unwrap().len(),
+        )
+    }
+
+    pub fn shutdown(&self) {
+        if let Some(ref tx) = self.shutdown_tx {
+            let _ = tx.send(());
+        }
+    }
+}
+
+impl Drop for MoriIOServiceRegistry {
+    fn drop(&mut self) {
+        self.shutdown();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_transfer_mode_parse() {
+        assert_eq!("READ".parse::<TransferMode>().unwrap(), TransferMode::Read);
+        assert_eq!("WRITE".parse::<TransferMode>().unwrap(), TransferMode::Write);
+        assert_eq!("read".parse::<TransferMode>().unwrap(), TransferMode::Read);
+        assert_eq!("write".parse::<TransferMode>().unwrap(), TransferMode::Write);
+        assert!("UNKNOWN".parse::<TransferMode>().is_err());
+    }
+
+    #[test]
+    fn test_transfer_mode_display() {
+        assert_eq!(TransferMode::Read.to_string(), "READ");
+        assert_eq!(TransferMode::Write.to_string(), "WRITE");
+    }
+
+    #[tokio::test]
+    async fn test_handle_registration_mode_mismatch() {
+        let prefill = Arc::new(Mutex::new(HashMap::new()));
+        let decode = Arc::new(Mutex::new(HashMap::new()));
+        let global = Arc::new(Mutex::new(Some(TransferMode::Read)));
+
+        // Build a WRITE-mode registration msgpack
+        let reg = MoriIORegistration {
+            message_type: "register".to_string(),
+            role: "P".to_string(),
+            request_address: "http://1.2.3.4:8000/v1/completions".to_string(),
+            handshake_port: 8001,
+            notify_port: 8002,
+            dp_size: 1,
+            tp_size: 1,
+            transfer_mode: "WRITE".to_string(),
+        };
+        let data = rmp_serde::to_vec_named(&reg).unwrap();
+
+        MoriIOServiceRegistry::handle_registration(&data, &prefill, &decode, &global).await;
+
+        // Should have been rejected — no prefill instance added
+        assert!(prefill.lock().unwrap().is_empty());
+        // Global mode must still be READ
+        assert_eq!(*global.lock().unwrap(), Some(TransferMode::Read));
+    }
+
+    #[tokio::test]
+    async fn test_handle_registration_sets_global_mode() {
+        let prefill = Arc::new(Mutex::new(HashMap::new()));
+        let decode = Arc::new(Mutex::new(HashMap::new()));
+        let global = Arc::new(Mutex::new(None));
+
+        let reg = MoriIORegistration {
+            message_type: "HELLO".to_string(),
+            role: "P".to_string(),
+            request_address: "http://1.2.3.4:8000/v1/completions".to_string(),
+            handshake_port: 8001,
+            notify_port: 8002,
+            dp_size: 1,
+            tp_size: 1,
+            transfer_mode: "READ".to_string(),
+        };
+        let data = rmp_serde::to_vec_named(&reg).unwrap();
+
+        MoriIOServiceRegistry::handle_registration(&data, &prefill, &decode, &global).await;
+
+        assert_eq!(*global.lock().unwrap(), Some(TransferMode::Read));
+        assert_eq!(prefill.lock().unwrap().len(), 1);
+    }
+}

--- a/src/routers/http/moriio_service_discovery.rs
+++ b/src/routers/http/moriio_service_discovery.rs
@@ -134,8 +134,8 @@ impl MoriIOServiceRegistry {
                 }
 
                 match socket.recv_multipart(zmq::DONTWAIT) {
-                    Ok(parts) if parts.len() >= 3 => {
-                        let message_data = &parts[2];
+                    Ok(parts) if parts.len() >= 2 => {
+                        let message_data = &parts[1];
                         Self::handle_registration(
                             message_data,
                             &prefill_instances,
@@ -144,7 +144,7 @@ impl MoriIOServiceRegistry {
                         );
                     }
                     Ok(_) => {
-                        warn!("MoRIIO ZMQ received malformed multipart message (< 3 parts)");
+                        warn!("MoRIIO ZMQ received malformed multipart message (< 2 parts)");
                     }
                     Err(zmq::Error::EAGAIN) => {
                         tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;


### PR DESCRIPTION
<!-- markdownlint-disable -->

Fixes #126.

## Purpose
Adds a `moriio_prefill_decode` routing mode for AMD's MoRIIO KV-transfer connector, which is the MoRIIO equivalent of the existing `vllm_prefill_decode` mode (which to my understanding works only with NixlConnector, possibvly P2PNCCL as well). Ported from the [toy proxy](https://github.com/vllm-project/vllm/blob/main/examples/online_serving/disaggregated_serving/moriio_toy_proxy_server.py).

Main differences from the NIXL flow:

- Registration messages include `handshake_port`, `notify_port`, `dp_size`, `tp_size`, and
`transfer_mode` instead of just a ZMQ address. (see for instance [here](https://github.com/vllm-project/vllm/blob/384e4d5f48cea203b0fbcd41951d2d49775bf6bd/examples/online_serving/disaggregated_serving/moriio_toy_proxy_server.py#L251)).
- `kv_transfer_param` needs some more information. Prefill tells decode where to pull blocks from,
decode tells prefill where to push them
- Two transfer modes depending on how the vLLM instances are configured:
  - `READ`: router waits for prefill to finish, extracts remote_engine_id/remote_block_ids from
the P's response, then sends decode with those
  - `WRITE`_ prefill is fire-and-forget (spawned in background), decode is sent immediately and
handles synchronization over ZMQ internally. (D listens on P's notification of completion, and then proceeds with a batch load).

Transfer mode is auto-detected from the first registration message as in the toy proxy. If instances register with
mismatched modes the conflicting one is rejected and an error is logged.

## Test Plan

1. Unit tests for kv_transfer_params construction, host/port extraction, and service discovery
registration parsing (including mismatch rejection)
2. Smallest possible reproducer on 2 MI300X.
3. Manual test with DSR1, 1P1D with `vllm bench serve` results compared to toy proxy.

Basic usage:
```bash
vllm-router \
    --port 30000 \
    --host 0.0.0.0 \
    --policy consistent_hash \
    --moriio-pd-disaggregation \
    --moriio-discovery-address 0.0.0.0:30001
```

## Test Result

1. Existing and new tests pass.

2. Reproducer

```Dockerfile
FROM vllm/vllm-openai-rocm:v0.17.1

ARG ROUTER_REPO=https://github.com/simondanielsson/router.git
ARG ROUTER_BRANCH=feature/moriio-compatibility
RUN apt-get update && apt-get install -y libzmq3-dev libssl-dev pkg-config protobuf-compiler && \
    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable && \
    . "$HOME/.cargo/env" && \
    git clone --depth 1 --branch ${ROUTER_BRANCH} ${ROUTER_REPO} /tmp/router && \
    cd /tmp/router && \
    cargo build --release && \
    cp target/release/vllm-router /usr/local/bin/vllm-router && \
    rm -rf /tmp/router

...
```

4. TODO

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
