### PR TITLE
fix: return OpenAI-compatible response from IGW /v1/models

### DIFF
--- a/src/routers/router_manager.rs
+++ b/src/routers/router_manager.rs
@@ -533,7 +533,7 @@ impl RouterTrait for RouterManager {
 
     /// Get available models - query from worker registry
     // NOTE: serde_json::json!() sorts keys alphabetically,
-    // resulting in a different field order from the OpenAI API Spec. 
+    // resulting in a different field order from the OpenAI API Spec.
     // TODO: Preserve declaration order.
     async fn get_models(&self, _req: Request<Body>) -> Response {
         let models = self.worker_registry.get_models();

--- a/src/routers/router_manager.rs
+++ b/src/routers/router_manager.rs
@@ -533,21 +533,26 @@ impl RouterTrait for RouterManager {
 
     /// Get available models - query from worker registry
     async fn get_models(&self, _req: Request<Body>) -> Response {
-        // Get models from worker registry
         let models = self.worker_registry.get_models();
 
-        if models.is_empty() {
-            (StatusCode::SERVICE_UNAVAILABLE, "No models available").into_response()
-        } else {
-            (
-                StatusCode::OK,
+        let data: Vec<serde_json::Value> = models
+            .into_iter()
+            .map(|model_id| {
                 serde_json::json!({
-                    "models": models
+                    "id": model_id,
+                    "object": "model",
+                    "created": 0,
+                    "owned_by": "vllm",
                 })
-                .to_string(),
-            )
-                .into_response()
-        }
+            })
+            .collect();
+
+        let body = serde_json::json!({
+            "object": "list",
+            "data": data,
+        });
+
+        (StatusCode::OK, body.to_string()).into_response()
     }
 
     /// Get model information

--- a/src/routers/router_manager.rs
+++ b/src/routers/router_manager.rs
@@ -532,6 +532,9 @@ impl RouterTrait for RouterManager {
     }
 
     /// Get available models - query from worker registry
+    // NOTE: serde_json::json!() sorts keys alphabetically,
+    // resulting in a different field order from the OpenAI API Spec. 
+    // TODO: Preserve declaration order.
     async fn get_models(&self, _req: Request<Body>) -> Response {
         let models = self.worker_registry.get_models();
 


### PR DESCRIPTION
<!-- markdownlint-disable -->
Related Issue: #133 

- Fix `RouterManager::get_models()` to return the OpenAI / vLLM compatible format`{"object": "list", "data": [...]}` format instead of `{"models": [...]}`
- Change empty registry response from `503 SERVICE_UNAVAILABLE` to `200 OK` with an empty `data: []` array
  - The OpenAI API returns 200 with an empty list as zero models is a valid state, not a service failure


## Purpose
Fix GET /v1/models in IGW mode to return OpenAI compatible response format so the OpenAI Client can work correctly.

## Test Plan
```
$ curl -s http://localhost:3199/v1/models | jq
```

```python
from openai import OpenAI

client = OpenAI(base_url="http://localhost3199/v1", api_key="dummy")
models = list(client.models.list())

print(f"Models returned: {len(models)}")
```


## Test Result
```
{
  "data": [
    {
      "created": 0,
      "id": "InternVL3-8B-AWQ",
      "object": "model",
      "owned_by": "vllm"
    },
    {
      "created": 0,
      "id": "InternVL3-1B",
      "object": "model",
      "owned_by": "vllm"
    }
  ],
  "object": "list"
}
```
_NOTE_: The json field order within each model entry is alphabetical rather than matching OpenAI's order (id, object, created, owned_by) as `serde_json::json!()` sorts keys alphabetically. This does not affect the compatibility, and I decided to leave it as a todo. 

```
Models returned: 2
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
