### PR TITLE
[Fix] add streaming support in process_vllm_two_stage_request_discovered

### DIFF
--- a/src/routers/http/vllm_pd_router.rs
+++ b/src/routers/http/vllm_pd_router.rs
@@ -636,7 +636,9 @@ impl VllmPDRouter {
 
             Ok(response)
         } else {
-            // No logprobs merging needed - return decode response as-is
+            // No logprobs merging needed - stream decode response as-is (handles both streaming
+            // and non-streaming). Using bytes_stream() avoids buffering the entire SSE stream
+            // into memory, which would cause streaming requests to return an empty reply.
             debug!(
                 "No logprobs merging needed (streaming={}, needs_logprobs={})",
                 is_streaming, needs_logprobs
@@ -644,18 +646,19 @@ impl VllmPDRouter {
 
             let status = decode_response.status();
             let headers = decode_response.headers().clone();
-            let body = decode_response
-                .bytes()
-                .await
-                .map_err(|e| format!("Failed to read decode response: {}", e))?;
 
             let mut response_builder = axum::http::Response::builder().status(status);
             for (name, value) in headers.iter() {
-                response_builder = response_builder.header(name, value);
+                // Skip hop-by-hop headers that must not be forwarded as-is; axum will
+                // set transfer-encoding and content-length correctly for the streamed body.
+                if name != "transfer-encoding" && name != "content-length" {
+                    response_builder = response_builder.header(name, value);
+                }
             }
 
+            let body = axum::body::Body::from_stream(decode_response.bytes_stream());
             let response = response_builder
-                .body(axum::body::Body::from(body))
+                .body(body)
                 .map_err(|e| format!("Failed to build response: {}", e))?;
 
             Ok(response)


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

_We might close this PR in favor of #114_

Closes #113. 

The service discovery path for vllm PD disaggregation does not support streaming, as opposed to the regular `process_vllm_two_stage_request` path (without service discovery) which [does support streaming](https://github.com/vllm-project/router/blob/4df9bbc6562bd0ccaddb991efad581bfd14843a5/src/routers/http/vllm_pd_router.rs#L1030-L1042). 

This PR adds support for response streaming also in the service discovery path. Without this, you cannot use the router with service discovery together with `vllm bench serve --backend vllm` which requires that streaming works.

## Test Plan

Reproducer:
```shell
```


## Test Result

Reproducer:

```shell
```


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
