### PR TITLE
feat: add --engine-wait-timeout-secs for graceful degradation during rolling updates

### DIFF
--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -81,6 +81,12 @@ pub struct RouterConfig {
     /// Profiling timeout in seconds (for vLLM profiling endpoints)
     #[serde(default = "default_profile_timeout_secs")]
     pub profile_timeout_secs: u64,
+    /// Seconds to wait for a healthy worker when none are available (0 = immediate 503).
+    /// During rolling updates, new pods may take minutes to load models. This setting
+    /// makes the router hold requests until a worker becomes available rather than
+    /// immediately returning 503.
+    #[serde(default)]
+    pub engine_wait_timeout_secs: u64,
 }
 
 fn default_profile_timeout_secs() -> u64 {
@@ -487,6 +493,7 @@ impl Default for RouterConfig {
             history_backend: default_history_backend(),
             enable_profiling: false,
             profile_timeout_secs: default_profile_timeout_secs(),
+            engine_wait_timeout_secs: 0,
         }
     }
 }
@@ -1058,6 +1065,7 @@ mod tests {
             history_backend: default_history_backend(),
             enable_profiling: false,
             profile_timeout_secs: default_profile_timeout_secs(),
+            engine_wait_timeout_secs: 0,
         };
 
         assert!(config.mode.is_pd_mode());
@@ -1125,6 +1133,7 @@ mod tests {
             history_backend: default_history_backend(),
             enable_profiling: false,
             profile_timeout_secs: default_profile_timeout_secs(),
+            engine_wait_timeout_secs: 0,
         };
 
         assert!(!config.mode.is_pd_mode());
@@ -1188,6 +1197,7 @@ mod tests {
             history_backend: default_history_backend(),
             enable_profiling: false,
             profile_timeout_secs: default_profile_timeout_secs(),
+            engine_wait_timeout_secs: 0,
         };
 
         assert!(config.has_service_discovery());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -251,6 +251,7 @@ impl Router {
             history_backend: config::HistoryBackend::Memory,
             enable_profiling: false, // Profiling disabled in Python binding by default
             profile_timeout_secs: 10, // Default profiling timeout
+            engine_wait_timeout_secs: 0, // Disabled by default in Python binding
         })
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -363,6 +363,12 @@ struct CliArgs {
     /// Enable profiling calls to vLLM workers
     #[arg(long, default_value_t = false)]
     profile: bool,
+
+    /// Seconds to wait for a healthy worker when none are available (0 = immediate 503).
+    /// Useful during rolling updates when new pods take minutes to load models.
+    /// The router holds requests until a worker becomes available or the timeout expires.
+    #[arg(long, default_value_t = 0)]
+    engine_wait_timeout_secs: u64,
 }
 
 impl CliArgs {
@@ -651,6 +657,7 @@ impl CliArgs {
             },
             enable_profiling: self.profile,
             profile_timeout_secs: 10, // Default profiling timeout
+            engine_wait_timeout_secs: self.engine_wait_timeout_secs,
         })
     }
 

--- a/src/routers/http/router.rs
+++ b/src/routers/http/router.rs
@@ -43,6 +43,7 @@ pub struct Router {
     api_key: Option<String>,
     retry_config: RetryConfig,
     circuit_breaker_config: CircuitBreakerConfig,
+    engine_wait_timeout: Duration,
     _worker_loads: Arc<tokio::sync::watch::Receiver<HashMap<String, isize>>>,
     _load_monitor_handle: Option<Arc<tokio::task::JoinHandle<()>>>,
 }
@@ -179,6 +180,9 @@ impl Router {
             api_key: ctx.router_config.api_key.clone(),
             retry_config: ctx.router_config.effective_retry_config(),
             circuit_breaker_config: core_cb_config,
+            engine_wait_timeout: Duration::from_secs(
+                ctx.router_config.engine_wait_timeout_secs,
+            ),
             _worker_loads: worker_loads,
             _load_monitor_handle: load_monitor_handle,
         })
@@ -554,6 +558,31 @@ impl Router {
             |_: u32| async {
                 let worker = match self.select_worker_for_model(model_id, Some(&text), headers) {
                     Some(w) => w,
+                    None if !self.engine_wait_timeout.is_zero() => {
+                        // Wait for a healthy worker to become available instead of
+                        // immediately returning 503. This is useful during rolling
+                        // updates when new pods take minutes to load models.
+                        let wait_start = Instant::now();
+                        loop {
+                            if wait_start.elapsed() >= self.engine_wait_timeout {
+                                RouterMetrics::record_request_error(
+                                    route,
+                                    "no_available_workers",
+                                );
+                                return (
+                                    StatusCode::SERVICE_UNAVAILABLE,
+                                    "No available workers after waiting for engine readiness",
+                                )
+                                    .into_response();
+                            }
+                            tokio::time::sleep(Duration::from_secs(1)).await;
+                            if let Some(w) =
+                                self.select_worker_for_model(model_id, Some(&text), headers)
+                            {
+                                break w;
+                            }
+                        }
+                    }
                     None => {
                         RouterMetrics::record_request_error(route, "no_available_workers");
                         return (
@@ -1792,6 +1821,7 @@ mod tests {
             client: Client::new(),
             retry_config: RetryConfig::default(),
             circuit_breaker_config: CircuitBreakerConfig::default(),
+            engine_wait_timeout: Duration::ZERO,
             _worker_loads: Arc::new(rx),
             _load_monitor_handle: None,
         }
@@ -1864,6 +1894,7 @@ mod tests {
             client: Client::new(),
             retry_config: RetryConfig::default(),
             circuit_breaker_config: CircuitBreakerConfig::default(),
+            engine_wait_timeout: Duration::ZERO,
             _worker_loads: Arc::new(rx),
             _load_monitor_handle: None,
         }


### PR DESCRIPTION
## Purpose

When all workers are temporarily unavailable (e.g., during a Kubernetes rolling update where new pods take minutes to load models), the router currently returns `503 Service Unavailable` immediately with `"No available workers (all circuits open or unhealthy)"`.

This is problematic in production GPU workloads where:
- Model loading takes 2-10 minutes per pod (large LLMs like Llama 70B+)
- Kubernetes rolling updates replace pods one-at-a-time (`maxSurge: 1, maxUnavailable: 0`) to minimize GPU cost
- Upstream load balancers (e.g., KEDA HTTP add-on) continue forwarding traffic during rollover
- The router correctly waits for K8s `Ready` condition before adding workers, but new pods aren't Ready yet

**Result: thousands of 503s during every deployment** even though healthy workers become available within minutes.

### Production evidence

From a production cluster during a rolling update of 20 vLLM replicas:
```
vllm_router_request_errors_total{error_type="no_available_workers"} 5610
vllm_router_requests_total{route="/v1/chat/completions"}            1999
```

Router worker count timeline during deployment:
```
15:33  2 workers  ← old pods terminating, new pods loading models
16:01  5 workers  ← new pods becoming Ready
16:14  3 workers  ← another rollover wave
16:23  16 workers ← fully recovered
```

### Solution

Add `--engine-wait-timeout-secs` (default: `0`, preserving current behavior). When non-zero, the router holds requests and polls for a healthy worker every second until one becomes available or the timeout expires.

```
vllm-router --engine-wait-timeout-secs 300  # wait up to 5 min for a worker
```

This trades latency for reliability — requests wait instead of failing during transient unavailability.

### Changes

| File | Change |
|------|--------|
| `src/config/types.rs` | Add `engine_wait_timeout_secs` field to `RouterConfig` |
| `src/main.rs` | Add `--engine-wait-timeout-secs` CLI arg (default: 0) |
| `src/routers/http/router.rs` | Wait loop in `route_typed_request()` when no workers available and timeout > 0 |
| `src/lib.rs` | Set default (0) in Python bindings |

### Design decisions

- **Polling interval: 1 second.** Service discovery runs on a separate tokio task and adds workers as pods pass K8s readiness. 1s is frequent enough to detect new workers promptly without excessive CPU.
- **Default: 0 (disabled).** No behavioral change for existing users. Opt-in only.
- **Works with all policies.** The wait loop re-calls `select_worker_for_model()` which respects the configured policy (cache_aware, round_robin, etc.).
- **Non-blocking.** Uses `tokio::time::sleep` — doesn't block other requests or the service discovery task.
- **Bounded by `--request-timeout-secs`.** Even if `engine_wait_timeout_secs` is set very high, the outer request timeout still applies.

Closes #140

## Test Plan

- Unit tests updated (new `engine_wait_timeout` field added to test Router constructors)
- With `--engine-wait-timeout-secs 0`: behavior identical to current (immediate 503)
- With `--engine-wait-timeout-secs 300`: requests wait during rolling update window instead of 503

## Test Result

CI will validate compilation and existing tests. Manual testing in a Kubernetes cluster with KEDA + rolling update confirms:
- Before: 5,610 `no_available_workers` errors during deployment
- After (with timeout=300): requests queue and succeed once workers become Ready