### PR TITLE
feat: plumb --kv-connector through Python launcher to Rust router

### DIFF
--- a/py_src/vllm_router/router_args.py
+++ b/py_src/vllm_router/router_args.py
@@ -50,6 +50,8 @@ class RouterArgs:
     prefill_selector: Dict[str, str] = dataclasses.field(default_factory=dict)
     decode_selector: Dict[str, str] = dataclasses.field(default_factory=dict)
     bootstrap_port_annotation: str = "vllm.ai/bootstrap-port"
+    # KV connector for PD disaggregation (nixl pull-based or mooncake push-based)
+    kv_connector: str = "nixl"
     # Prometheus configuration
     prometheus_port: Optional[int] = None
     prometheus_host: Optional[str] = None
@@ -315,6 +317,15 @@ class RouterArgs:
             nargs="+",
             default={},
             help="Label selector for decode server pods in PD mode (format: key1=value1 key2=value2)",
+        )
+        parser.add_argument(
+            f"--{prefix}kv-connector",
+            type=str,
+            default=RouterArgs.kv_connector,
+            choices=["nixl", "mooncake"],
+            help="KV connector type for PD disaggregation. 'nixl' (default) uses NIXL's "
+            "pull-based KV transfer; 'mooncake' uses Mooncake's push-based protocol "
+            "(queries each prefill node's bootstrap server for engine_id per DP rank).",
         )
         # Prometheus configuration
         parser.add_argument(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,6 +103,8 @@ struct Router {
     // OpenTelemetry tracing
     enable_trace: bool,
     otlp_traces_endpoint: Option<String>,
+    // KV connector for PD disaggregation ("nixl" or "mooncake")
+    kv_connector: String,
 }
 
 impl Router {
@@ -251,7 +253,18 @@ impl Router {
             history_backend: config::HistoryBackend::Memory,
             enable_profiling: false, // Profiling disabled in Python binding by default
             profile_timeout_secs: 10, // Default profiling timeout
-            kv_connector: config::KvConnector::Nixl,
+            kv_connector: match self.kv_connector.to_ascii_lowercase().as_str() {
+                "nixl" => config::KvConnector::Nixl,
+                "mooncake" => config::KvConnector::Mooncake,
+                other => {
+                    return Err(config::ConfigError::ValidationFailed {
+                        reason: format!(
+                            "Invalid kv_connector '{}': expected 'nixl' or 'mooncake'",
+                            other
+                        ),
+                    });
+                }
+            },
         })
     }
 }
@@ -326,6 +339,8 @@ impl Router {
         // Tracing defaults
         enable_trace = false,
         otlp_traces_endpoint = None,
+        // KV connector default (PD disaggregation)
+        kv_connector = String::from("nixl"),
     ))]
     #[allow(clippy::too_many_arguments)]
     fn new(
@@ -389,6 +404,7 @@ impl Router {
         tokenizer_path: Option<String>,
         enable_trace: bool,
         otlp_traces_endpoint: Option<String>,
+        kv_connector: String,
     ) -> PyResult<Self> {
         // Determine connection mode from worker URLs
         let mut all_urls = worker_urls.clone();
@@ -469,6 +485,7 @@ impl Router {
             tokenizer_path,
             enable_trace,
             otlp_traces_endpoint,
+            kv_connector,
         })
     }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -854,11 +854,12 @@ pub async fn startup(config: ServerConfig) -> Result<(), Box<dyn std::error::Err
     println!("DEBUG: Prometheus metrics initialized");
 
     info!(
-        "Starting router on {}:{} | mode: {:?} | policy: {:?} | max_payload: {}MB",
+        "Starting router on {}:{} | mode: {:?} | policy: {:?} | kv_connector: {:?} | max_payload: {}MB",
         config.host,
         config.port,
         config.router_config.mode,
         config.router_config.policy,
+        config.router_config.kv_connector,
         config.max_payload_size / (1024 * 1024)
     );
 


### PR DESCRIPTION
## Summary

- The Mooncake connector PR (#151) added `--kv-connector` to the Rust clap CLI (`src/main.rs`) only. The Python argparse launcher (`vllm-router` console script, `vllm_router.launch_router:main`) and the PyO3 `Router` bridge in `src/lib.rs` were not updated, so:
  - `vllm-router --kv-connector mooncake` (the pip-installed entry point) fails with `error: unrecognized arguments: --kv-connector mooncake`.
  - `Router::from_args` / `to_router_config` hardcoded `kv_connector: KvConnector::Nixl`, so even if a user bypassed argparse and constructed `Router(**kwargs)` from Python, Mooncake could not be selected.
- This PR completes the plumbing:
  - `py_src/vllm_router/router_args.py`: add `kv_connector: str = "nixl"` dataclass field and `--kv-connector {nixl,mooncake}` argparse flag. `from_cli_args` auto-picks it up via the `dataclasses.fields` loop, and `Router.from_args` forwards it via `vars(args)` to `_Router`.
  - `src/lib.rs`: add `kv_connector: String` to the PyO3 `Router` struct and `#[new]` signature (default `"nixl"`); replace the hardcoded `KvConnector::Nixl` in `to_router_config` with a `nixl`/`mooncake` match that returns `ConfigError::ValidationFailed` on bad input. Argparse `choices=["nixl","mooncake"]` handles CLI validation; the Rust match is defense-in-depth for direct `Router(**kwargs)` callers.
- NIXL remains the default. No behavior change when `--kv-connector` is not specified.

## Test plan

- [x] `cargo check --lib` clean.
- [x] `cargo check --bin vllm-router` clean (Rust CLI still builds).
- [x] `uv pip install -e .` rebuilt the PyO3 extension into a local venv.
- [x] `vllm-router --help` now shows `--kv-connector {nixl,mooncake}` with the expected help text.
- [x] `vllm-router --kv-connector mooncake --pd-disaggregation --prefill <url> --decode <url>` parses successfully and reaches worker startup (previously rejected at argparse).
- [ ] Reviewer: please run full `cargo test` and any Mooncake-specific integration tests in CI.

## AI assistance disclosure

AI assistance (Claude Code) was used to help write this change. The submitter reviewed every changed line. This is not a duplicate of any open PR (checked `gh pr list --state open --search "kv-connector"` — none open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)