### PR TITLE
[fix] Preserve unknown fields in `ChatCompletionRequest`

### DIFF
--- a/benches/request_processing.rs
+++ b/benches/request_processing.rs
@@ -75,6 +75,7 @@ fn default_chat_completion_request() -> ChatCompletionRequest {
         reasoning_effort: None,
         include_reasoning: true,
         structured_outputs: None,
+        other: serde_json::Map::new(),
     }
 }
 

--- a/src/protocols/spec.rs
+++ b/src/protocols/spec.rs
@@ -524,6 +524,10 @@ pub struct ChatCompletionRequest {
     /// Structured outputs parameters
     #[serde(skip_serializing_if = "Option::is_none")]
     pub structured_outputs: Option<StructuredOutputsParams>,
+
+    /// Additional fields passed through transparently to the backend
+    #[serde(flatten)]
+    pub other: serde_json::Map<String, serde_json::Value>,
 }
 
 impl GenerationRequest for ChatCompletionRequest {

--- a/src/protocols/validation.rs
+++ b/src/protocols/validation.rs
@@ -924,6 +924,7 @@ mod tests {
                 chat_template_kwargs: None,
                 return_hidden_states: false,
                 structured_outputs: None,
+                other: Default::default(),
             }
         }
 

--- a/tests/benchmark_integration.rs
+++ b/tests/benchmark_integration.rs
@@ -78,6 +78,7 @@ fn default_chat_completion_request() -> ChatCompletionRequest {
         reasoning_effort: None,
         include_reasoning: true,
         structured_outputs: None,
+        other: serde_json::Map::new(),
     }
 }
 

--- a/tests/test_extra_args_chat.rs
+++ b/tests/test_extra_args_chat.rs
@@ -1,0 +1,73 @@
+//! Tests that unknown/extra fields in ChatCompletionRequest are preserved through serde roundtrip.
+use vllm_router_rs::protocols::spec::ChatCompletionRequest;
+
+#[test]
+fn test_extra_fields_preserved_on_deserialize() {
+    let json = r#"{
+        "model": "test-model",
+        "messages": [{"role": "user", "content": "Hello"}],
+        "max_tokens": 100,
+        "return_token_ids": true,
+        "some_custom_param": "value"
+    }"#;
+
+    let req: ChatCompletionRequest = serde_json::from_str(json).unwrap();
+
+    assert!(
+        req.other.contains_key("return_token_ids"),
+        "return_token_ids should be captured in other"
+    );
+    assert!(
+        req.other.contains_key("some_custom_param"),
+        "some_custom_param should be captured in other"
+    );
+    assert_eq!(
+        req.other["some_custom_param"],
+        serde_json::Value::String("value".to_string())
+    );
+}
+
+#[test]
+fn test_extra_fields_survive_roundtrip() {
+    let json = r#"{
+        "model": "test-model",
+        "messages": [{"role": "user", "content": "Hello"}],
+        "max_tokens": 100,
+        "return_token_ids": true
+    }"#;
+
+    let req: ChatCompletionRequest = serde_json::from_str(json).unwrap();
+    let serialized = serde_json::to_string(&req).unwrap();
+    let roundtrip: ChatCompletionRequest = serde_json::from_str(&serialized).unwrap();
+
+    assert_eq!(roundtrip.other["return_token_ids"], serde_json::json!(true));
+}
+
+#[test]
+fn test_extra_fields_appear_at_top_level_in_serialized_json() {
+    let json = r#"{
+        "model": "test-model",
+        "messages": [{"role": "user", "content": "Hello"}],
+        "return_token_ids": true
+    }"#;
+
+    let req: ChatCompletionRequest = serde_json::from_str(json).unwrap();
+    let value: serde_json::Value = serde_json::to_value(&req).unwrap();
+
+    assert!(
+        value.get("return_token_ids").is_some(),
+        "return_token_ids should be at the top level of the serialized JSON"
+    );
+    assert_eq!(value["return_token_ids"], serde_json::json!(true));
+}
+
+#[test]
+fn test_no_other_fields_gives_empty_map() {
+    let json = r#"{
+        "model": "test-model",
+        "messages": [{"role": "user", "content": "Hello"}]
+    }"#;
+
+    let req: ChatCompletionRequest = serde_json::from_str(json).unwrap();
+    assert!(req.other.is_empty());
+}


### PR DESCRIPTION
# What does this PR do?

## Purpose


Fixes #161

`ChatCompletionRequest` was silently dropping unrecognized fields (e.g. prompt_token_ids) on deserialization. Add `#[serde(flatten)] pub other` to match the existing pattern on `CompletionRequest`, so extra fields are captured and re-emitted at the top level when forwarded to the backend.

## Test Plan


Ran a simple chat completion request with a vllm endpoint + vllm router running at port 8000:

``` bash
# vllm server (terminal 1)
 python tests/mock_vllm_server.py --port 8081
```

```bash
# vllm router built from source (terminal 2)
 ./target/debug/vllm-router --host 0.0.0.0 --port 8000 --worker-urls http://localhost:8081
```

```bash
# chat completions request (terminal 3)
 host=0.0.0.0:8000
  curl http://$host/v1/chat/completions \
    -H "Content-Type: application/json" \
    -d '{
      "messages": [{"role": "user", "content": "Hello, how are you?"}],
      "max_tokens": 10,
      "temperature": 0.7,
      "top_p": 1.0,
      "top_k": -1,
      "model": "meta-llama/Meta-Llama-3-8B-Instruct",
      "return_token_ids": true
    }'
```

## Test Result

With changes in this PR:

```bash
Body (JSON):
{
  "model": "meta-llama/Meta-Llama-3-8B-Instruct",
  "messages": [
    {
      "role": "user",
      "content": "Hello, how are you?"
    }
  ],
  "temperature": 0.7,
  "top_p": 1.0,
  "stream": false,
  "max_tokens": 10,
  "logprobs": false,
  "top_k": -1,
  "no_stop_trim": false,
  "ignore_eos": false,
  "add_generation_prompt": true,
  "continue_final_message": false,
  "skip_special_tokens": true,
  "separate_reasoning": true,
  "stream_reasoning": true,
  "return_hidden_states": false,
  "include_reasoning": true,
  "return_token_ids": true
}
```

With `main`:

```bash
Body (JSON):
{
  "model": "meta-llama/Meta-Llama-3-8B-Instruct",
  "messages": [
    {
      "role": "user",
      "content": "Hello, how are you?"
    }
  ],
  "temperature": 0.7,
  "top_p": 1.0,
  "stream": false,
  "max_tokens": 10,
  "logprobs": false,
  "top_k": -1,
  "no_stop_trim": false,
  "ignore_eos": false,
  "add_generation_prompt": true,
  "continue_final_message": false,
  "skip_special_tokens": true,
  "separate_reasoning": true,
  "stream_reasoning": true,
  "return_hidden_states": false,
  "include_reasoning": true 
}

[SUCCESS] /v1/chat/completions endpoint called
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
