### PR TITLE
feat: export queue metrics and make queue size/timeout configurable

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -251,6 +251,14 @@ struct CliArgs {
     #[arg(long, default_value_t = 32768)]
     max_concurrent_requests: usize,
 
+    /// Maximum capacity of the requests queue
+    #[arg(long, default_value_t = 100)]
+    queue_size: usize,
+
+    /// Maximum time a request can spend in the queue before being rejected with a timeout
+    #[arg(long, default_value_t = 60)]
+    queue_timeout_secs: u64,
+
     /// CORS allowed origins
     #[arg(long, num_args = 0..)]
     cors_allowed_origins: Vec<String>,
@@ -523,8 +531,8 @@ impl CliArgs {
                 Some(self.request_id_headers.clone())
             },
             max_concurrent_requests: self.max_concurrent_requests,
-            queue_size: 100,        // Default queue size
-            queue_timeout_secs: 60, // Default timeout
+            queue_size: self.queue_size,
+            queue_timeout_secs: self.queue_timeout_secs,
             cors_allowed_origins: self.cors_allowed_origins.clone(),
             retry: RetryConfig {
                 max_retries: self.retry_max_retries,

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -44,6 +44,22 @@ pub fn init_metrics() {
         "vllm_router_retries_exhausted_total",
         "Total number of requests that exhausted retries by route"
     );
+    describe_counter!(
+        "vllm_router_queue_enqueued_total",
+        "Total number of requests enqueued in the concurrency queue"
+    );
+    describe_gauge!(
+        "vllm_router_queue_size",
+        "Current number of requests in the concurrency queue"
+    );
+    describe_counter!(
+        "vllm_router_queue_timeouts_total",
+        "Total number of queued requests that timed out"
+    );
+    describe_counter!(
+        "vllm_router_queue_rejections_total",
+        "Total number of requests rejected because the queue was full"
+    );
 
     // Circuit breaker metrics
     describe_gauge!(
@@ -281,6 +297,8 @@ pub fn start_prometheus(config: PrometheusConfig) {
 pub struct RouterMetrics;
 
 pub struct TokenizerMetrics;
+
+pub struct QueueMetrics;
 
 impl RouterMetrics {
     // Request metrics
@@ -626,6 +644,28 @@ impl TokenizerMetrics {
     }
 }
 
+impl QueueMetrics {
+    pub fn inc_request_queue_size() {
+        gauge!("vllm_router_queue_size").increment(1);
+    }
+
+    pub fn record_request_queued() {
+        counter!("vllm_router_queue_enqueued_total").increment(1);
+    }
+
+    pub fn dec_request_queue_size() {
+        gauge!("vllm_router_queue_size").decrement(1);
+    }
+
+    pub fn record_queued_request_timeout() {
+        counter!("vllm_router_queue_timeouts_total").increment(1);
+    }
+
+    pub fn record_queued_request_rejected() {
+        counter!("vllm_router_queue_rejections_total").increment(1);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -926,6 +966,17 @@ mod tests {
 
         // Vocabulary metrics
         TokenizerMetrics::set_vocab_size("huggingface", 50000);
+    }
+
+    #[test]
+    fn test_queue_metrics_static_methods() {
+        // Test that all static methods can be called without panic.
+        // Pair inc/dec so the gauge nets to zero across the test.
+        QueueMetrics::inc_request_queue_size();
+        QueueMetrics::record_request_queued();
+        QueueMetrics::dec_request_queue_size();
+        QueueMetrics::record_queued_request_timeout();
+        QueueMetrics::record_queued_request_rejected();
     }
 
     // ============= Port Availability Tests =============

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -16,7 +16,7 @@ use tracing_opentelemetry::OpenTelemetrySpanExt;
 
 pub use crate::core::token_bucket::TokenBucket;
 
-use crate::metrics::RouterMetrics;
+use crate::metrics::{QueueMetrics, RouterMetrics};
 use crate::server::AppState;
 
 /// Generate OpenAI-compatible request ID based on endpoint
@@ -388,15 +388,6 @@ pub struct QueuedRequest {
     permit_tx: oneshot::Sender<Result<(), StatusCode>>,
 }
 
-/// Queue metrics for monitoring
-#[derive(Debug, Default)]
-pub struct QueueMetrics {
-    pub total_queued: std::sync::atomic::AtomicU64,
-    pub current_queued: std::sync::atomic::AtomicU64,
-    pub total_timeout: std::sync::atomic::AtomicU64,
-    pub total_rejected: std::sync::atomic::AtomicU64,
-}
-
 /// Queue processor that handles queued requests
 pub struct QueueProcessor {
     token_bucket: Arc<TokenBucket>,
@@ -426,6 +417,8 @@ impl QueueProcessor {
             let elapsed = queued.queued_at.elapsed();
             if elapsed >= self.queue_timeout {
                 warn!("Request already timed out in queue");
+                QueueMetrics::record_queued_request_timeout();
+                QueueMetrics::dec_request_queue_size();
                 let _ = queued.permit_tx.send(Err(StatusCode::REQUEST_TIMEOUT));
                 continue;
             }
@@ -436,6 +429,7 @@ impl QueueProcessor {
             if self.token_bucket.try_acquire(1.0).await.is_ok() {
                 // Got token immediately
                 debug!("Queue: acquired token immediately for queued request");
+                QueueMetrics::dec_request_queue_size();
                 let _ = queued.permit_tx.send(Ok(()));
             } else {
                 // Need to wait for token
@@ -449,9 +443,12 @@ impl QueueProcessor {
                         .is_ok()
                     {
                         debug!("Queue: acquired token after waiting");
+                        QueueMetrics::dec_request_queue_size();
                         let _ = queued.permit_tx.send(Ok(()));
                     } else {
                         warn!("Queue: request timed out waiting for token");
+                        QueueMetrics::record_queued_request_timeout();
+                        QueueMetrics::dec_request_queue_size();
                         let _ = queued.permit_tx.send(Err(StatusCode::REQUEST_TIMEOUT));
                     }
                 });
@@ -525,10 +522,12 @@ pub async fn concurrency_limit_middleware(
                 permit_tx,
             };
 
-            // Try to send to queue
+            // Increment the gauge eagerly to avoid it being decremented below zero by QueueProcessor
+            QueueMetrics::inc_request_queue_size();
             match queue_tx.try_send(queued) {
                 Ok(_) => {
-                    // On successful enqueue, update embeddings queue gauge if applicable
+                    QueueMetrics::record_request_queued();
+                    // Update embeddings-specific queue gauge if applicable
                     if is_embeddings {
                         let new_val = EMBEDDINGS_QUEUE_SIZE.fetch_add(1, Ordering::Relaxed) + 1;
                         RouterMetrics::set_embeddings_queue_size(new_val as usize);
@@ -575,6 +574,8 @@ pub async fn concurrency_limit_middleware(
                     }
                 }
                 Err(_) => {
+                    QueueMetrics::record_queued_request_rejected();
+                    QueueMetrics::dec_request_queue_size();
                     warn!("Request queue is full, returning 429");
                     StatusCode::TOO_MANY_REQUESTS.into_response()
                 }


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
- Being able to configure queue size and timeout is useful for tailoring the router to different traffic types. For example a larger queue size is useful for bursty traffic.
- Exporting the queue metrics to prometheus allows observability into the queue state and scaling based on queue size with tools like Keda for example.

## Test Plan
- Ran the project locally with dummy backends: cargo run -- --worker-urls http://worker1:8000 http://worker2:8000 --queue-size 500 --queue-timeout-secs 300
- Added unit tests similar to those already present for `RouterMetrics`, but am unsure if this is enough?

## Test Result
- Starting the project locally with the above command works
- Tests pass locally
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
