### PR TITLE
[ROCm] Add MoRI support to Python router

### DIFF
--- a/py_src/vllm_router/router_args.py
+++ b/py_src/vllm_router/router_args.py
@@ -326,8 +326,7 @@ class RouterArgs:
             help="KV connector type for PD disaggregation. 'nixl' (default) uses NIXL's "
             "pull-based KV transfer; 'mooncake' uses Mooncake's push-based protocol "
             "(queries each prefill node's bootstrap server for engine_id per DP rank); "
-            "'moriio' uses the MoRI-IO connector (either READ or WRITE modes)."
-            ,
+            "'moriio' uses the MoRI-IO connector (either READ or WRITE modes).",
         )
         # Prometheus configuration
         parser.add_argument(

--- a/py_src/vllm_router/router_args.py
+++ b/py_src/vllm_router/router_args.py
@@ -49,6 +49,8 @@ class RouterArgs:
     prefill_selector: Dict[str, str] = dataclasses.field(default_factory=dict)
     decode_selector: Dict[str, str] = dataclasses.field(default_factory=dict)
     bootstrap_port_annotation: str = "vllm.ai/bootstrap-port"
+    # ZMQ service discovery address for vLLM PD mode
+    vllm_discovery_address: Optional[str] = None
     # KV connector for PD disaggregation (nixl pull-based or mooncake push-based)
     kv_connector: str = "nixl"
     # Prometheus configuration
@@ -310,13 +312,22 @@ class RouterArgs:
             help="Label selector for decode server pods in PD mode (format: key1=value1 key2=value2)",
         )
         parser.add_argument(
+            f"--{prefix}vllm-discovery-address",
+            type=str,
+            default=None,
+            help="ZMQ service discovery address for vLLM PD mode (e.g., '0.0.0.0:30001'). "
+            "Workers register their HTTP and ZMQ addresses here.",
+        )
+        parser.add_argument(
             f"--{prefix}kv-connector",
             type=str,
             default=RouterArgs.kv_connector,
-            choices=["nixl", "mooncake"],
+            choices=["nixl", "mooncake", "moriio"],
             help="KV connector type for PD disaggregation. 'nixl' (default) uses NIXL's "
             "pull-based KV transfer; 'mooncake' uses Mooncake's push-based protocol "
-            "(queries each prefill node's bootstrap server for engine_id per DP rank).",
+            "(queries each prefill node's bootstrap server for engine_id per DP rank); "
+            "'moriio' uses the MoRI-IO connector (either READ or WRITE modes)."
+            ,
         )
         # Prometheus configuration
         parser.add_argument(

--- a/py_src/vllm_router/router_args.py
+++ b/py_src/vllm_router/router_args.py
@@ -522,7 +522,7 @@ class RouterArgs:
         # Validate configuration based on mode
         if self.vllm_pd_disaggregation:
             # Validate PD configuration - skip URL requirements if using service discovery
-            if not self.service_discovery:
+            if not self.service_discovery and not self.vllm_discovery_address:
                 if not self.prefill_urls:
                     raise ValueError("PD disaggregation mode requires --prefill")
                 if not self.decode_urls:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,6 +61,7 @@ struct Router {
     request_timeout_secs: u64,
     request_id_headers: Option<Vec<String>>,
     vllm_pd_disaggregation: bool,
+    vllm_discovery_address: Option<String>,
     prefill_urls: Option<Vec<(String, Option<u16>)>>,
     decode_urls: Option<Vec<String>>,
     prefill_policy: Option<PolicyType>,
@@ -138,7 +139,7 @@ impl Router {
                 decode_urls: self.decode_urls.clone().unwrap_or_default(),
                 prefill_policy: self.prefill_policy.as_ref().map(convert_policy),
                 decode_policy: self.decode_policy.as_ref().map(convert_policy),
-                discovery_address: None,
+                discovery_address: self.vllm_discovery_address.clone(),
             }
         } else {
             RoutingMode::Regular {
@@ -226,10 +227,11 @@ impl Router {
             kv_connector: match self.kv_connector.to_ascii_lowercase().as_str() {
                 "nixl" => config::KvConnector::Nixl,
                 "mooncake" => config::KvConnector::Mooncake,
+                "moriio" => config::KvConnector::MoriIO,
                 other => {
                     return Err(config::ConfigError::ValidationFailed {
                         reason: format!(
-                            "Invalid kv_connector '{}': expected 'nixl' or 'mooncake'",
+                            "Invalid kv_connector '{}': expected 'nixl', 'mooncake', or 'moriio'",
                             other
                         ),
                     });
@@ -272,6 +274,7 @@ impl Router {
         request_timeout_secs = 1800,  // Add configurable request timeout
         request_id_headers = None,  // Custom request ID headers
         vllm_pd_disaggregation = false,  // New flag for PD mode
+        vllm_discovery_address = None,
         prefill_urls = None,
         decode_urls = None,
         prefill_policy = None,
@@ -339,6 +342,7 @@ impl Router {
         request_timeout_secs: u64,
         request_id_headers: Option<Vec<String>>,
         vllm_pd_disaggregation: bool,
+        vllm_discovery_address: Option<String>,
         prefill_urls: Option<Vec<(String, Option<u16>)>>,
         decode_urls: Option<Vec<String>>,
         prefill_policy: Option<PolicyType>,
@@ -399,6 +403,7 @@ impl Router {
             request_timeout_secs,
             request_id_headers,
             vllm_pd_disaggregation,
+            vllm_discovery_address,
             prefill_urls,
             decode_urls,
             prefill_policy,


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Fixes #173.

This PR allows running vllm-router with MoRI through python.

Helps ease of use as a `pip install vllm-router` is then sufficient to run MoRI.

**Usage**:
```shell
pip install vllm-router    # onced merged
vllm-router \
    --vllm-pd-disaggregation \
    --kv-connector moriio \
    --vllm-discovery-address "0.0.0.0:${PROXY_PING_PORT}" \
    --port "${ROUTER_PORT}" \
    --host 0.0.0.0 
```

## Test Plan

1. Build locally
```shell
docker run --rm \
  -v "$(pwd):/workdir" \
  -w /workdir \
   quay.io/pypa/manylinux_2_28_x86_64 \
   bash .buildkite/build-wheel.sh
# outputs dist/vllm_router-0.1.14-cp38-abi3-manylinux_2_28_x86_64.whl
```

2. Install and test the wheel on 2 MI300X nodes using DeepSeek-R1 1P1D together on vLLM 0.20.1:

```shell
# Install and run the python router
docker run \
    --name vllm-router \
    --network host \
    --rm \
    -v "$(pwd)/dist:/wheels" \
    python:3.11-slim \
    bash -c "pip install /wheels/vllm_router-0.1.14-cp38-abi3-manylinux_2_28_x86_64.whl && \
      vllm-router \
        --vllm-pd-disaggregation \
        --kv-connector moriio \
        --vllm-discovery-address '0.0.0.0:36367' \
        --policy consistent_hash \
        --prefill-policy consistent_hash \
        --decode-policy consistent_hash \
        --log-level info"

# On both nodes, set PREFILL_IP
PREFILL_IP=<your ip>

# Node 1: Launch a P instance
# Note: depending on your environment, to run MoRI you might need to use a different image that ships the necessary RDMA userspace libs for your NICs.
docker run \
  --rm \
  --name moriio-prefill \
  --init --network host --ipc host --privileged \
  --cap-add SYS_PTRACE --security-opt seccomp=unconfined \
  --ulimit memlock=-1 --ulimit stack=67108864 \
  --shm-size 256G \
  --group-add video --group-add render \
  --device /dev/kfd --device /dev/dri --device /dev/infiniband \
  -v /sys:/sys \
  -v "${HOME}/.cache/huggingface:/root/.cache/huggingface" \
  -e HF_HOME=/root/.cache/huggingface \
  -e HF_HUB_ENABLE_HF_TRANSFER=0 \
  -e VLLM_MORIIO_CONNECTOR_READ_MODE=1 \
  -e NCCL_MIN_NCHANNELS=112 \
  -e VLLM_USE_V1=1 \
  -e VLLM_ENGINE_READY_TIMEOUT_S=3600 \
  -e VLLM_SERVER_DEV_MODE=1 \
  -e VLLM_ROCM_USE_AITER=1 \
  -e VLLM_ROCM_USE_AITER_PAGED_ATTN=0 \
  -e VLLM_ROCM_USE_AITER_RMSNORM=1 \
  -e VLLM_USE_AITER_TRITON_SILU_MUL=0 \
  vllm/vllm-openai-rocm:v0.20.1 \
  deepseek-ai/DeepSeek-R1-0528 \
    --port 8100 \
    --tensor-parallel-size 8 \
    --kv-cache-dtype fp8 \
    --load-format dummy \
    --gpu-memory-utilization 0.7 \
    --max-num-batched-tokens 32768 \
    --max-model-len 16384 \
    --trust-remote-code \
    --no-enable-prefix-caching \
    --block-size 1 \
    --enforce-eager \
    --kv-transfer-config '{
      "kv_connector": "MoRIIOConnector",
      "kv_role": "kv_producer",
      "kv_connector_extra_config": {
        "proxy_ip": "'"${PREFILL_IP}"'",
        "proxy_ping_port": "36367",
        "http_port": "8100",
        "handshake_port": "6301",
        "notify_port": "61005"
      }
    }'

# Node 2: Launch a D instance
docker run \
  --rm \
  --name moriio-decode \
  --init --network host --ipc host --privileged \
  --cap-add SYS_PTRACE --security-opt seccomp=unconfined \
  --ulimit memlock=-1 --ulimit stack=67108864 \
  --shm-size 256G \
  --group-add video --group-add render \
  --device /dev/kfd --device /dev/dri --device /dev/infiniband \
  -v /sys:/sys \
  -v "${HOME}/.cache/huggingface:/root/.cache/huggingface" \
  -e HF_HOME=/root/.cache/huggingface \
  -e HF_HUB_ENABLE_HF_TRANSFER=0 \
  -e VLLM_MORIIO_CONNECTOR_READ_MODE=1 \
  -e NCCL_MIN_NCHANNELS=112 \
  -e VLLM_USE_V1=1 \
  -e VLLM_ENGINE_READY_TIMEOUT_S=3600 \
  -e VLLM_SERVER_DEV_MODE=1 \
  -e VLLM_ROCM_USE_AITER=1 \
  -e VLLM_ROCM_USE_AITER_PAGED_ATTN=0 \
  -e VLLM_ROCM_USE_AITER_RMSNORM=1 \
  -e VLLM_USE_AITER_TRITON_SILU_MUL=0 \
  vllm/vllm-openai-rocm:v0.20.1 \
  deepseek-ai/DeepSeek-R1-0528 \
    --port 8200 \
    --tensor-parallel-size 8 \
    --kv-cache-dtype fp8 \
    --load-format dummy \
    --gpu-memory-utilization 0.7 \
    --max-num-batched-tokens 32768 \
    --max-model-len 16384 \
    --trust-remote-code \
    --no-enable-prefix-caching \
    --block-size 1 \
    --enable-expert-parallel \
    --all2all-backend mori \
    --compilation-config '{"cudagraph_mode": "PIECEWISE"}' \
    --kv-transfer-config '{
      "kv_connector": "MoRIIOConnector",
      "kv_role": "kv_consumer",
      "kv_connector_extra_config": {
        "proxy_ip": "'"${PREFILL_IP}"'",
        "proxy_ping_port": "36367",
        "http_port": "8200",
        "handshake_port": "6301",
        "notify_port": "61005"
      }
    }'

# Node 1: Run some tests
docker exec moriio-prefill \
  vllm bench serve \
    --base-url http://localhost:30000 \
    --backend vllm \
    --model deepseek-ai/DeepSeek-R1-0528 \
    --dataset-name random \
    --random-input-len 1000 \
    --random-output-len 1000 \
    --max-concurrency 128 \
    --num-warmups 256 \
    --num-prompts 1280 \
    --seed 1234
```

## Test Result

1. Build runs successfully 
```
Successfully built vllm_router-0.1.14.tar.gz and vllm_router-0.1.14-cp38-abi3-linux_x86_64.whl
INFO:auditwheel.main_repair:Repairing vllm_router-0.1.14-cp38-abi3-linux_x86_64.whl
INFO:auditwheel.wheeltools:Previous filename tags: linux_x86_64
INFO:auditwheel.wheeltools:New filename tags: manylinux_2_28_x86_64
INFO:auditwheel.wheeltools:Previous WHEEL info tags: cp38-abi3-linux_x86_64
INFO:auditwheel.wheeltools:New WHEEL info tags: cp38-abi3-manylinux_2_28_x86_64
INFO:auditwheel.main_repair:
Fixed-up wheel written to /workdir/dist/vllm_router-0.1.14-cp38-abi3-manylinux_2_28_x86_64.whl
INFO:auditwheel.main_repair:Repairing vllm_router-0.1.14-cp38-abi3-manylinux_2_28_x86_64.whl
INFO:auditwheel.wheeltools:Previous filename tags: manylinux_2_28_x86_64
INFO:auditwheel.wheeltools:No filename tags change needed.
INFO:auditwheel.wheeltools:Previous WHEEL info tags: cp38-abi3-manylinux_2_28_x86_64
INFO:auditwheel.wheeltools:No WHEEL info change needed.
INFO:auditwheel.main_repair:
Fixed-up wheel written to /workdir/dist/vllm_router-0.1.14-cp38-abi3-manylinux_2_28_x86_64.whl
```

2. Test

Router: python install OK and is in correct mode and both instances are discovered
```
Processing /wheels/vllm_router-0.1.14-cp38-abi3-manylinux_2_28_x86_64.whl
Collecting setproctitle (from vllm-router==0.1.14)
  Downloading setproctitle-1.3.7-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl.metadata (10 kB)
...
Downloading annotated_types-0.7.0-py3-none-any.whl (13 kB)
Downloading anyio-4.13.0-py3-none-any.whl (114 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 114.4/114.4 kB 149.0 MB/s eta 0:00:00
Installing collected packages: urllib3, typing-extensions, setproctitle, propcache, orjson, multidict, idna, h11, frozenlist, click, charset_normalizer, certifi, attrs, annotated-types, annotated-doc, aiohappyeyeballs, yarl, uvicorn, typing-inspection, requests, pydantic-core, anyio, aiosignal, starlette, pydantic, aiohttp, fastapi, vllm-router
Successfully installed aiohappyeyeballs-2.6.1 aiohttp-3.13.5 aiosignal-1.4.0 annotated-doc-0.0.4 annotated-types-0.7.0 anyio-4.13.0 attrs-26.1.0 certifi-2026.4.22 charset_normalizer-3.4.7 click-8.3.3 fastapi-0.136.1 frozenlist-1.8.0 h11-0.16.0 idna-3.13 multidict-6.7.1 orjson-3.11.8 propcache-0.4.1 pydantic-2.13.3 pydantic-core-2.46.3 requests-2.33.1 setproctitle-1.3.7 starlette-1.0.0 typing-extensions-4.15.0 typing-inspection-0.4.2 urllib3-2.6.3 uvicorn-0.46.0 vllm-router-0.1.14 yarl-1.23.0
WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv

[notice] A new release of pip is available: 24.0 -> 26.1.1
[notice] To update, run: pip install --upgrade pip
Both --prefill-policy and --decode-policy are specified. The main --policy flag will be ignored for PD mode.
DEBUG: Server startup function called
DEBUG: Initializing logging
DEBUG: Logging initialized
DEBUG: Initializing Prometheus metrics
DEBUG: Prometheus metrics initialized
2026-05-06 08:54:40  INFO vllm_router_rs::server: src/server.rs:831: Starting router on 127.0.0.1:30000 | mode: VllmPrefillDecode { prefill_urls: [], decode_urls: [], prefill_policy: Some(ConsistentHash { virtual_nodes: 160 }), decode_policy: Some(ConsistentHash { virtual_nodes: 160 }), discovery_address: Some("0.0.0.0:36367") } | policy: ConsistentHash { virtual_nodes: 160 } | kv_connector: MoriIO | max_payload: 512MB
DEBUG: Creating HTTP client
DEBUG: HTTP client created
DEBUG: Creating AppContext
DEBUG: AppContext created
2026-05-06 08:54:40  INFO vllm_router_rs::server: src/server.rs:929: Single router mode (enable_igw=false)
2026-05-06 08:54:40  INFO vllm_router_rs::routers::factory: src/routers/factory.rs:29: Creating VllmPDRouter with prefill_urls: [], decode_urls: [], discovery: Some("0.0.0.0:36367")
2026-05-06 08:54:40  INFO vllm_router_rs::routers::factory: src/routers/factory.rs:81: Creating VllmPDRouter with service discovery at: Some("0.0.0.0:36367")
2026-05-06 08:54:40  INFO vllm_router_rs::routers::http::vllm_pd_router: src/routers/http/vllm_pd_router.rs:1334: VllmPDRouter::new called in discovery mode with address: 0.0.0.0:36367
2026-05-06 08:54:40  INFO vllm_router_rs::routers::http::pd_router: src/routers/http/pd_router.rs:574: DP-aware mode disabled, using original worker URLs
2026-05-06 08:54:40  INFO vllm_router_rs::routers::http::vllm_pd_router: src/routers/http/vllm_pd_router.rs:1345: Starting vLLM service discovery on 0.0.0.0:36367
2026-05-06 08:54:40  INFO vllm_router_rs::routers::http::vllm_service_discovery: src/routers/http/vllm_service_discovery.rs:72: Starting vLLM service discovery listener on 0.0.0.0:36367
2026-05-06 08:54:40  INFO vllm_router_rs::routers::http::vllm_pd_router: src/routers/http/vllm_pd_router.rs:1351: VllmPDRouter created successfully with pure service discovery, kv_connector=MoriIO
2026-05-06 08:54:40  INFO vllm_router_rs::routers::factory: src/routers/factory.rs:101: VllmPDRouter instance created successfully
2026-05-06 08:54:40  INFO vllm_router_rs::server: src/server.rs:941: Started health checker for workers with 60s interval
2026-05-06 08:54:40  INFO vllm_router_rs::server: src/server.rs:956: Started request queue with size: 100, timeout: 60s
2026-05-06 08:54:40  INFO vllm_router_rs::middleware: src/middleware.rs:421: Starting concurrency queue processor
2026-05-06 08:54:40  INFO vllm_router_rs::server: src/server.rs:992: Router ready | workers: []
2026-05-06 08:54:40  INFO vllm_router_rs::server: src/server.rs:1021: Starting server on 127.0.0.1:30000
2026-05-06 08:54:40  INFO vllm_router_rs::routers::http::vllm_service_discovery: src/routers/http/vllm_service_discovery.rs:94: ZMQ service discovery bound to tcp://0.0.0.0:36367
2026-05-06 08:59:06  INFO vllm_router_rs::routers::http::vllm_service_discovery: 
2026-05-06 09:04:38  INFO vllm_router_rs::routers::http::vllm_service_discovery: src/routers/http/vllm_service_discovery.rs:175: 🔵Add Prefill [HTTP:10.21.9.34:8100, ZMQ:host:10.21.9.34,handshake:6301,notify:61005]
2026-05-06 09:05:16  INFO vllm_router_rs::routers::http::vllm_service_discovery: src/routers/http/vllm_service_discovery.rs:192: 🔵Add Decode [HTTP:10.21.9.8:8200, ZMQ:host:10.21.9.8,handshake:6301,notify:61005]
```

Bench succeeds:
```shell
INFO 05-06 09:08:51 [utils.py:90] Sampling input_len from [1000, 1000] and output_len from [1000, 1000]
Starting initial single prompt test run...
Warming up with 256 requests...
100%|██████████| 256/256 [00:50<00:00,  5.06it/s]
Warmup run completed.
Starting main benchmark run...
Traffic request rate: inf
Burstiness factor: 1.0 (Poisson process)
Maximum request concurrency: 128
100%|██████████| 1280/1280 [04:17<00:00,  4.98it/s]
============ Serving Benchmark Result ============
Successful requests:                     1280
Failed requests:                         0
Maximum request concurrency:             128
Benchmark duration (s):                  257.22
Total input tokens:                      1280000
Total generated tokens:                  1280000
Request throughput (req/s):              4.98
Output token throughput (tok/s):         4976.28
Peak output token throughput (tok/s):    7275.00
Peak concurrent requests:                184.00
Total token throughput (tok/s):          9952.57
---------------Time to First Token----------------
Mean TTFT (ms):                          6341.37
Median TTFT (ms):                        1093.25
P99 TTFT (ms):                           61747.46
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          18.32
Median TPOT (ms):                        18.40
P99 TPOT (ms):                           18.93
---------------Inter-token Latency----------------
Mean ITL (ms):                           18.32
Median ITL (ms):                         18.18
P99 ITL (ms):                            33.12
==================================================
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
