### PR TITLE
fix: align load endpoint with vLLM API (/load + server_load)

### DIFF
--- a/py_test/fixtures/mock_worker.py
+++ b/py_test/fixtures/mock_worker.py
@@ -5,6 +5,7 @@ Implements minimal endpoints used by the router:
 - GET /health, /health_generate
 - POST /generate, /v1/completions, /v1/chat/completions
 - POST /flush_cache
+- GET /load (returns {"server_load": N} matching vLLM API)
 - GET /get_server_info, /get_model_info, /v1/models
 
 Behavior knobs are controlled via CLI flags to simulate failures, latency, and load.
@@ -138,9 +139,9 @@ def create_app(args: argparse.Namespace) -> FastAPI:
             }
         )
 
-    @app.get("/get_load")
-    async def get_load():
-        return JSONResponse({"load": _inflight})
+    @app.get("/load")
+    async def load():
+        return JSONResponse({"server_load": _inflight})
 
     def make_json_response(obj: dict, status_code: int = 200) -> JSONResponse:
         resp = JSONResponse(obj, status_code=status_code)

--- a/py_test/integration/load_balancing/test_power_of_two.py
+++ b/py_test/integration/load_balancing/test_power_of_two.py
@@ -9,7 +9,7 @@ import requests
 @pytest.mark.integration
 def test_power_of_two_prefers_less_loaded(mock_workers, router_manager):
     # Start two workers: one slow (higher inflight), one fast
-    # Router monitors /get_load and Power-of-Two uses cached loads to choose
+    # Router monitors /load (server_load) and Power-of-Two uses cached loads to choose
     # Start one slow and one fast worker using the fixture factory
     procs_slow, urls_slow, ids_slow = mock_workers(n=1, args=["--latency-ms", "200"])
     procs_fast, urls_fast, ids_fast = mock_workers(n=1, args=["--latency-ms", "0"])

--- a/src/routers/http/pd_router.rs
+++ b/src/routers/http/pd_router.rs
@@ -853,11 +853,11 @@ impl PdRouterBase {
 // Helper functions
 
 async fn get_worker_load(client: &Client, worker_url: &str) -> Option<isize> {
-    match client.get(format!("{}/get_load", worker_url)).send().await {
+    match client.get(format!("{}/load", worker_url)).send().await {
         Ok(res) if res.status().is_success() => match res.bytes().await {
             Ok(bytes) => match serde_json::from_slice::<Value>(&bytes) {
                 Ok(data) => data
-                    .get("load")
+                    .get("server_load")
                     .and_then(|v| v.as_i64())
                     .map(|v| v as isize),
                 Err(e) => {

--- a/src/routers/http/router.rs
+++ b/src/routers/http/router.rs
@@ -1243,16 +1243,11 @@ impl Router {
             worker_url
         };
 
-        match self
-            .client
-            .get(format!("{}/get_load", worker_url))
-            .send()
-            .await
-        {
+        match self.client.get(format!("{}/load", worker_url)).send().await {
             Ok(res) if res.status().is_success() => match res.bytes().await {
                 Ok(bytes) => match serde_json::from_slice::<serde_json::Value>(&bytes) {
                     Ok(data) => data
-                        .get("load")
+                        .get("server_load")
                         .and_then(|v| v.as_i64())
                         .map(|v| v as isize),
                     Err(e) => {
@@ -1328,11 +1323,11 @@ impl Router {
             worker_url
         };
 
-        match client.get(format!("{}/get_load", worker_url)).send().await {
+        match client.get(format!("{}/load", worker_url)).send().await {
             Ok(res) if res.status().is_success() => match res.bytes().await {
                 Ok(bytes) => match serde_json::from_slice::<serde_json::Value>(&bytes) {
                     Ok(data) => data
-                        .get("load")
+                        .get("server_load")
                         .and_then(|v| v.as_i64())
                         .map(|v| v as isize),
                     Err(e) => {

--- a/tests/api_endpoints_test.rs
+++ b/tests/api_endpoints_test.rs
@@ -1600,6 +1600,91 @@ mod cache_tests {
         assert!(body_json.is_object());
         // The exact structure depends on the implementation
         // but should contain worker load information
+        assert!(body_json.get("workers").is_some());
+        let workers = body_json["workers"].as_array().unwrap();
+        assert_eq!(workers.len(), 2);
+        // Each worker entry should have "worker" (url) and "load" fields
+        for entry in workers {
+            assert!(entry.get("worker").is_some());
+            assert!(entry.get("load").is_some());
+        }
+
+        ctx.shutdown().await;
+    }
+
+    // Verify that the mock worker's /load endpoint returns {"server_load": N}
+    // matching the vLLM API format that the router now expects
+    #[tokio::test]
+    async fn test_worker_load_endpoint_format() {
+        let mut worker = MockWorker::new(MockWorkerConfig {
+            port: 0, // ephemeral port
+            worker_type: WorkerType::Regular,
+            health_status: HealthStatus::Healthy,
+            response_delay_ms: 0,
+            fail_rate: 0.0,
+        });
+        let url = worker.start().await.unwrap();
+
+        let client = Client::new();
+        let resp = client.get(format!("{}/load", url)).send().await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let body: serde_json::Value = resp.json().await.unwrap();
+        // vLLM returns {"server_load": N}, not {"load": N}
+        assert!(
+            body.get("server_load").is_some(),
+            "Expected 'server_load' key in /load response, got: {:?}",
+            body
+        );
+        assert!(
+            body.get("server_load").unwrap().is_i64(),
+            "server_load should be an integer, got: {:?}",
+            body["server_load"]
+        );
+
+        worker.stop().await;
+    }
+
+    // Verify that the router successfully fetches load from workers via /load
+    // and that the returned load value is non-negative (not -1 fallback).
+    #[tokio::test]
+    async fn test_router_fetches_load_via_server_load_key() {
+        let ctx = TestContext::new(vec![MockWorkerConfig {
+            port: 0,
+            worker_type: WorkerType::Regular,
+            health_status: HealthStatus::Healthy,
+            response_delay_ms: 0,
+            fail_rate: 0.0,
+        }])
+        .await;
+
+        let app = ctx.create_app().await;
+
+        let req = Request::builder()
+            .method("GET")
+            .uri("/get_loads")
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body_json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+        let workers = body_json["workers"].as_array().unwrap();
+        assert_eq!(workers.len(), 1);
+        // The load value should be 0 (mock default), NOT -1 (fallback for
+        // failed fetch), proving the router correctly calls GET /load and
+        // parses the "server_load" key.
+        let load_val = workers[0]["load"].as_i64().unwrap();
+        assert!(
+            load_val >= 0,
+            "Load should be >= 0 when /load endpoint is reachable, got: {}",
+            load_val
+        );
 
         ctx.shutdown().await;
     }

--- a/tests/common/mock_worker.rs
+++ b/tests/common/mock_worker.rs
@@ -90,6 +90,7 @@ impl MockWorker {
                 post(responses_cancel_handler),
             )
             .route("/flush_cache", post(flush_cache_handler))
+            .route("/load", get(load_handler))
             .route("/v1/models", get(v1_models_handler))
             .with_state(config);
 
@@ -692,6 +693,26 @@ async fn flush_cache_handler(State(config): State<Arc<RwLock<MockWorkerConfig>>>
 
     Json(json!({
         "message": "Cache flushed successfully"
+    }))
+    .into_response()
+}
+
+// Mimics vLLM's GET /load endpoint returning {"server_load": N}
+async fn load_handler(State(config): State<Arc<RwLock<MockWorkerConfig>>>) -> Response {
+    let config = config.read().await;
+
+    if should_fail(&config).await {
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({
+                "error": "Random failure for testing"
+            })),
+        )
+            .into_response();
+    }
+
+    Json(json!({
+        "server_load": 0
     }))
     .into_response()
 }


### PR DESCRIPTION
vLLM exposes GET /load returning {"server_load": N}, not GET /get_load returning {"load": N}. This mismatch caused power_of_two policy to always get 404, degrading to random selection.



- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results

## Purpose
fix #174 
## Test Plan
1. launch vllm-router
```
/vllm/vllm-router \
    --log-level debug
    --vllm-pd-disaggregation \
    --prefill "http://prefill1:6700" \
    --prefill "http://prefill2:6700" \
    --decode "http://decode1:63110" \
    --decode "http://decode2:63111" \
    --decode "http://decode3:63110" \
    --decode "http://decode4:63111" \
    --prefill-policy power_of_two \
    --decode-policy power_of_two \
    --host $router_ip \
    --port $router_port
```
2. keep prefill1 busy by calling expensive reqs directly to prefill1, bypassing router
```
seq 500 | xargs -P20 -I{} bash -c '
PAYLOAD=$(python3 -c "
import random, string, json
text = \" \".join(\"\".join(random.choices(string.ascii_letters + string.digits, k=random.randint(8,15))) for _ in range(6000))
msg = {\"model\":\"glm-5.1\",\"max_tokens\":1,\"messages\":[{\"role\":\"user\",\"content\":text}]} 
print(json.dumps(msg))
")
curl -s --request POST \
  --url http://prefill1:6700/v1/chat/completions \
  -H "content-type: application/json" \
  -d "$PAYLOAD"
'
```
```
curl http://prefill1:6700/load
{"server_load":20}
```

3. send small requests to router
```
seq 50 | xargs -P2 -I{} curl -s --request POST   --url http://$router_ip:$router_port/v1/chat/completions   -H 'content-type: application/json'   -d '{"model":"glm-5.1","max_tokens":1,"messages":[{"role":"user","content":"hi"}]}'
```

### Expected Result
1. no `GET /get_load HTTP/1.1" 404 Not Found` in vllm logs.
2. from router's log, all requests should be routed to prefill2, as prefill1 is busy.

## Test Result
1. no `GET /get_load HTTP/1.1" 404 Not Found` in vllm logs.
`(APIServer pid=99192) INFO:     ip:port - "GET /load HTTP/1.1" 200 OK`
2. from router's log, all requests should be routed to prefill2, as prefill1 is busy.
### before: requests were routed to prefill1 and prefill2 evenly
```
2026-05-21 10:08:30  INFO vllm_router_rs::routers::http::vllm_pd_router: src/routers/http/vllm_pd_router.rs:1618: Chat: Selected prefill=http://prefill2:6700 [policy:power_of_two], decode=http://d-node1:63111 [policy:power_of_two]
2026-05-21 10:08:30  INFO vllm_router_rs::routers::http::vllm_pd_router: src/routers/http/vllm_pd_router.rs:1618: Chat: Selected prefill=http://prefill1:6700 [policy:power_of_two], decode=http://d-node1:63110 [policy:power_of_two]
2026-05-21 10:08:30  INFO vllm_router_rs::routers::http::vllm_pd_router: src/routers/http/vllm_pd_router.rs:1618: Chat: Selected prefill=http://prefill1:6700 [policy:power_of_two], decode=http://d-node2:63110 [policy:power_of_two]
2026-05-21 10:08:35  INFO vllm_router_rs::routers::http::vllm_pd_router: src/routers/http/vllm_pd_router.rs:1618: Chat: Selected prefill=http://prefill2:6700 [policy:power_of_two], decode=http://d-node1:63111 [policy:power_of_two]
2026-05-21 10:08:35  INFO vllm_router_rs::routers::http::vllm_pd_router: src/routers/http/vllm_pd_router.rs:1618: Chat: Selected prefill=http://prefill2:6700 [policy:power_of_two], decode=http://d-node1:63110 [policy:power_of_two]
2026-05-21 10:08:41  INFO vllm_router_rs::routers::http::vllm_pd_router: src/routers/http/vllm_pd_router.rs:1618: Chat: Selected prefill=http://prefill1:6700 [policy:power_of_two], decode=http://d-node1:63110 [policy:power_of_two]
2026-05-21 10:08:41  INFO vllm_router_rs::routers::http::vllm_pd_router: src/routers/http/vllm_pd_router.rs:1618: Chat: Selected prefill=http://prefill2:6700 [policy:power_of_two], decode=http://d-node2:63110 [policy:power_of_two]
2026-05-21 10:08:46  INFO vllm_router_rs::routers::http::vllm_pd_router: src/routers/http/vllm_pd_router.rs:1618: Chat: Selected prefill=http://prefill2:6700 [policy:power_of_two], decode=http://d-node2:63110 [policy:power_of_two]
2026-05-21 10:08:50  INFO vllm_router_rs::routers::http::vllm_pd_router: src/routers/http/vllm_pd_router.rs:1618: Chat: Selected prefill=http://prefill1:6700 [policy:power_of_two], decode=http://d-node2:63111 [policy:power_of_two]
```

### after: all requests were routed to prefill2, as prefill1 is busy.
```
2026-05-21 11:09:55  INFO vllm_router_rs::routers::http::vllm_pd_router: src/routers/http/vllm_pd_router.rs:1618: Chat: Selected prefill=http://prefill2:6700 [policy:power_of_two], decode=http://d-node2:63110 [policy:power_of_two]
2026-05-21 11:09:55  INFO vllm_router_rs::routers::http::vllm_pd_router: src/routers/http/vllm_pd_router.rs:1618: Chat: Selected prefill=http://prefill2:6700 [policy:power_of_two], decode=http://d-node1:63111 [policy:power_of_two]
2026-05-21 11:10:00  INFO vllm_router_rs::routers::http::vllm_pd_router: src/routers/http/vllm_pd_router.rs:1618: Chat: Selected prefill=http://prefill2:6700 [policy:power_of_two], decode=http://d-node2:63110 [policy:power_of_two]
2026-05-21 11:10:00  INFO vllm_router_rs::routers::http::vllm_pd_router: src/routers/http/vllm_pd_router.rs:1618: Chat: Selected prefill=http://prefill2:6700 [policy:power_of_two], decode=http://d-node2:63111 [policy:power_of_two]
2026-05-21 11:10:06  INFO vllm_router_rs::routers::http::vllm_pd_router: src/routers/http/vllm_pd_router.rs:1618: Chat: Selected prefill=http://prefill2:6700 [policy:power_of_two], decode=http://d-node1:63111 [policy:power_of_two]
2026-05-21 11:10:06  INFO vllm_router_rs::routers::http::vllm_pd_router: src/routers/http/vllm_pd_router.rs:1618: Chat: Selected prefill=http://prefill2:6700 [policy:power_of_two], decode=http://d-node1:63111 [policy:power_of_two]
2026-05-21 11:10:12  INFO vllm_router_rs::routers::http::vllm_pd_router: src/routers/http/vllm_pd_router.rs:1618: Chat: Selected prefill=http://prefill2:6700 [policy:power_of_two], decode=http://d-node2:63111 [policy:power_of_two]
2026-05-21 11:10:12  INFO vllm_router_rs::routers::http::vllm_pd_router: src/routers/http/vllm_pd_router.rs:1618: Chat: Selected prefill=http://prefill2:6700 [policy:power_of_two], decode=http://d-node2:63110 [policy:power_of_two]
2026-05-21 11:10:18  INFO vllm_router_rs::routers::http::vllm_pd_router: src/routers/http/vllm_pd_router.rs:1618: Chat: Selected prefill=http://prefill2:6700 [policy:power_of_two], decode=http://d-node2:63110 [policy:power_of_two]
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>
