### PR TITLE
Fix decode load tracking for streaming PD responses

### DIFF
--- a/src/routers/http/vllm_pd_router.rs
+++ b/src/routers/http/vllm_pd_router.rs
@@ -1559,35 +1559,14 @@ impl VllmPDRouter {
                 }
             }
 
-            if is_streaming {
-                let stream =
-                    LoadTrackedDecodeStream::new(decode_response.bytes_stream(), decode_worker);
-                let body = Body::from_stream(stream);
-                response_builder
-                    .body(body)
-                    .map_err(|e| PDRouterError::NetworkError {
-                        message: format!("Failed to build response from {}: {}", decode_url, e),
-                    })
-            } else {
-                let body = match decode_response.bytes().await {
-                    Ok(body) => body,
-                    Err(e) => {
-                        decode_worker.decrement_load();
-                        return Err(PDRouterError::NetworkError {
-                            message: format!(
-                                "Failed to read decode response from {}: {}",
-                                decode_url, e
-                            ),
-                        });
-                    }
-                };
-                decode_worker.decrement_load();
-                response_builder
-                    .body(Body::from(body))
-                    .map_err(|e| PDRouterError::NetworkError {
-                        message: format!("Failed to build response from {}: {}", decode_url, e),
-                    })
-            }
+            let stream =
+                LoadTrackedDecodeStream::new(decode_response.bytes_stream(), decode_worker);
+            let body = Body::from_stream(stream);
+            response_builder
+                .body(body)
+                .map_err(|e| PDRouterError::NetworkError {
+                    message: format!("Failed to build response from {}: {}", decode_url, e),
+                })
         }
     }
 

--- a/src/routers/http/vllm_pd_router.rs
+++ b/src/routers/http/vllm_pd_router.rs
@@ -18,9 +18,13 @@ use axum::{
     http::{HeaderMap, Method, StatusCode},
     response::{IntoResponse, Response},
 };
+use bytes::Bytes;
+use futures_util::Stream;
 use serde_json::{json, Value};
 use std::collections::HashMap;
+use std::pin::Pin;
 use std::sync::Arc;
+use std::task::{Context, Poll};
 use std::time::Instant;
 use tokio::sync::Mutex;
 use tracing::{debug, error, info, warn};
@@ -63,6 +67,47 @@ pub struct VllmPDRouter {
 /// Transfer ID prefix used by MoRI-IO to correlate prefill and decode legs.
 /// Must match `MoRIIOConstants.TRANSFER_PREFIX` in the vLLM Python connector.
 const MORIIO_TRANSFER_PREFIX: &str = "tx";
+
+struct LoadTrackedDecodeStream {
+    inner: Pin<Box<dyn Stream<Item = Result<Bytes, reqwest::Error>> + Send>>,
+    worker: Option<Arc<dyn Worker>>,
+}
+
+impl LoadTrackedDecodeStream {
+    fn new(
+        stream: impl Stream<Item = Result<Bytes, reqwest::Error>> + Send + 'static,
+        worker: Arc<dyn Worker>,
+    ) -> Self {
+        Self {
+            inner: Box::pin(stream),
+            worker: Some(worker),
+        }
+    }
+
+    fn decrement_load_once(&mut self) {
+        if let Some(worker) = self.worker.take() {
+            worker.decrement_load();
+        }
+    }
+}
+
+impl Stream for LoadTrackedDecodeStream {
+    type Item = Result<Bytes, reqwest::Error>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let poll = self.inner.as_mut().poll_next(cx);
+        if matches!(poll, Poll::Ready(None)) {
+            self.decrement_load_once();
+        }
+        poll
+    }
+}
+
+impl Drop for LoadTrackedDecodeStream {
+    fn drop(&mut self) {
+        self.decrement_load_once();
+    }
+}
 
 /// Strip the DP-rank suffix from a worker's HTTP address and return the base address
 /// plus the parsed rank. Returns `(original, None)` when DP is disabled.
@@ -1417,11 +1462,8 @@ impl VllmPDRouter {
             }
         };
 
-        // Stop profiling on decode server after response received
+        // Stop profiling on decode server after response headers are received.
         self.stop_profiling(&decode_base_url).await;
-
-        // Decode phase complete: decrement decode load
-        decode_worker.decrement_load();
 
         let status = decode_response.status();
         let headers = decode_response.headers().clone();
@@ -1455,17 +1497,20 @@ impl VllmPDRouter {
         if needs_logprobs && !is_streaming {
             debug!("Logprobs requested and non-streaming - merging prefill and decode logprobs");
 
-            // Read decode response body
-            let decode_body =
-                decode_response
-                    .bytes()
-                    .await
-                    .map_err(|e| PDRouterError::NetworkError {
+            // Read the full decode response before releasing decode load.
+            let decode_body = match decode_response.bytes().await {
+                Ok(body) => body,
+                Err(e) => {
+                    decode_worker.decrement_load();
+                    return Err(PDRouterError::NetworkError {
                         message: format!(
                             "Failed to read decode response from {}: {}",
                             decode_url, e
                         ),
-                    })?;
+                    });
+                }
+            };
+            decode_worker.decrement_load();
 
             // Parse decode response as JSON
             let mut decode_json: Value =
@@ -1501,7 +1546,7 @@ impl VllmPDRouter {
                 }
             })
         } else {
-            // No logprobs merging needed - return decode response as-is (streaming or no logprobs)
+            // No logprobs merging needed.
             debug!(
                 "No logprobs merging needed (streaming={}, needs_logprobs={})",
                 is_streaming, needs_logprobs
@@ -1514,12 +1559,35 @@ impl VllmPDRouter {
                 }
             }
 
-            let body = Body::from_stream(decode_response.bytes_stream());
-            response_builder
-                .body(body)
-                .map_err(|e| PDRouterError::NetworkError {
-                    message: format!("Failed to build response from {}: {}", decode_url, e),
-                })
+            if is_streaming {
+                let stream =
+                    LoadTrackedDecodeStream::new(decode_response.bytes_stream(), decode_worker);
+                let body = Body::from_stream(stream);
+                response_builder
+                    .body(body)
+                    .map_err(|e| PDRouterError::NetworkError {
+                        message: format!("Failed to build response from {}: {}", decode_url, e),
+                    })
+            } else {
+                let body = match decode_response.bytes().await {
+                    Ok(body) => body,
+                    Err(e) => {
+                        decode_worker.decrement_load();
+                        return Err(PDRouterError::NetworkError {
+                            message: format!(
+                                "Failed to read decode response from {}: {}",
+                                decode_url, e
+                            ),
+                        });
+                    }
+                };
+                decode_worker.decrement_load();
+                response_builder
+                    .body(Body::from(body))
+                    .map_err(|e| PDRouterError::NetworkError {
+                        message: format!("Failed to build response from {}: {}", decode_url, e),
+                    })
+            }
         }
     }
 
@@ -2329,6 +2397,8 @@ impl WorkerManagement for VllmPDRouter {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bytes::Bytes;
+    use futures_util::StreamExt;
     use serde_json::json;
 
     // --- OpenAI-style endpoint tests (chat/completions, completions) ---
@@ -2510,6 +2580,45 @@ mod tests {
         // Verify the KvConnector::Nixl variant exists and is the default.
         let connector = KvConnector::default();
         assert_eq!(connector, KvConnector::Nixl);
+    }
+
+    #[tokio::test]
+    async fn test_load_tracked_decode_stream_decrements_after_eof() {
+        let worker: Arc<dyn Worker> = Arc::new(BasicWorker::new(
+            "http://decode".to_string(),
+            WorkerType::Decode,
+        ));
+        worker.increment_load();
+
+        let stream = futures_util::stream::iter(vec![
+            Ok::<Bytes, reqwest::Error>(Bytes::from_static(b"data: first\n\n")),
+            Ok::<Bytes, reqwest::Error>(Bytes::from_static(b"data: [DONE]\n\n")),
+        ]);
+        let mut stream = LoadTrackedDecodeStream::new(stream, worker.clone());
+
+        assert_eq!(worker.load(), 1);
+        assert!(stream.next().await.is_some());
+        assert_eq!(worker.load(), 1);
+        assert!(stream.next().await.is_some());
+        assert_eq!(worker.load(), 1);
+        assert!(stream.next().await.is_none());
+        assert_eq!(worker.load(), 0);
+    }
+
+    #[test]
+    fn test_load_tracked_decode_stream_decrements_on_drop() {
+        let worker: Arc<dyn Worker> = Arc::new(BasicWorker::new(
+            "http://decode".to_string(),
+            WorkerType::Decode,
+        ));
+        worker.increment_load();
+
+        let stream = futures_util::stream::pending::<Result<Bytes, reqwest::Error>>();
+        let stream = LoadTrackedDecodeStream::new(stream, worker.clone());
+
+        assert_eq!(worker.load(), 1);
+        drop(stream);
+        assert_eq!(worker.load(), 0);
     }
 
     // --- MoRI-IO WRITE mode parameter tests ---


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Fix decode worker load accounting for vLLM PD streaming responses.

Before this change, `process_vllm_two_stage_request` decremented decode load immediately after receiving decode response headers. For streaming responses, the decode backend continues generating and forwarding tokens after headers are returned, so decode load was released too early. In cache-aware routing, this made decode workers appear idle even while they still had active running requests, preventing the load-balance policy from detecting imbalance and redistributing traffic.

This PR keeps decode load active until the decode response body is actually finished or dropped without buffering pass-through decode responses:

- Wrap pass-through decode bodies in `LoadTrackedDecodeStream` for both streaming and non-streaming requests that do not need logprobs merging.
- Decrement decode load once on upstream stream EOF.
- Decrement decode load on body drop, covering client disconnects and early response disposal.
- Keep full-body buffering only for non-streaming logprobs merging, where the JSON body must be modified before returning it.
- Add focused tests for EOF and drop behavior.

## Test Plan

1. Start the router in vLLM PD disaggregation mode with cache-aware routing:

```bash
vllm-router \
  --vllm-pd-disaggregation \
  --host 0.0.0.0 \
  --port 29100 \
  --policy cache_aware \
  --cache-threshold 0.5 \
  --balance-abs-threshold 32 \
  --balance-rel-threshold 1.1 \
  --intra-node-data-parallel-size 4 \
  --prefill http://0.0.0.0:18000 \
  --decode http://0.0.0.0:28000 \
  --log-level debug
```

2. Send streaming requests through the router and compare cache-aware load-balance logs plus the running-requests dashboard before and after the change.

3. Run focused unit and compile checks in Docker because the local host does not have Cargo installed:

```bash
cargo fmt --check
cargo test test_load_tracked_decode_stream --lib
cargo check --lib --bin vllm-router
```

## Test Result

Automated validation passed in Docker with `--network=host`:

```text
cargo fmt --check
passed

cargo test test_load_tracked_decode_stream --lib
2 passed; 0 failed

cargo check --lib --bin vllm-router
Finished `dev` profile
```

- Before the fix, decode load stayed at `max_load=0, min_load=0` in cache-aware logs even while the scheduler dashboard showed running decode requests concentrated on one worker. Because the recorded decode load stayed at zero, the load-balance policy saw `is_unbalanced=false` and did not trigger redistribution.

<img width="1550" height="475" alt="image" src="https://github.com/user-attachments/assets/b9feb93c-f067-45a1-b759-dabfecfbe19e" />
<img width="733" height="372" alt="image" src="https://github.com/user-attachments/assets/f2fff790-bf0e-4172-967b-1470cb1b8500" />

- After the fix, decode load was recorded during streaming. Cache-aware logs showed decode imbalance such as `max_load=39, min_load=2, is_unbalanced=true`, and the running-requests dashboard showed traffic spread across decode workers. The load-balance policy could trigger normally.

<img width="1549" height="556" alt="image" src="https://github.com/user-attachments/assets/7b00f0cd-8345-4c29-8b9f-6167ffda2bb8" />
<img width="726" height="356" alt="image" src="https://github.com/user-attachments/assets/6c5b14c6-ec27-4251-ac29-217f18a6c18a" />

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results.

</details>