### PR TITLE
fix(power_of_two): combine cached load with local counter to avoid thundering herd

### DIFF
--- a/src/policies/power_of_two.rs
+++ b/src/policies/power_of_two.rs
@@ -26,15 +26,19 @@ impl PowerOfTwoPolicy {
     }
 
     fn get_worker_load(&self, worker: &dyn Worker) -> isize {
-        // First check cached loads (from external monitoring)
+        let local = worker.load() as isize;
+
+        // Combine cached load (external monitoring, e.g. vLLM /load endpoint)
+        // with local counter (in-flight requests tracked by router).
+        // This avoids thundering herd when cached loads go stale between
+        // 5-second polling intervals.
         if let Ok(loads) = self.cached_loads.read() {
-            if let Some(&load) = loads.get(worker.url()) {
-                return load;
+            if let Some(&cached) = loads.get(worker.url()) {
+                return cached + local;
             }
         }
 
-        // Fall back to local load counter
-        worker.load() as isize
+        local
     }
 }
 
@@ -184,8 +188,75 @@ mod tests {
             }
         }
 
-        // Worker2 should be selected significantly more often
-        assert!(w2_selected > 35); // Should win most of the time
+        // With only 2 workers, power-of-two always picks the same pair,
+        // so the less-loaded one wins every time
+        assert_eq!(w2_selected, 50);
+    }
+
+    /// Verify that cached_load and local_counter are combined:
+    /// When two workers have equal cached_load, local_counter should break the tie.
+    /// This prevents thundering herd when cached_load goes stale between polling intervals.
+    #[test]
+    fn test_power_of_two_combines_cached_and_local_load() {
+        let policy = PowerOfTwoPolicy::new();
+        let worker1 = BasicWorker::new("http://w1:8000".to_string(), WorkerType::Regular);
+        let worker2 = BasicWorker::new("http://w2:8000".to_string(), WorkerType::Regular);
+
+        // Set equal cached_loads, but worker1 has higher local counter
+        let mut loads = HashMap::new();
+        loads.insert("http://w1:8000".to_string(), 50);
+        loads.insert("http://w2:8000".to_string(), 50);
+        policy.update_loads(&loads);
+
+        // Increment worker1's local counter
+        for _ in 0..5 {
+            worker1.increment_load();
+        }
+        // worker2 local counter remains 0
+
+        // worker1 total load = cached(50) + local(5) = 55
+        // worker2 total load = cached(50) + local(0) = 50
+        // So worker2 should be selected more often
+        let workers: Vec<Arc<dyn Worker>> = vec![Arc::new(worker1), Arc::new(worker2)];
+
+        let mut w2_selected = 0;
+        for _ in 0..50 {
+            if let Some(idx) = policy.select_worker(&workers, None) {
+                if idx == 1 {
+                    w2_selected += 1;
+                }
+            }
+        }
+
+        // With only 2 workers, the less-loaded one is always selected
+        assert_eq!(w2_selected, 50);
+    }
+
+    /// Verify that without cached_load, only local_counter is used
+    #[test]
+    fn test_power_of_two_without_cached_loads_uses_local() {
+        let policy = PowerOfTwoPolicy::new();
+        let worker1 = BasicWorker::new("http://w1:8000".to_string(), WorkerType::Regular);
+        let worker2 = BasicWorker::new("http://w2:8000".to_string(), WorkerType::Regular);
+
+        // No cached_load set, rely only on local counter
+        for _ in 0..10 {
+            worker1.increment_load();
+        }
+
+        let workers: Vec<Arc<dyn Worker>> = vec![Arc::new(worker1), Arc::new(worker2)];
+
+        let mut w2_selected = 0;
+        for _ in 0..50 {
+            if let Some(idx) = policy.select_worker(&workers, None) {
+                if idx == 1 {
+                    w2_selected += 1;
+                }
+            }
+        }
+
+        // With only 2 workers, the less-loaded one is always selected
+        assert_eq!(w2_selected, 50);
     }
 
     #[test]


### PR DESCRIPTION
to fix #177 

fix(power_of_two): combine cached load with local counter to avoid thundering herd

## Purpose

Fix thundering herd in `PowerOfTwoPolicy` when external load monitoring is enabled.

`get_worker_load()` was returning **either** `cached_load` **or** `local_counter`, never both. When the router polls the vLLM `/load` endpoint every ~5s, all requests within a polling window see the same stale cached values, causing them to pile onto whichever instance reported lower load last cycle.

**Before (bug):** With 2 prefill instances where P0 has cached_load=0 and P1 has cached_load=1, 8 concurrent requests all see the same stale values → all 8 routed to P0.

**After (fix):** `get_worker_load()` returns `cached_load + local_counter`. Each dispatched request increments the local counter, so the next request sees the updated total and distributes evenly.

## Test Plan

Send 8 concurrent requests to the router with `--prefill-policy power_of_two` against 2 prefill instances, observe whether requests are evenly distributed across prefill instances.

Test command:
```bash
printf '%s\n' {1..8} | xargs -P 8 -I {} curl -s -X POST \
  "http://<ROUTER_HOST>:<ROUTER_PORT>/v1/chat/completions" \
  -H "authorization: Bearer $OPENAI_API_KEY" \
  -H "Content-Type: application/json; charset=UTF-8" \
  -d @req.json
```

Deployment: 2 prefill instances + 4 decode instances, vLLM with `--enable-server-load-tracking`.

## Test Result

### Before fix

All concurrent requests routed to the same prefill instance (the one with lower cached load at the last 5-second poll). Typical pattern:

```
Chat: Selected prefill=http://<P0_HOST>:<P_PORT>   ← all 8 requests
Chat: Selected prefill=http://<P0_HOST>:<P_PORT>
Chat: Selected prefill=http://<P0_HOST>:<P_PORT>
Chat: Selected prefill=http://<P0_HOST>:<P_PORT>
Chat: Selected prefill=http://<P0_HOST>:<P_PORT>
Chat: Selected prefill=http://<P0_HOST>:<P_PORT>
Chat: Selected prefill=http://<P0_HOST>:<P_PORT>
Chat: Selected prefill=http://<P0_HOST>:<P_PORT>
```

Distribution: **P0: 8, P1: 0**

### After fix

Requests evenly distributed across both prefill instances:

```
Chat: Selected prefill=http://<P0_HOST>:<P_PORT> [policy:power_of_two], decode=http://<D0_HOST>:<D_PORT1> [policy:power_of_two]
Chat: Selected prefill=http://<P1_HOST>:<P_PORT> [policy:power_of_two], decode=http://<D0_HOST>:<D_PORT0> [policy:power_of_two]
Chat: Selected prefill=http://<P1_HOST>:<P_PORT> [policy:power_of_two], decode=http://<D0_HOST>:<D_PORT0> [policy:power_of_two]
Chat: Selected prefill=http://<P0_HOST>:<P_PORT> [policy:power_of_two], decode=http://<D1_HOST>:<D_PORT0> [policy:power_of_two]
Chat: Selected prefill=http://<P1_HOST>:<P_PORT> [policy:power_of_two], decode=http://<D0_HOST>:<D_PORT0> [policy:power_of_two]
Chat: Selected prefill=http://<P0_HOST>:<P_PORT> [policy:power_of_two], decode=http://<D1_HOST>:<D_PORT0> [policy:power_of_two]
Chat: Selected prefill=http://<P1_HOST>:<P_PORT> [policy:power_of_two], decode=http://<D0_HOST>:<D_PORT0> [policy:power_of_two]
Chat: Selected prefill=http://<P0_HOST>:<P_PORT> [policy:power_of_two], decode=http://<D1_HOST>:<D_PORT0> [policy:power_of_two]
```

Distribution: **P0: 4, P1: 4** ✅

---

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results

</details>