### PR TITLE
feat(router): register /inference/v1/generate as a typed route

### DIFF
--- a/src/protocols/spec.rs
+++ b/src/protocols/spec.rs
@@ -1971,6 +1971,42 @@ impl GenerationRequest for GenerateRequest {
 }
 
 // ==================================================================
+// =   VLLM SPEC - DISAGG /inference/v1/generate API              =
+// ==================================================================
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct InferenceGenerateRequest {
+    pub token_ids: Vec<i32>,
+
+    #[serde(default)]
+    pub stream: bool,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+
+    #[serde(flatten)]
+    pub other: serde_json::Map<String, serde_json::Value>,
+}
+
+impl GenerationRequest for InferenceGenerateRequest {
+    fn is_stream(&self) -> bool {
+        self.stream
+    }
+
+    fn get_model(&self) -> Option<&str> {
+        self.model.as_deref()
+    }
+
+    fn extract_text_for_routing(&self) -> String {
+        self.token_ids
+            .iter()
+            .map(|id| id.to_string())
+            .collect::<Vec<String>>()
+            .join(" ")
+    }
+}
+
+// ==================================================================
 // =            VLLM SPEC - RERANK API                            =
 // ==================================================================
 
@@ -2371,6 +2407,80 @@ pub enum LoRAPath {
 mod tests {
     use super::*;
     use serde_json;
+
+    // ==================================================================
+    // =  InferenceGenerateRequest (/inference/v1/generate) TESTS       =
+    // ==================================================================
+
+    #[test]
+    fn test_inference_generate_routing_key_from_token_ids() {
+        let body = serde_json::json!({
+            "token_ids": [151644, 8948, 198, 2610],
+            "sampling_params": {"max_tokens": 4096, "seed": 42, "logprobs": 1}
+        });
+        let req: InferenceGenerateRequest = serde_json::from_value(body).unwrap();
+        assert_eq!(req.extract_text_for_routing(), "151644 8948 198 2610");
+    }
+
+    #[test]
+    fn test_inference_generate_lossless_passthrough() {
+        let body = serde_json::json!({
+            "token_ids": [1, 2, 3],
+            "model": "qwen3-30b",
+            "sampling_params": {
+                "max_tokens": 4096,
+                "seed": 42,
+                "logprobs": 1,
+                "temperature": 1.0
+            }
+        });
+        let req: InferenceGenerateRequest = serde_json::from_value(body).unwrap();
+        let forwarded: serde_json::Value = serde_json::to_value(&req).unwrap();
+
+        assert_eq!(forwarded["token_ids"], serde_json::json!([1, 2, 3]));
+        assert_eq!(forwarded["sampling_params"]["max_tokens"], 4096);
+        assert_eq!(forwarded["sampling_params"]["seed"], 42);
+        assert_eq!(forwarded["sampling_params"]["logprobs"], 1);
+        assert_eq!(forwarded["sampling_params"]["temperature"], 1.0);
+        assert_eq!(forwarded["model"], "qwen3-30b");
+    }
+
+    #[test]
+    fn test_inference_generate_same_tokens_same_key_regardless_of_sampling() {
+        let make = |seed: i64| -> InferenceGenerateRequest {
+            serde_json::from_value(serde_json::json!({
+                "token_ids": [151644, 8948, 198],
+                "sampling_params": {"seed": seed}
+            }))
+            .unwrap()
+        };
+        assert_eq!(
+            make(1).extract_text_for_routing(),
+            make(2).extract_text_for_routing()
+        );
+    }
+
+    #[test]
+    fn test_inference_generate_is_stream() {
+        let non_stream: InferenceGenerateRequest =
+            serde_json::from_value(serde_json::json!({"token_ids": [1]})).unwrap();
+        assert!(!non_stream.is_stream());
+
+        let stream: InferenceGenerateRequest =
+            serde_json::from_value(serde_json::json!({"token_ids": [1], "stream": true})).unwrap();
+        assert!(stream.is_stream());
+    }
+
+    #[test]
+    fn test_inference_generate_get_model() {
+        let with_model: InferenceGenerateRequest =
+            serde_json::from_value(serde_json::json!({"token_ids": [1], "model": "m"})).unwrap();
+        assert_eq!(with_model.get_model(), Some("m"));
+
+        let without: InferenceGenerateRequest =
+            serde_json::from_value(serde_json::json!({"token_ids": [1]})).unwrap();
+        assert_eq!(without.get_model(), None);
+    }
 
     // ==================================================================
     // =            RERANK REQUEST TESTS                                =

--- a/src/routers/http/openai_router.rs
+++ b/src/routers/http/openai_router.rs
@@ -4,7 +4,8 @@ use crate::config::CircuitBreakerConfig;
 use crate::core::{CircuitBreaker, CircuitBreakerConfig as CoreCircuitBreakerConfig};
 use crate::otel_http::{self, ClientRequestOptions};
 use crate::protocols::spec::{
-    ChatCompletionRequest, CompletionRequest, GenerateRequest, RerankRequest,
+    ChatCompletionRequest, CompletionRequest, GenerateRequest, InferenceGenerateRequest,
+    RerankRequest,
 };
 use async_trait::async_trait;
 use axum::{
@@ -202,6 +203,19 @@ impl super::super::RouterTrait for OpenAIRouter {
         _model_id: Option<&str>,
     ) -> Response {
         // Generate endpoint is VLLM-specific, not supported for OpenAI backend
+        (
+            StatusCode::NOT_IMPLEMENTED,
+            "Generate endpoint not supported for OpenAI backend",
+        )
+            .into_response()
+    }
+
+    async fn route_inference_generate(
+        &self,
+        _headers: Option<&HeaderMap>,
+        _body: &InferenceGenerateRequest,
+        _model_id: Option<&str>,
+    ) -> Response {
         (
             StatusCode::NOT_IMPLEMENTED,
             "Generate endpoint not supported for OpenAI backend",

--- a/src/routers/http/router.rs
+++ b/src/routers/http/router.rs
@@ -8,7 +8,7 @@ use crate::otel_http::{self, ClientRequestOptions};
 use crate::policies::{LoadBalancingPolicy, PolicyRegistry};
 use crate::protocols::spec::{
     ChatCompletionRequest, CompletionRequest, EmbeddingRequest, GenerateRequest, GenerationRequest,
-    RerankRequest, RerankResponse, RerankResult, ResponsesRequest,
+    InferenceGenerateRequest, RerankRequest, RerankResponse, RerankResult, ResponsesRequest,
 };
 use crate::routers::header_utils;
 use crate::routers::http::dp_utils;
@@ -1445,6 +1445,16 @@ impl RouterTrait for Router {
         model_id: Option<&str>,
     ) -> Response {
         self.route_typed_request(headers, body, "/generate", model_id)
+            .await
+    }
+
+    async fn route_inference_generate(
+        &self,
+        headers: Option<&HeaderMap>,
+        body: &InferenceGenerateRequest,
+        model_id: Option<&str>,
+    ) -> Response {
+        self.route_typed_request(headers, body, "/inference/v1/generate", model_id)
             .await
     }
 

--- a/src/routers/http/vllm_pd_router.rs
+++ b/src/routers/http/vllm_pd_router.rs
@@ -1747,6 +1747,31 @@ impl RouterTrait for VllmPDRouter {
             .await
     }
 
+    async fn route_inference_generate(
+        &self,
+        headers: Option<&HeaderMap>,
+        body: &crate::protocols::spec::InferenceGenerateRequest,
+        _model_id: Option<&str>,
+    ) -> Response {
+        let request_json = match serde_json::to_value(body) {
+            Ok(json) => json,
+            Err(e) => {
+                return (
+                    axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("Serialization error: {}", e),
+                )
+                    .into_response()
+            }
+        };
+        self.route_transparent(
+            headers,
+            "/inference/v1/generate",
+            &Method::POST,
+            request_json,
+        )
+        .await
+    }
+
     // Override OpenAI-compatible routes for vLLM two-stage processing
     async fn route_chat(
         &self,

--- a/src/routers/mod.rs
+++ b/src/routers/mod.rs
@@ -10,8 +10,8 @@ use axum::{
 use std::fmt::Debug;
 
 use crate::protocols::spec::{
-    ChatCompletionRequest, CompletionRequest, EmbeddingRequest, GenerateRequest, RerankRequest,
-    ResponsesRequest,
+    ChatCompletionRequest, CompletionRequest, EmbeddingRequest, GenerateRequest,
+    InferenceGenerateRequest, RerankRequest, ResponsesRequest,
 };
 
 pub mod factory;
@@ -68,6 +68,14 @@ pub trait RouterTrait: Send + Sync + Debug + WorkerManagement {
         &self,
         headers: Option<&HeaderMap>,
         body: &GenerateRequest,
+        model_id: Option<&str>,
+    ) -> Response;
+
+    /// Route a generate request to vLLM's disaggregated `/inference/v1/generate`.
+    async fn route_inference_generate(
+        &self,
+        headers: Option<&HeaderMap>,
+        body: &InferenceGenerateRequest,
         model_id: Option<&str>,
     ) -> Response;
 

--- a/src/routers/router_manager.rs
+++ b/src/routers/router_manager.rs
@@ -7,8 +7,8 @@
 use crate::config::RouterConfig;
 use crate::core::{CircuitBreakerConfig, Worker, WorkerFactory, WorkerRegistry, WorkerType};
 use crate::protocols::spec::{
-    ChatCompletionRequest, CompletionRequest, EmbeddingRequest, GenerateRequest, RerankRequest,
-    ResponsesRequest,
+    ChatCompletionRequest, CompletionRequest, EmbeddingRequest, GenerateRequest,
+    InferenceGenerateRequest, RerankRequest, ResponsesRequest,
 };
 use crate::protocols::worker_spec::{
     ServerInfo, WorkerApiResponse, WorkerConfigRequest, WorkerErrorResponse, WorkerInfo,
@@ -564,6 +564,25 @@ impl RouterTrait for RouterManager {
             router.route_generate(headers, body, None).await
         } else {
             // Return 404 when no router is available for the request
+            (
+                StatusCode::NOT_FOUND,
+                "No router available for this request",
+            )
+                .into_response()
+        }
+    }
+
+    async fn route_inference_generate(
+        &self,
+        headers: Option<&HeaderMap>,
+        body: &InferenceGenerateRequest,
+        _model_id: Option<&str>,
+    ) -> Response {
+        let router = self.select_router_for_request(headers, None);
+
+        if let Some(router) = router {
+            router.route_inference_generate(headers, body, None).await
+        } else {
             (
                 StatusCode::NOT_FOUND,
                 "No router available for this request",

--- a/src/server.rs
+++ b/src/server.rs
@@ -9,7 +9,7 @@ use crate::{
     protocols::{
         spec::{
             ChatCompletionRequest, CompletionRequest, EmbeddingRequest, GenerateRequest,
-            RerankRequest, V1RerankReqInput,
+            InferenceGenerateRequest, RerankRequest, V1RerankReqInput,
         },
         worker_spec::{WorkerApiResponse, WorkerConfigRequest, WorkerErrorResponse},
     },
@@ -224,6 +224,21 @@ async fn generate(
     state
         .router
         .route_generate(Some(&headers), &body, None)
+        .await
+}
+
+async fn inference_generate(
+    State(state): State<Arc<AppState>>,
+    headers: http::HeaderMap,
+    Json(body): Json<InferenceGenerateRequest>,
+) -> Response {
+    if let Err(response) = authorize_request(&state, &headers).await {
+        return response;
+    }
+
+    state
+        .router
+        .route_inference_generate(Some(&headers), &body, None)
         .await
 }
 
@@ -705,6 +720,7 @@ pub fn build_app_with_request_tracing(
     // Create routes
     let protected_routes = Router::new()
         .route("/generate", post(generate))
+        .route("/inference/v1/generate", post(inference_generate))
         .route("/v1/chat/completions", post(v1_chat_completions))
         .route("/v1/completions", post(v1_completions))
         .route("/rerank", post(rerank))


### PR DESCRIPTION
Fixes #179.

## Problem

vLLM's disaggregated engine serves generation at `/inference/v1/generate` (the `/inference/v1/` prefix is vendor-private). The router has no first-class typed route for it, so it falls through to the **transparent proxy**. On that path `cache_aware` never tracks worker load, so it degrades to single-worker prefix affinity — one engine serves every shared-prefix request (and can OOM its KV cache) while the others idle.

## Fix

Register `/inference/v1/generate` as a **typed route**, so it reuses `route_typed_request`'s `cache_aware` routing + worker load tracking + retry + circuit breaker + metrics — identical to `/generate`.

The typed path forwards by re-serializing the request struct, so a new **lossless** `InferenceGenerateRequest` models only what the router reads — `token_ids` (the cache_aware routing key), `stream`, and `model` (for `get_model`, consistent with the other typed endpoints) — and passes everything else through with `#[serde(flatten)]`. The nested `sampling_params` is forwarded untouched, so `seed` / `max_tokens` / `logprobs` reach the engine unchanged (the router never interprets sampling params; mirroring vLLM's ~100-field `SamplingParams` would be pure drift risk). `GenerateRequest` and `/generate` are untouched.

## Test

Unit tests for `InferenceGenerateRequest`: routing key = `token_ids` joined as decimal string; **lossless round-trip** (`sampling_params.{max_tokens,seed,logprobs,temperature}` + `model` survive deserialize → serialize); same `token_ids` / different `seed` → identical routing key; `is_stream` / `get_model`.

> Supersedes the earlier transparent-proxy load-tracking approach previously on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
