### PR TITLE
Expose --queue-size, --queue-timeout-secs, and --rate-limit-tokens-per-second CLI flags

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -251,6 +251,21 @@ struct CliArgs {
     #[arg(long, default_value_t = 32768)]
     max_concurrent_requests: usize,
 
+    /// Queue size for pending requests when the max-concurrent limit is
+    /// reached (0 = no queue: shed immediately with HTTP 429)
+    #[arg(long, default_value_t = 100)]
+    queue_size: usize,
+
+    /// Maximum time in seconds a request may wait in the concurrency queue
+    /// before timing out
+    #[arg(long, default_value_t = 60)]
+    queue_timeout_secs: u64,
+
+    /// Token-bucket refill rate in tokens per second. Defaults to
+    /// --max-concurrent-requests when unset.
+    #[arg(long)]
+    rate_limit_tokens_per_second: Option<usize>,
+
     /// CORS allowed origins
     #[arg(long, num_args = 0..)]
     cors_allowed_origins: Vec<String>,
@@ -523,8 +538,8 @@ impl CliArgs {
                 Some(self.request_id_headers.clone())
             },
             max_concurrent_requests: self.max_concurrent_requests,
-            queue_size: 100,        // Default queue size
-            queue_timeout_secs: 60, // Default timeout
+            queue_size: self.queue_size,
+            queue_timeout_secs: self.queue_timeout_secs,
             cors_allowed_origins: self.cors_allowed_origins.clone(),
             retry: RetryConfig {
                 max_retries: self.retry_max_retries,
@@ -549,7 +564,7 @@ impl CliArgs {
                 endpoint: self.health_check_endpoint.clone(),
             },
             enable_igw: self.enable_igw,
-            rate_limit_tokens_per_second: None,
+            rate_limit_tokens_per_second: self.rate_limit_tokens_per_second,
             history_backend: match self.history_backend.as_str() {
                 "none" => HistoryBackend::None,
                 _ => HistoryBackend::Memory,


### PR DESCRIPTION
## Purpose

The standalone Rust `vllm-router` binary hardcodes three queue / rate-limiting
knobs in `CliArgs::to_router_config()` and exposes no CLI flags for them:

- `queue_size = 100`
- `queue_timeout_secs = 60`
- `rate_limit_tokens_per_second = None`

…even though `RouterConfig` already supports all three fields and the Python
launcher (`py_src/vllm_router/router_args.py`) already exposes them as
`--queue-size` / `--queue-timeout-secs` / `--rate-limit-tokens-per-second`.
This is a flag drift between the two entry points: configuration that works via
the Python launcher silently cannot be set when running the binary directly.

In particular, binary users cannot set `--queue-size 0`, which disables the
concurrency queue so the limiter sheds immediately with HTTP 429 (fail-fast)
instead of queuing up to 100 requests for up to 60s.

This PR adds the three flags to `CliArgs` and threads them through
`to_router_config()`. **Defaults are identical to the previously hardcoded
values (`100` / `60` / `None`), so behavior is unchanged unless a flag is
explicitly passed.** The new `--help` text mirrors the Python launcher's wording.

## Test Plan

Built and exercised the release binary with stable Rust (rustc 1.96.0):

- `cargo fmt --check`
- `cargo check`
- `cargo clippy --all-targets`
- `cargo build --release`
- `./target/release/vllm-router --help` lists the three new flags with defaults
- Boot the binary with `--queue-size 0` and confirm `RouterConfig::validate()`
  accepts it

## Test Result

- `cargo fmt --check`, `cargo check`, `cargo clippy --all-targets`, and
  `cargo build --release`: all clean.
- `--help` output:
  - `--queue-size <QUEUE_SIZE>` — `[default: 100]`
  - `--queue-timeout-secs <QUEUE_TIMEOUT_SECS>` — `[default: 60]`
  - `--rate-limit-tokens-per-second <RATE_LIMIT_TOKENS_PER_SECOND>` — falls back
    to `--max-concurrent-requests` when unset
- Booting with `--queue-size 0` logs `Configuration validated successfully` and
  proceeds past config validation (the limiter then runs queue-less, shedding
  with HTTP 429 at the concurrency limit).

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR — fix the binary/Python-launcher flag drift so the
  queue and rate-limit knobs are configurable from the binary.
- [x] The test plan — `cargo fmt/check/clippy/build --release` plus a `--help`
  and `--queue-size 0` boot check.
- [x] The test results — all checks clean; `--help` and `--queue-size 0` boot
  verified (see above).

</details>
