### PR TITLE
Support for NIXL push mode

### DIFF
--- a/src/routers/http/dp_utils.rs
+++ b/src/routers/http/dp_utils.rs
@@ -2,7 +2,71 @@
 // This module provides common functions for data-parallel aware routing
 // that can be reused across different router implementations.
 
-use tracing::info;
+use std::collections::HashSet;
+
+use tracing::{info, warn};
+
+/// Count the engines a vLLM server exposes on `/metrics`. It emits one series
+/// per engine it can address, the same set `X-data-parallel-rank` selects from.
+/// Hybrid load balancing labels them with global ranks, so count distinct
+/// labels rather than taking the maximum.
+fn count_engine_labels(metrics_body: &str) -> Option<usize> {
+    let engines: HashSet<&str> = metrics_body
+        .lines()
+        .filter(|line| line.starts_with("vllm:"))
+        .filter_map(|line| {
+            let (_, after_label) = line.split_once("engine=\"")?;
+            let (engine, _) = after_label.split_once('"')?;
+            Some(engine)
+        })
+        .collect();
+
+    (!engines.is_empty()).then_some(engines.len())
+}
+
+/// Number of engines a worker fronts, so prefill and decode can run different
+/// data-parallel sizes. Falls back to `fallback_dp_size` for workers exposing
+/// no vLLM metrics, e.g. under `--disable-log-stats`.
+pub async fn discover_dp_size(
+    client: &reqwest::Client,
+    worker_url: &str,
+    fallback_dp_size: usize,
+) -> usize {
+    let fallback_dp_size = fallback_dp_size.max(1);
+    let (base_url, _) = parse_worker_url(worker_url);
+    // /metrics sits outside vLLM's authenticated path prefixes.
+    let metrics_url = format!("{}/metrics", base_url.trim_end_matches('/'));
+
+    let body = match client.get(&metrics_url).send().await {
+        Ok(response) if response.status().is_success() => response.text().await.ok(),
+        Ok(response) => {
+            warn!(
+                "DP discovery for {} returned {}",
+                metrics_url,
+                response.status()
+            );
+            None
+        }
+        Err(error) => {
+            warn!("DP discovery for {} failed: {}", metrics_url, error);
+            None
+        }
+    };
+
+    match body.as_deref().and_then(count_engine_labels) {
+        Some(dp_size) => {
+            info!("Worker {} reports {} engine(s)", base_url, dp_size);
+            dp_size
+        }
+        None => {
+            info!(
+                "Worker {} reports no engine metrics; assuming {} engine(s)",
+                base_url, fallback_dp_size
+            );
+            fallback_dp_size
+        }
+    }
+}
 
 /// Given a list of worker URLs, expand them into DP-aware URLs
 /// with dp_rank as suffix (format: "http://host:port@rank")

--- a/src/routers/http/pd_router.rs
+++ b/src/routers/http/pd_router.rs
@@ -305,7 +305,12 @@ impl PdRouterBase {
             return Err(PDRouterError::WorkerAlreadyExists { url });
         }
 
-        info!("Added {} server {} as {} worker(s)", role, url, workers.len());
+        info!(
+            "Added {} server {} as {} worker(s)",
+            role,
+            url,
+            workers.len()
+        );
         for worker in workers {
             self.register_and_notify(worker);
         }

--- a/src/routers/http/pd_router.rs
+++ b/src/routers/http/pd_router.rs
@@ -3,8 +3,8 @@
 use super::dp_utils;
 use super::pd_types::PDRouterError;
 use crate::core::{
-    BasicWorker, CircuitBreakerConfig, DPAwareWorker, HealthConfig, Worker, WorkerFactory,
-    WorkerRegistry, WorkerType,
+    BasicWorker, CircuitBreakerConfig, DPAwareWorker, HealthConfig, Worker, WorkerRegistry,
+    WorkerType,
 };
 use crate::policies::{LoadBalancingPolicy, PolicyRegistry};
 use crate::routers::header_utils;
@@ -32,8 +32,45 @@ pub struct PdRouterBase {
     pub load_monitor_handle: Option<Arc<tokio::task::JoinHandle<()>>>,
     pub client: Client,
     pub circuit_breaker_config: CircuitBreakerConfig,
-    // Intra-node data parallel size for creating DPAwareWorker in add_*_server()
+    // Fallback DP size for servers that report no engine metrics
     pub dp_size: usize,
+}
+
+/// Build the workers backing one server URL, one per engine the server fronts.
+fn build_dp_workers(
+    url: &str,
+    dp_size: usize,
+    worker_type: WorkerType,
+    circuit_breaker_config: &CircuitBreakerConfig,
+    health_config: Option<&HealthConfig>,
+) -> Vec<Arc<dyn Worker>> {
+    let (base_url, pinned_rank) = dp_utils::parse_worker_url(url);
+
+    // DPAwareWorker strips the @rank suffix in endpoint_url(), preventing
+    // IPv6+DP URL corruption where HTTP clients read @N as userinfo (RFC 3986).
+    let dp_worker = |rank: usize| -> Arc<dyn Worker> {
+        let worker = DPAwareWorker::new(base_url.clone(), rank, dp_size, worker_type.clone())
+            .with_circuit_breaker_config(circuit_breaker_config.clone());
+        let worker = match health_config {
+            Some(config) => worker.with_health_config(config.clone()),
+            None => worker,
+        };
+        Arc::new(worker)
+    };
+
+    match pinned_rank {
+        Some(rank) => vec![dp_worker(rank)],
+        None if dp_size > 1 => (0..dp_size).map(dp_worker).collect(),
+        None => {
+            let worker = BasicWorker::new(url.to_string(), worker_type.clone())
+                .with_circuit_breaker_config(circuit_breaker_config.clone());
+            let worker = match health_config {
+                Some(config) => worker.with_health_config(config.clone()),
+                None => worker,
+            };
+            vec![Arc::new(worker) as Arc<dyn Worker>]
+        }
+    }
 }
 
 impl PdRouterBase {
@@ -235,125 +272,45 @@ impl PdRouterBase {
         url: String,
         bootstrap_port: Option<u16>,
     ) -> Result<String, PDRouterError> {
-        // Wait for the new server to be healthy
-        self.wait_for_server_health(&url).await?;
-
-        let worker_type = WorkerType::Prefill { bootstrap_port };
-
-        if self.dp_size > 1 {
-            let (_base_url, dp_rank) = dp_utils::parse_worker_url(&url);
-            if dp_rank.is_some() {
-                // URL already has @rank suffix (e.g., from direct URL mode).
-                // Create a single DPAwareWorker. DPAwareWorker strips the @rank
-                // suffix in endpoint_url(), preventing IPv6+DP URL corruption
-                // where HTTP clients interpret @N as a userinfo separator per RFC 3986.
-                if self.worker_registry.get_by_url(&url).is_some() {
-                    return Err(PDRouterError::WorkerAlreadyExists { url: url.clone() });
-                }
-                let (base_url, dp_rank) = dp_utils::parse_worker_url(&url);
-                let worker_arc: Arc<dyn Worker> = Arc::new(
-                    DPAwareWorker::new(base_url, dp_rank.unwrap_or(0), self.dp_size, worker_type)
-                        .with_circuit_breaker_config(self.circuit_breaker_config.clone()),
-                );
-                self.register_and_notify(worker_arc);
-                info!("Added prefill server: {}", url);
-            } else {
-                // Bare URL without @rank (e.g., from K8s service discovery).
-                // Expand into dp_size workers, one per DP rank, matching the
-                // expansion logic in router.rs::add_worker() and PdRouterBase::new().
-                // Without this, all traffic pins to rank 0 via unwrap_or(0),
-                // bypassing vLLM's hybrid load balancer.
-                let first_dp_url = format!("{}@0", url);
-                if self.worker_registry.get_by_url(&first_dp_url).is_some() {
-                    return Err(PDRouterError::WorkerAlreadyExists { url: url.clone() });
-                }
-                for rank in 0..self.dp_size {
-                    let dp_url = format!("{}@{}", url, rank);
-                    let worker_arc: Arc<dyn Worker> = Arc::new(
-                        DPAwareWorker::new(url.clone(), rank, self.dp_size, worker_type.clone())
-                            .with_circuit_breaker_config(self.circuit_breaker_config.clone()),
-                    );
-                    self.register_and_notify(worker_arc);
-                    info!("Added prefill server: {} (rank {})", dp_url, rank);
-                }
-                info!(
-                    "Expanded prefill server {} into {} DP-aware workers",
-                    url, self.dp_size
-                );
-            }
-        } else {
-            // dp_size == 1: no DP-aware routing, use BasicWorker
-            if self.worker_registry.get_by_url(&url).is_some() {
-                return Err(PDRouterError::WorkerAlreadyExists { url: url.clone() });
-            }
-            let worker_arc: Arc<dyn Worker> = Arc::from(WorkerFactory::create_prefill_with_config(
-                url.clone(),
-                bootstrap_port,
-                self.circuit_breaker_config.clone(),
-            ));
-            self.register_and_notify(worker_arc);
-            info!("Added prefill server: {}", url);
-        }
-
-        Ok(format!("Successfully added prefill server: {}", url))
+        self.add_server(url, "prefill", WorkerType::Prefill { bootstrap_port })
+            .await
     }
 
     pub async fn add_decode_server(&self, url: String) -> Result<String, PDRouterError> {
+        self.add_server(url, "decode", WorkerType::Decode).await
+    }
+
+    async fn add_server(
+        &self,
+        url: String,
+        role: &str,
+        worker_type: WorkerType,
+    ) -> Result<String, PDRouterError> {
         // Wait for the new server to be healthy
         self.wait_for_server_health(&url).await?;
 
-        if self.dp_size > 1 {
-            let (_base_url, dp_rank) = dp_utils::parse_worker_url(&url);
-            if dp_rank.is_some() {
-                // URL already has @rank suffix — single DPAwareWorker
-                if self.worker_registry.get_by_url(&url).is_some() {
-                    return Err(PDRouterError::WorkerAlreadyExists { url: url.clone() });
-                }
-                let (base_url, dp_rank) = dp_utils::parse_worker_url(&url);
-                let worker_arc: Arc<dyn Worker> = Arc::new(
-                    DPAwareWorker::new(
-                        base_url,
-                        dp_rank.unwrap_or(0),
-                        self.dp_size,
-                        WorkerType::Decode,
-                    )
-                    .with_circuit_breaker_config(self.circuit_breaker_config.clone()),
-                );
-                self.register_and_notify(worker_arc);
-                info!("Added decode server: {}", url);
-            } else {
-                // Bare URL — expand into dp_size workers (same as add_prefill_server)
-                let first_dp_url = format!("{}@0", url);
-                if self.worker_registry.get_by_url(&first_dp_url).is_some() {
-                    return Err(PDRouterError::WorkerAlreadyExists { url: url.clone() });
-                }
-                for rank in 0..self.dp_size {
-                    let dp_url = format!("{}@{}", url, rank);
-                    let worker_arc: Arc<dyn Worker> = Arc::new(
-                        DPAwareWorker::new(url.clone(), rank, self.dp_size, WorkerType::Decode)
-                            .with_circuit_breaker_config(self.circuit_breaker_config.clone()),
-                    );
-                    self.register_and_notify(worker_arc);
-                    info!("Added decode server: {} (rank {})", dp_url, rank);
-                }
-                info!(
-                    "Expanded decode server {} into {} DP-aware workers",
-                    url, self.dp_size
-                );
-            }
-        } else {
-            if self.worker_registry.get_by_url(&url).is_some() {
-                return Err(PDRouterError::WorkerAlreadyExists { url: url.clone() });
-            }
-            let worker_arc: Arc<dyn Worker> = Arc::from(WorkerFactory::create_decode_with_config(
-                url.clone(),
-                self.circuit_breaker_config.clone(),
-            ));
-            self.register_and_notify(worker_arc);
-            info!("Added decode server: {}", url);
+        let dp_size = dp_utils::discover_dp_size(&self.client, &url, self.dp_size).await;
+        let workers = build_dp_workers(
+            &url,
+            dp_size,
+            worker_type,
+            &self.circuit_breaker_config,
+            None,
+        );
+
+        if workers
+            .iter()
+            .any(|worker| self.worker_registry.get_by_url(worker.url()).is_some())
+        {
+            return Err(PDRouterError::WorkerAlreadyExists { url });
         }
 
-        Ok(format!("Successfully added decode server: {}", url))
+        info!("Added {} server {} as {} worker(s)", role, url, workers.len());
+        for worker in workers {
+            self.register_and_notify(worker);
+        }
+
+        Ok(format!("Successfully added {} server: {}", role, url))
     }
 
     /// Register a worker and notify the policy registry.
@@ -373,10 +330,8 @@ impl PdRouterBase {
     }
 
     pub async fn remove_prefill_server(&self, url: &str) -> Result<String, PDRouterError> {
-        if self.dp_size > 1 && !url.contains('@') {
-            // Bare URL: remove all DP-expanded workers by prefix match,
-            // mirroring the expansion in add_prefill_server and the
-            // prefix-match removal in router.rs::remove_worker().
+        // A bare URL that is not registered as-is was expanded per DP rank.
+        if !url.contains('@') && self.worker_registry.get_by_url(url).is_none() {
             return self.remove_dp_expanded_workers(url, "prefill");
         }
 
@@ -417,7 +372,7 @@ impl PdRouterBase {
     }
 
     pub async fn remove_decode_server(&self, url: &str) -> Result<String, PDRouterError> {
-        if self.dp_size > 1 && !url.contains('@') {
+        if !url.contains('@') && self.worker_registry.get_by_url(url).is_none() {
             return self.remove_dp_expanded_workers(url, "decode");
         }
 
@@ -516,68 +471,21 @@ impl PdRouterBase {
             window_duration: Duration::from_secs(circuit_breaker_config.window_duration_secs),
         };
 
-        // Automatically expand to DP-aware format when intra_node_data_parallel_size > 1
-        // This creates multiple worker URLs with @rank suffixes (e.g., "http://host:8000@0", "@1", etc.)
-        // without querying the workers. The router will add X-data-parallel-rank headers to route to specific ranks.
-        let (expanded_prefill_urls, expanded_decode_urls) =
-            if ctx.router_config.intra_node_data_parallel_size > 1 {
-                info!(
-                "DP-aware mode enabled (intra_node_data_parallel_size={}), expanding worker URLs",
-                ctx.router_config.intra_node_data_parallel_size
-            );
-
-                // Extract base URLs from prefill_urls (url, port) tuples
-                let prefill_base_urls: Vec<String> =
-                    prefill_urls.iter().map(|(url, _)| url.clone()).collect();
-
-                // Expand prefill URLs with DP ranks (0..intra_node_data_parallel_size-1)
-                let expanded_prefill = super::dp_utils::get_dp_aware_workers(
-                    &prefill_base_urls,
-                    &ctx.router_config.api_key,
-                    ctx.router_config.intra_node_data_parallel_size,
+        // Workers must be up before they can report their engine count.
+        let prefill_base_urls: Vec<String> =
+            prefill_urls.iter().map(|(url, _)| url.clone()).collect();
+        for urls in [&prefill_base_urls, &decode_urls] {
+            if !urls.is_empty() {
+                crate::routers::http::router::Router::wait_for_healthy_workers(
+                    urls,
+                    ctx.router_config.worker_startup_timeout_secs,
+                    ctx.router_config.worker_startup_check_interval_secs,
                 )
-                .await
-                .map_err(|e| format!("Failed to expand prefill workers: {}", e))?;
+                .await?;
+            }
+        }
 
-                // Expand decode URLs with DP ranks (0..intra_node_data_parallel_size-1)
-                let expanded_decode = super::dp_utils::get_dp_aware_workers(
-                    &decode_urls,
-                    &ctx.router_config.api_key,
-                    ctx.router_config.intra_node_data_parallel_size,
-                )
-                .await
-                .map_err(|e| format!("Failed to expand decode workers: {}", e))?;
-
-                info!(
-                    "Expanded {} prefill URLs to {} DP-aware URLs",
-                    prefill_base_urls.len(),
-                    expanded_prefill.len()
-                );
-                info!(
-                    "Expanded {} decode URLs to {} DP-aware URLs",
-                    decode_urls.len(),
-                    expanded_decode.len()
-                );
-
-                // Keep the bootstrap_port from the original URLs, apply to all expanded URLs
-                let prefill_with_ports: Vec<(String, Option<u16>)> = expanded_prefill
-                    .into_iter()
-                    .map(|url| {
-                        // Use the port from the first original URL (all DP replicas share the same port config)
-                        let port = prefill_urls.first().and_then(|(_, p)| *p);
-                        (url, port)
-                    })
-                    .collect();
-
-                (prefill_with_ports, expanded_decode)
-            } else {
-                info!("DP-aware mode disabled, using original worker URLs");
-                (prefill_urls, decode_urls)
-            };
-
-        let mut prefill_workers_urls = vec![];
-        let mut decode_workers_urls = vec![];
-        let dp_size = ctx.router_config.intra_node_data_parallel_size;
+        let fallback_dp_size = ctx.router_config.intra_node_data_parallel_size.max(1);
         let health_config = HealthConfig {
             timeout_secs: ctx.router_config.health_check.timeout_secs,
             check_interval_secs: ctx.router_config.health_check.check_interval_secs,
@@ -586,73 +494,34 @@ impl PdRouterBase {
             success_threshold: ctx.router_config.health_check.success_threshold,
         };
 
-        // Register prefill workers in the registry
-        for (url, port) in expanded_prefill_urls {
-            prefill_workers_urls.push(url.clone());
-            let worker_type = WorkerType::Prefill {
-                bootstrap_port: port,
-            };
-            let worker: Arc<dyn Worker> = if dp_size > 1 {
-                let (base_url, dp_rank) = dp_utils::parse_worker_url(&url);
-                Arc::new(
-                    DPAwareWorker::new(base_url, dp_rank.unwrap_or(0), dp_size, worker_type)
-                        .with_circuit_breaker_config(core_cb_config.clone())
-                        .with_health_config(health_config.clone()),
-                )
-            } else {
-                Arc::new(
-                    BasicWorker::new(url, worker_type)
-                        .with_circuit_breaker_config(core_cb_config.clone())
-                        .with_health_config(health_config.clone()),
-                )
-            };
-            ctx.worker_registry.register(worker);
+        let prefill_workers = prefill_urls.iter().map(|(url, bootstrap_port)| {
+            (
+                url,
+                WorkerType::Prefill {
+                    bootstrap_port: *bootstrap_port,
+                },
+            )
+        });
+        let decode_workers = decode_urls.iter().map(|url| (url, WorkerType::Decode));
+        for (url, worker_type) in prefill_workers.chain(decode_workers) {
+            let dp_size = dp_utils::discover_dp_size(&ctx.client, url, fallback_dp_size).await;
+            for worker in build_dp_workers(
+                url,
+                dp_size,
+                worker_type,
+                &core_cb_config,
+                Some(&health_config),
+            ) {
+                ctx.worker_registry.register(worker);
+            }
         }
 
-        // Register decode workers in the registry
-        for url in expanded_decode_urls {
-            decode_workers_urls.push(url.clone());
-            let worker: Arc<dyn Worker> = if dp_size > 1 {
-                let (base_url, dp_rank) = dp_utils::parse_worker_url(&url);
-                Arc::new(
-                    DPAwareWorker::new(base_url, dp_rank.unwrap_or(0), dp_size, WorkerType::Decode)
-                        .with_circuit_breaker_config(core_cb_config.clone())
-                        .with_health_config(health_config.clone()),
-                )
-            } else {
-                Arc::new(
-                    BasicWorker::new(url, WorkerType::Decode)
-                        .with_circuit_breaker_config(core_cb_config.clone())
-                        .with_health_config(health_config.clone()),
-                )
-            };
-            ctx.worker_registry.register(worker);
-        }
-
-        // Get all workers from registry for health check
+        // Get all workers from registry for load monitoring
         let all_workers = ctx.worker_registry.get_all();
         let all_urls: Vec<String> = all_workers
             .iter()
             .map(|worker| worker.url().to_string())
             .collect();
-        // At least one prefill and one decode are up
-        if !prefill_workers_urls.is_empty() {
-            crate::routers::http::router::Router::wait_for_healthy_workers(
-                &prefill_workers_urls,
-                ctx.router_config.worker_startup_timeout_secs,
-                ctx.router_config.worker_startup_check_interval_secs,
-            )
-            .await?;
-        }
-
-        if !decode_workers_urls.is_empty() {
-            crate::routers::http::router::Router::wait_for_healthy_workers(
-                &decode_workers_urls,
-                ctx.router_config.worker_startup_timeout_secs,
-                ctx.router_config.worker_startup_check_interval_secs,
-            )
-            .await?;
-        }
 
         // Initialize cache-aware policies with workers from registry
         // Note: We need to get workers by type and convert to Box<dyn Worker> for CacheAwarePolicy
@@ -704,7 +573,7 @@ impl PdRouterBase {
             load_monitor_handle,
             client: ctx.client.clone(),
             circuit_breaker_config: core_cb_config,
-            dp_size,
+            dp_size: fallback_dp_size,
         })
     }
 
@@ -1225,7 +1094,7 @@ impl PdRouterBase {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::{BasicWorker, DPAwareWorker, Worker, WorkerType};
+    use crate::core::{BasicWorker, DPAwareWorker, Worker, WorkerFactory, WorkerType};
 
     fn create_test_pd_router() -> PdRouterBase {
         let worker_registry = Arc::new(WorkerRegistry::new());

--- a/src/routers/http/vllm_pd_router.rs
+++ b/src/routers/http/vllm_pd_router.rs
@@ -317,10 +317,7 @@ impl VllmPDRouter {
                         prefill_response_json,
                     )
                     .await?;
-                Some(Self::build_nixl_push_decode_params(
-                    &identity,
-                    request_id?,
-                ))
+                Some(Self::build_nixl_push_decode_params(&identity, request_id?))
             }
         }
     }
@@ -1158,8 +1155,12 @@ impl VllmPDRouter {
                 Ok(json) => json,
             };
             if let Some(prefill_json) = concurrent_prefill_response_json.as_ref() {
-                self.maybe_cache_nixl_push_identity(&prefill_url_key, prefill_dp_rank, prefill_json)
-                    .await;
+                self.maybe_cache_nixl_push_identity(
+                    &prefill_url_key,
+                    prefill_dp_rank,
+                    prefill_json,
+                )
+                .await;
             }
             let decode_response = match decode_result {
                 Ok(resp) => resp,
@@ -1658,9 +1659,7 @@ impl VllmPDRouter {
         let request_id = Self::generate_vllm_request_id(&prefill_zmq_addr, &decode_zmq_addr);
 
         let mut prefill_request = Self::prepare_prefill_request(original_request.clone(), path);
-        prefill_request["kv_transfer_params"] = self
-            .build_prefill_kv_transfer_params(None)
-            .ok()?;
+        prefill_request["kv_transfer_params"] = self.build_prefill_kv_transfer_params(None).ok()?;
 
         let mut decode_request = original_request.clone();
         decode_request["kv_transfer_params"] =

--- a/src/routers/http/vllm_pd_router.rs
+++ b/src/routers/http/vllm_pd_router.rs
@@ -65,22 +65,6 @@ pub struct VllmPDRouter {
 /// Must match `MoRIIOConstants.TRANSFER_PREFIX` in the vLLM Python connector.
 const MORIIO_TRANSFER_PREFIX: &str = "tx";
 
-/// Strip the DP-rank suffix from a worker's HTTP address and return the base address
-/// plus the parsed rank. Returns `(original, None)` when DP is disabled.
-fn extract_base_http_and_dp_rank(
-    http: &str,
-    intra_node_data_parallel_size: usize,
-) -> (String, Option<usize>) {
-    if intra_node_data_parallel_size > 1 {
-        let url = format!("http://{}", http);
-        let (base, rank) = dp_utils::parse_worker_url(&url);
-        let base_http = base.replace("http://", "").replace("https://", "");
-        (base_http, rank)
-    } else {
-        (http.to_string(), None)
-    }
-}
-
 /// Build a prefill reqwest::RequestBuilder with the standard headers and dp-rank header.
 fn build_prefill_request_builder(
     http_client: &reqwest::Client,
@@ -894,10 +878,8 @@ impl VllmPDRouter {
             self.kv_connector
         );
 
-        let (prefill_base_http, prefill_dp_rank) =
-            extract_base_http_and_dp_rank(prefill_http, self.intra_node_data_parallel_size);
-        let (decode_base_http, decode_dp_rank) =
-            extract_base_http_and_dp_rank(decode_http, self.intra_node_data_parallel_size);
+        let (prefill_base_http, prefill_dp_rank) = dp_utils::parse_worker_url(prefill_http);
+        let (decode_base_http, decode_dp_rank) = dp_utils::parse_worker_url(decode_http);
         let prefill_url_key = format!("http://{}", prefill_base_http);
 
         let is_concurrent_dispatch = (matches!(self.kv_connector, KvConnector::MoriIO)

--- a/src/routers/http/vllm_pd_router.rs
+++ b/src/routers/http/vllm_pd_router.rs
@@ -58,6 +58,7 @@ pub struct VllmPDRouter {
     kv_connector: KvConnector,
     /// Mooncake bootstrap info: prefill base_url -> MooncakePrefillInfo
     mooncake_prefill_info: Arc<Mutex<HashMap<String, MooncakePrefillInfo>>>,
+    nixl_prefill_info: Arc<Mutex<HashMap<String, HashMap<usize, Value>>>>,
 }
 
 /// Transfer ID prefix used by MoRI-IO to correlate prefill and decode legs.
@@ -257,6 +258,7 @@ impl VllmPDRouter {
         prefill_response_json: Option<&Value>,
         transfer_id: Option<&str>,
         prefill_dp_rank: Option<u32>,
+        request_id: Option<&str>,
     ) -> Option<Value> {
         match self.kv_connector {
             KvConnector::Mooncake => {
@@ -303,7 +305,23 @@ impl VllmPDRouter {
                     Some(params)
                 }
             }
-            KvConnector::Nixl => Some(prefill_response_json?.get("kv_transfer_params")?.clone()),
+            KvConnector::Nixl => {
+                let kvt = prefill_response_json?.get("kv_transfer_params")?;
+                if !Self::is_nixl_push_mode(kvt) {
+                    return Some(kvt.clone());
+                }
+                let identity = self
+                    .ensure_nixl_push_identity(
+                        prefill_url,
+                        prefill_dp_rank.map(|r| r as usize),
+                        prefill_response_json,
+                    )
+                    .await?;
+                Some(Self::build_nixl_push_decode_params(
+                    &identity,
+                    request_id?,
+                ))
+            }
         }
     }
 
@@ -342,6 +360,104 @@ impl VllmPDRouter {
             }
         }
         None
+    }
+
+    fn is_nixl_push_mode(kvt: &Value) -> bool {
+        kvt.get("transfer_mode")
+            .and_then(|v| v.as_str())
+            .is_some_and(|mode| mode == "push")
+    }
+
+    fn nixl_push_identity_from_kvt(kvt: &Value) -> Option<Value> {
+        if !Self::is_nixl_push_mode(kvt) {
+            return None;
+        }
+        let engine_id = kvt.get("remote_engine_id")?;
+        let host = kvt.get("remote_host")?;
+        let port = kvt.get("remote_port")?;
+        if engine_id.is_null() || host.is_null() || port.is_null() {
+            return None;
+        }
+        Some(json!({
+            "remote_engine_id": engine_id.clone(),
+            "remote_host": host.clone(),
+            "remote_port": port.clone(),
+            "tp_size": kvt.get("tp_size").cloned().unwrap_or_else(|| json!(1)),
+            "transfer_mode": "push",
+        }))
+    }
+
+    fn build_nixl_push_decode_params(identity: &Value, request_id: &str) -> Value {
+        json!({
+            "do_remote_prefill": true,
+            "do_remote_decode": false,
+            "remote_engine_id": identity.get("remote_engine_id").cloned().unwrap_or(Value::Null),
+            "remote_host": identity.get("remote_host").cloned().unwrap_or(Value::Null),
+            "remote_port": identity.get("remote_port").cloned().unwrap_or(Value::Null),
+            "tp_size": identity.get("tp_size").cloned().unwrap_or_else(|| json!(1)),
+            "remote_request_id": request_id,
+        })
+    }
+
+    async fn get_nixl_push_identity(
+        &self,
+        prefill_url: &str,
+        dp_rank: Option<usize>,
+    ) -> Option<Value> {
+        let identity = self.get_nixl_info(prefill_url, dp_rank).await?;
+        Self::is_nixl_push_mode(&identity).then_some(identity)
+    }
+
+    async fn ensure_nixl_push_identity(
+        &self,
+        prefill_url: &str,
+        dp_rank: Option<usize>,
+        prefill_response_json: Option<&Value>,
+    ) -> Option<Value> {
+        if let Some(identity) = self.get_nixl_push_identity(prefill_url, dp_rank).await {
+            return Some(identity);
+        }
+        let identity = prefill_response_json
+            .and_then(|json| json.get("kv_transfer_params"))
+            .and_then(Self::nixl_push_identity_from_kvt)?;
+        self.store_nixl_info(prefill_url, dp_rank, identity.clone())
+            .await;
+        Some(identity)
+    }
+
+    async fn maybe_cache_nixl_push_identity(
+        &self,
+        prefill_url: &str,
+        dp_rank: Option<usize>,
+        prefill_response_json: &Value,
+    ) {
+        if let Some(identity) = prefill_response_json
+            .get("kv_transfer_params")
+            .and_then(Self::nixl_push_identity_from_kvt)
+        {
+            self.store_nixl_info(prefill_url, dp_rank, identity).await;
+        }
+    }
+
+    async fn get_nixl_info(&self, prefill_url: &str, dp_rank: Option<usize>) -> Option<Value> {
+        let info = self.nixl_prefill_info.lock().await;
+        if let Some(per_rank) = info.get(prefill_url) {
+            let rank = dp_rank.unwrap_or(0);
+            if let Some(identity) = per_rank.get(&rank) {
+                return Some(identity.clone());
+            }
+            if let Some(identity) = per_rank.values().next() {
+                return Some(identity.clone());
+            }
+        }
+        None
+    }
+
+    async fn store_nixl_info(&self, prefill_url: &str, dp_rank: Option<usize>, identity: Value) {
+        let mut info = self.nixl_prefill_info.lock().await;
+        info.entry(prefill_url.to_string())
+            .or_default()
+            .insert(dp_rank.unwrap_or(0), identity);
     }
 
     /// Generate vLLM-specific request ID with prefill/decode addressing
@@ -786,10 +902,15 @@ impl VllmPDRouter {
             extract_base_http_and_dp_rank(prefill_http, self.intra_node_data_parallel_size);
         let (decode_base_http, decode_dp_rank) =
             extract_base_http_and_dp_rank(decode_http, self.intra_node_data_parallel_size);
+        let prefill_url_key = format!("http://{}", prefill_base_http);
 
-        // Concurrent dispatch: e.g. MoRI-IO WRITE mode
-        let is_concurrent_dispatch = matches!(self.kv_connector, KvConnector::MoriIO)
-            && matches!(self.moriio_transfer_mode(), Some(MoriIOTransferMode::Write));
+        let is_concurrent_dispatch = (matches!(self.kv_connector, KvConnector::MoriIO)
+            && matches!(self.moriio_transfer_mode(), Some(MoriIOTransferMode::Write)))
+            || (matches!(self.kv_connector, KvConnector::Nixl)
+                && self
+                    .get_nixl_push_identity(&prefill_url_key, prefill_dp_rank)
+                    .await
+                    .is_some());
 
         let needs_logprobs = request_json.get("logprobs").is_some()
             || request_json
@@ -889,13 +1010,13 @@ impl VllmPDRouter {
 
         // Prepare decode request
         let mut decode_request = request_json.clone();
-        let prefill_url_key = format!("http://{}", prefill_base_http);
         if let Some(params) = self
             .build_decode_kv_transfer_params(
                 &prefill_url_key,
                 prefill_response_json.as_ref(),
                 transfer_id.as_deref(),
                 prefill_dp_rank.map(|r| r as u32),
+                Some(&request_id),
             )
             .await
         {
@@ -1037,6 +1158,10 @@ impl VllmPDRouter {
                 }
                 Ok(json) => json,
             };
+            if let Some(prefill_json) = concurrent_prefill_response_json.as_ref() {
+                self.maybe_cache_nixl_push_identity(&prefill_url_key, prefill_dp_rank, prefill_json)
+                    .await;
+            }
             let decode_response = match decode_result {
                 Ok(resp) => resp,
                 Err(e) => {
@@ -1125,6 +1250,25 @@ impl VllmPDRouter {
     ) -> Result<Response, PDRouterError> {
         debug!("ENTERED process_vllm_two_stage_request method");
         let start_time = Instant::now();
+
+        if let Some((prefill_request, decode_request, request_id)) = self
+            .try_build_concurrent_requests(&original_request, &prefill_worker, &decode_worker, path)
+            .await
+        {
+            return self
+                .process_concurrent_two_stage(
+                    prefill_request,
+                    decode_request,
+                    prefill_worker,
+                    decode_worker,
+                    request_id,
+                    path,
+                    headers,
+                    start_time,
+                )
+                .await;
+        }
+
         debug!(
             "Prefill worker: {}, Decode worker: {}, Path: {}",
             prefill_worker.url(),
@@ -1286,18 +1430,6 @@ impl VllmPDRouter {
             }
         };
 
-        // Extract kv_transfer_params from prefill response if present
-        let kv_transfer_params = prefill_response_json.get("kv_transfer_params").cloned();
-
-        if let Some(ref params) = kv_transfer_params {
-            debug!(
-                "Extracted kv_transfer_params from prefill response: {}",
-                serde_json::to_string_pretty(params).unwrap_or_default()
-            );
-        } else {
-            debug!("No kv_transfer_params found in prefill response, will proceed without them");
-        }
-
         // Stop profiling on prefill server after its work is done
         self.stop_profiling(&prefill_base_url).await;
 
@@ -1309,41 +1441,22 @@ impl VllmPDRouter {
 
         // Stage 2: Prepare decode request with kv_transfer_params
         let mut decode_request = original_request.clone();
-        if matches!(self.kv_connector, KvConnector::Mooncake) {
-            // Mooncake: set decode params proactively from bootstrap info
-            if let Some((bootstrap_addr, engine_id)) = self
-                .get_mooncake_info(&prefill_base_url, prefill_dp_rank)
-                .await
-            {
-                decode_request["kv_transfer_params"] = self
-                    .build_mooncake_decode_kv_transfer_params(
-                        transfer_id.as_deref().unwrap_or(""),
-                        &bootstrap_addr,
-                        &engine_id,
-                    );
-                debug!(
-                    "Set Mooncake decode kv_transfer_params with bootstrap_addr={}, engine_id={}",
-                    bootstrap_addr, engine_id
-                );
-            } else {
-                warn!(
-                    "No Mooncake bootstrap info for prefill {}, decode will proceed without kv_transfer_params",
-                    prefill_base_url
-                );
-            }
+        if let Some(params) = self
+            .build_decode_kv_transfer_params(
+                &prefill_base_url,
+                Some(&prefill_response_json),
+                transfer_id.as_deref(),
+                prefill_dp_rank.map(|r| r as u32),
+                Some(&request_id),
+            )
+            .await
+        {
+            decode_request["kv_transfer_params"] = params;
         } else {
-            // Sequential dispatch (NIXL, MoRI-IO READ): extract kv_transfer_params from prefill response
-            if let Some(mut params) = kv_transfer_params {
-                if matches!(self.kv_connector, KvConnector::MoriIO) {
-                    // MoRI-IO decode connector needs to know how many prefill DP ranks to handshake with.
-                    params["remote_dp_size"] = json!(self.intra_node_data_parallel_size);
-                }
-                decode_request["kv_transfer_params"] = params;
-                debug!(
-                    "Added kv_transfer_params to decode request for {:?} connector",
-                    self.kv_connector
-                );
-            }
+            warn!(
+                "No kv_transfer_params for prefill {}, decode will proceed without them",
+                prefill_base_url
+            );
         }
 
         // Use endpoint_url() to get the base URL without @rank suffix,
@@ -1523,6 +1636,196 @@ impl VllmPDRouter {
         }
     }
 
+    async fn try_build_concurrent_requests(
+        &self,
+        original_request: &Value,
+        prefill_worker: &Arc<dyn Worker>,
+        decode_worker: &Arc<dyn Worker>,
+        path: &str,
+    ) -> Option<(Value, Value, String)> {
+        if !matches!(self.kv_connector, KvConnector::Nixl) {
+            return None;
+        }
+
+        let prefill_base_url = prefill_worker.base_url().to_string();
+        let prefill_dp_rank = prefill_worker.dp_rank();
+        let identity = self
+            .get_nixl_push_identity(&prefill_base_url, prefill_dp_rank)
+            .await?;
+
+        let prefill_zmq_addr =
+            self.get_zmq_address(prefill_worker.base_url(), ServiceType::Prefill);
+        let decode_zmq_addr = self.get_zmq_address(decode_worker.base_url(), ServiceType::Decode);
+        let request_id = Self::generate_vllm_request_id(&prefill_zmq_addr, &decode_zmq_addr);
+
+        let mut prefill_request = Self::prepare_prefill_request(original_request.clone(), path);
+        prefill_request["kv_transfer_params"] = self
+            .build_prefill_kv_transfer_params(None)
+            .ok()?;
+
+        let mut decode_request = original_request.clone();
+        decode_request["kv_transfer_params"] =
+            Self::build_nixl_push_decode_params(&identity, &request_id);
+
+        Some((prefill_request, decode_request, request_id))
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn process_concurrent_two_stage(
+        &self,
+        prefill_request: Value,
+        decode_request: Value,
+        prefill_worker: Arc<dyn Worker>,
+        decode_worker: Arc<dyn Worker>,
+        request_id: String,
+        path: &str,
+        headers: Option<&HeaderMap>,
+        start_time: Instant,
+    ) -> Result<Response, PDRouterError> {
+        let prefill_base_url = prefill_worker.base_url().to_string();
+        let prefill_dp_rank = prefill_worker.dp_rank();
+        let decode_base_url = decode_worker.base_url().to_string();
+        let decode_dp_rank = decode_worker.dp_rank();
+        let prefill_url = prefill_worker.endpoint_url(path);
+        let decode_url = decode_worker.endpoint_url(path);
+        let auth = format!(
+            "Bearer {}",
+            std::env::var("OPENAI_API_KEY").unwrap_or_default()
+        );
+        let stage_builder = |url: &str, rank: Option<usize>| {
+            dp_utils::add_dp_rank_header(
+                self.pd_router
+                    .client
+                    .post(url)
+                    .header("Content-Type", "application/json")
+                    .header("Authorization", auth.as_str())
+                    .header("X-Request-Id", request_id.as_str()),
+                rank,
+            )
+        };
+
+        prefill_worker.increment_load();
+        decode_worker.increment_load();
+        self.start_profiling(&prefill_base_url).await;
+        self.start_profiling(&decode_base_url).await;
+
+        let (prefill_result, decode_result) = tokio::join!(
+            otel_http::send_client_request(
+                stage_builder(&prefill_url, prefill_dp_rank).json(&prefill_request),
+                headers,
+                ClientRequestOptions {
+                    method: "POST",
+                    url: &prefill_url,
+                    route: Some(path),
+                    request_phase: Some("prefill"),
+                },
+            ),
+            otel_http::send_client_request(
+                stage_builder(&decode_url, decode_dp_rank).json(&decode_request),
+                headers,
+                ClientRequestOptions {
+                    method: "POST",
+                    url: &decode_url,
+                    route: Some(path),
+                    request_phase: Some("decode"),
+                },
+            ),
+        );
+
+        prefill_worker.decrement_load();
+        self.stop_profiling(&prefill_base_url).await;
+
+        let prefill_response_json = match prefill_result {
+            Ok(resp) if resp.status().is_success() => resp
+                .bytes()
+                .await
+                .ok()
+                .and_then(|b| serde_json::from_slice::<Value>(&b).ok()),
+            Ok(resp) => {
+                decode_worker.decrement_load();
+                self.stop_profiling(&decode_base_url).await;
+                RouterMetrics::record_pd_prefill_error(&prefill_base_url);
+                RouterMetrics::record_pd_request(path);
+                RouterMetrics::record_pd_request_duration(path, start_time.elapsed());
+                return Err(PDRouterError::NetworkError {
+                    message: format!(
+                        "Prefill request failed to {} with status {}",
+                        prefill_url,
+                        resp.status()
+                    ),
+                });
+            }
+            Err(e) => {
+                decode_worker.decrement_load();
+                self.stop_profiling(&decode_base_url).await;
+                RouterMetrics::record_pd_prefill_error(&prefill_base_url);
+                RouterMetrics::record_pd_request(path);
+                RouterMetrics::record_pd_request_duration(path, start_time.elapsed());
+                return Err(PDRouterError::NetworkError {
+                    message: format!(
+                        "Prefill request failed to {}: {}",
+                        prefill_url,
+                        error_chain(&e)
+                    ),
+                });
+            }
+        };
+        if let Some(prefill_json) = prefill_response_json.as_ref() {
+            self.maybe_cache_nixl_push_identity(&prefill_base_url, prefill_dp_rank, prefill_json)
+                .await;
+        }
+
+        let decode_response = match decode_result {
+            Ok(resp) => resp,
+            Err(e) => {
+                decode_worker.decrement_load();
+                self.stop_profiling(&decode_base_url).await;
+                RouterMetrics::record_pd_decode_error(&decode_base_url);
+                RouterMetrics::record_pd_request(path);
+                RouterMetrics::record_pd_request_duration(path, start_time.elapsed());
+                RouterMetrics::record_pd_prefill_request(&prefill_base_url);
+                return Err(PDRouterError::NetworkError {
+                    message: format!(
+                        "Decode request failed to {}: {}",
+                        decode_url,
+                        error_chain(&e)
+                    ),
+                });
+            }
+        };
+        decode_worker.decrement_load();
+
+        let needs_logprobs = decode_request.get("logprobs").is_some()
+            || decode_request
+                .get("echo")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+        let is_streaming = decode_request
+            .get("stream")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        let prefill_http = prefill_base_url
+            .strip_prefix("http://")
+            .unwrap_or(&prefill_base_url);
+        let decode_http = decode_base_url
+            .strip_prefix("http://")
+            .unwrap_or(&decode_base_url);
+
+        self.handle_decode_response(
+            decode_response,
+            prefill_response_json.as_ref(),
+            path,
+            prefill_http,
+            decode_http,
+            decode_http,
+            start_time,
+            is_streaming,
+            needs_logprobs,
+        )
+        .await
+        .map_err(|message| PDRouterError::NetworkError { message })
+    }
+
     /// Create a new vLLM PD router
     /// Supports two modes:
     /// 1. Discovery mode: discovery_address is Some, prefill_urls and decode_urls are empty
@@ -1572,6 +1875,7 @@ impl VllmPDRouter {
                 intra_node_data_parallel_size: ctx.router_config.intra_node_data_parallel_size,
                 kv_connector,
                 mooncake_prefill_info: Arc::new(Mutex::new(HashMap::new())),
+                nixl_prefill_info: Arc::new(Mutex::new(HashMap::new())),
             })
         } else {
             // Direct URL mode (same as PdRouterBase)
@@ -1660,6 +1964,7 @@ impl VllmPDRouter {
                 intra_node_data_parallel_size: ctx.router_config.intra_node_data_parallel_size,
                 kv_connector,
                 mooncake_prefill_info,
+                nixl_prefill_info: Arc::new(Mutex::new(HashMap::new())),
             })
         }
     }

--- a/src/routers/http/vllm_pd_router.rs
+++ b/src/routers/http/vllm_pd_router.rs
@@ -442,9 +442,8 @@ impl VllmPDRouter {
     async fn get_nixl_info(&self, prefill_url: &str, dp_rank: Option<usize>) -> Option<Value> {
         let info = self.nixl_prefill_info.lock().await;
         if let Some(per_rank) = info.get(prefill_url) {
-            let rank = dp_rank.unwrap_or(0);
-            if let Some(identity) = per_rank.get(&rank) {
-                return Some(identity.clone());
+            if let Some(rank) = dp_rank {
+                return per_rank.get(&rank).cloned();
             }
             if let Some(identity) = per_rank.values().next() {
                 return Some(identity.clone());

--- a/src/routers/http/vllm_pd_router.rs
+++ b/src/routers/http/vllm_pd_router.rs
@@ -1686,11 +1686,7 @@ impl VllmPDRouter {
         let decode_base_url = decode_worker.base_url().to_string();
         let mut prefill_request = Self::prepare_prefill_request(original_request.clone(), path);
         prefill_request["kv_transfer_params"] = self
-            .build_prefill_kv_transfer_params(
-                None,
-                Some(&decode_base_url),
-                decode_worker.dp_rank(),
-            )
+            .build_prefill_kv_transfer_params(None, Some(&decode_base_url), decode_worker.dp_rank())
             .ok()?;
 
         let mut decode_request = original_request.clone();


### PR DESCRIPTION
## Purpose
Recently NIXL push mode was added to vLLM, before that only NIXL pull existed (RDMA READ).
https://github.com/vllm-project/vllm/pull/35264
https://github.com/vllm-project/vllm/issues/36923

vllm-router used to work with NIXL pull mode (sequential), and in this mode new PUSH mode is slower than PULL mode, which is unexpected. It happens because of the extra message (see RFC)

**Scenario 1**: D registers before P finishes (overlap)
D sends REGISTER_BLOCKS_MSG to P's scheduler via ZMQ side channel
P stores the registration data
When P finishes the request (request_finished), it finds the stored registration
P enqueues to the push dispatcher thread, which sends a PUSH_TRIGGER_MSG via ZMQ TCP to all TP workers
**Scenario 2**: P finishes before D registers (push message D->P)
P finishes the request and stores block IDs in _finished_request_blocks
When D's REGISTER_BLOCKS_MSG arrives at P's listener thread, it enqueues to the push dispatcher
The dispatcher fuzzy-matches the registration to the finished request and sends the push trigger

The key insight is that vllm-router (sequential) always goes with scenario 2 for push mode, meaning extra message from D to P, which is why PUSH performance drops compared to PULL.

The fix is to make router parallel for push mode: `process_concurrent_two_stage` fires prefill and decode with a single call — both HTTP requests leave the router at the same time, and neither waits for the other.

Impl details:
1. Router learns prefill details from the first response and cache them, so no bootstrap or extra config needed, router works with `--kv-connector nixl`
2. On vLLM side push connector needs to be started with new config option `transfer_mode:push`:
This was already implemented in https://github.com/tzulingk/vllm/commit/7edf76276e0ba5e913145cdefa5e917a9caa3fa5

## Test Plan
Tested with benchmark
```
OUT=vllm.jsonl && rm -f "$OUT" && \
for num_prompts in 1 2 4 8 16 32 64 128 256 512 1024; do
  echo "========== num-prompts: $num_prompts =========="
  for run in 1 2 3 4 5; do
    vllm bench serve --host 127.0.0.1 --port 8200 \
      --model $MODEL --num-prompts $(( num_prompts * 2 )) \
      --max-concurrency $num_prompts \
      --random-input-len 1024 --random-output-len 64 \
      --random-range-ratio 0 --seed 42 \
      --num-warmups 8 --dataset-name random \
      --save-result --append-result --result-filename "$OUT" \
      --disable-tqdm 2>/dev/null \
      | awk -v r=$run '
          /Median TTFT/ {ttft=$NF}
          /P99 TTFT/    {ttft99=$NF}
          /Median TPOT/ {tpot=$NF}
          /P99 TPOT/    {printf "  run %s:  TTFT med=%s (p99 %s) ms   TPOT med=%s (p99 %s) ms\n", r, ttft, ttft99, tpot, $NF}'
  done
  echo ""
done
```

## Test Result
```
# p4d4, best mean TTFT of 4 runs, vllm-router
num_prompts  Mooncake  NIXL-PULL  NIXL-PUSH  NIXL-PUSH-PARALLEL
1            75        74         73         71
2            112       108        133        96
4            136       137        147        120
8            170       159        184        123
16           184       183        198        159
32           231       191        226        182
64           235       204        237        210
128          287       248        270        216
256          366       373        392        372
512          2398      2095       2171       2087
```

<img width="2250" height="1500" alt="pareto_compare_nixl_pull_nixl_push_nixl_push_router_mc_vs_concurrency_071223" src="https://github.com/user-attachments/assets/ab2dd044-d43e-40ed-9c44-71219f29ec54" />


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
