### PR TITLE
feat: session sticky round robin

### DIFF
--- a/py_src/vllm_router/router.py
+++ b/py_src/vllm_router/router.py
@@ -15,6 +15,7 @@ def policy_from_str(policy_str: Optional[str]) -> PolicyType:
         "cache_aware": PolicyType.CacheAware,
         "power_of_two": PolicyType.PowerOfTwo,
         "consistent_hash": PolicyType.ConsistentHash,
+        "sticky_round_robin": PolicyType.StickyRoundRobin,
     }
     return policy_map[policy_str]
 

--- a/py_src/vllm_router/router_args.py
+++ b/py_src/vllm_router/router_args.py
@@ -140,6 +140,7 @@ class RouterArgs:
                 "cache_aware",
                 "power_of_two",
                 "consistent_hash",
+                "sticky_round_robin",
             ],
             help="Load balancing policy to use. In PD mode, this is used for both prefill and decode unless overridden",
         )
@@ -153,6 +154,7 @@ class RouterArgs:
                 "cache_aware",
                 "power_of_two",
                 "consistent_hash",
+                "sticky_round_robin",
             ],
             help="Specific policy for prefill nodes in PD mode. If not specified, uses the main policy",
         )
@@ -166,6 +168,7 @@ class RouterArgs:
                 "cache_aware",
                 "power_of_two",
                 "consistent_hash",
+                "sticky_round_robin",
             ],
             help="Specific policy for decode nodes in PD mode. If not specified, uses the main policy",
         )

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -246,6 +246,9 @@ pub enum PolicyConfig {
 
     #[serde(rename = "rendezvous_hash")]
     RendezvousHash,
+
+    #[serde(rename = "sticky_round_robin")]
+    StickyRoundRobin,
 }
 
 impl PolicyConfig {
@@ -257,6 +260,7 @@ impl PolicyConfig {
             PolicyConfig::PowerOfTwo { .. } => "power_of_two",
             PolicyConfig::ConsistentHash { .. } => "consistent_hash",
             PolicyConfig::RendezvousHash => "rendezvous_hash",
+            PolicyConfig::StickyRoundRobin => "sticky_round_robin",
         }
     }
 }

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -126,7 +126,7 @@ impl ConfigValidator {
     /// Validate policy configuration
     fn validate_policy(policy: &PolicyConfig) -> ConfigResult<()> {
         match policy {
-            PolicyConfig::Random | PolicyConfig::RoundRobin => {
+            PolicyConfig::Random | PolicyConfig::RoundRobin | PolicyConfig::StickyRoundRobin => {
                 // No specific validation needed
             }
             PolicyConfig::CacheAware {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@ pub enum PolicyType {
     CacheAware,
     PowerOfTwo,
     ConsistentHash,
+    StickyRoundRobin,
 }
 
 #[pyclass]
@@ -124,6 +125,7 @@ impl Router {
                 PolicyType::ConsistentHash => ConfigPolicyConfig::ConsistentHash {
                     virtual_nodes: 160, // Default value
                 },
+                PolicyType::StickyRoundRobin => ConfigPolicyConfig::StickyRoundRobin,
             }
         };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -107,7 +107,7 @@ struct CliArgs {
     worker_urls: Vec<String>,
 
     /// Load balancing policy to use
-    #[arg(long, default_value = "cache_aware", value_parser = ["random", "round_robin", "cache_aware", "power_of_two", "consistent_hash", "rendezvous_hash"])]
+    #[arg(long, default_value = "cache_aware", value_parser = ["random", "round_robin", "cache_aware", "power_of_two", "consistent_hash", "rendezvous_hash", "sticky_round_robin"])]
     policy: String,
 
     /// Enable vLLM PD (Prefill-Decode) disaggregated mode with vLLM-specific two-stage processing
@@ -124,11 +124,11 @@ struct CliArgs {
     decode: Vec<String>,
 
     /// Specific policy for prefill nodes in PD mode
-    #[arg(long, value_parser = ["random", "round_robin", "cache_aware", "power_of_two", "consistent_hash", "rendezvous_hash"])]
+    #[arg(long, value_parser = ["random", "round_robin", "cache_aware", "power_of_two", "consistent_hash", "rendezvous_hash", "sticky_round_robin"])]
     prefill_policy: Option<String>,
 
     /// Specific policy for decode nodes in PD mode
-    #[arg(long, value_parser = ["random", "round_robin", "cache_aware", "power_of_two", "consistent_hash", "rendezvous_hash"])]
+    #[arg(long, value_parser = ["random", "round_robin", "cache_aware", "power_of_two", "consistent_hash", "rendezvous_hash", "sticky_round_robin"])]
     decode_policy: Option<String>,
 
     /// Timeout in seconds for worker startup
@@ -373,6 +373,7 @@ impl CliArgs {
                 virtual_nodes: 160, // Default value
             },
             "rendezvous_hash" => PolicyConfig::RendezvousHash,
+            "sticky_round_robin" => PolicyConfig::StickyRoundRobin,
             _ => PolicyConfig::RoundRobin, // Fallback
         }
     }

--- a/src/policies/factory.rs
+++ b/src/policies/factory.rs
@@ -2,7 +2,7 @@
 
 use super::{
     CacheAwareConfig, CacheAwarePolicy, ConsistentHashPolicy, LoadBalancingPolicy,
-    PowerOfTwoPolicy, RandomPolicy, RendezvousHashPolicy, RoundRobinPolicy,
+    PowerOfTwoPolicy, RandomPolicy, RendezvousHashPolicy, RoundRobinPolicy, StickyRoundRobinPolicy,
 };
 use crate::config::PolicyConfig;
 use std::sync::Arc;
@@ -39,6 +39,7 @@ impl PolicyFactory {
                 Arc::new(ConsistentHashPolicy::new())
             }
             PolicyConfig::RendezvousHash => Arc::new(RendezvousHashPolicy::new()),
+            PolicyConfig::StickyRoundRobin => Arc::new(StickyRoundRobinPolicy::new()),
         }
     }
 
@@ -51,6 +52,9 @@ impl PolicyFactory {
             "cache_aware" | "cacheaware" => Some(Arc::new(CacheAwarePolicy::new())),
             "consistent_hash" | "consistenthash" => Some(Arc::new(ConsistentHashPolicy::new())),
             "rendezvous_hash" | "rendezvoushash" => Some(Arc::new(RendezvousHashPolicy::new())),
+            "sticky_round_robin" | "stickyroundrobin" => {
+                Some(Arc::new(StickyRoundRobinPolicy::new()))
+            }
             _ => None,
         }
     }
@@ -94,6 +98,10 @@ mod tests {
         // Test RendezvousHash
         let policy = PolicyFactory::create_from_config(&PolicyConfig::RendezvousHash);
         assert_eq!(policy.name(), "rendezvous_hash");
+
+        // Test StickyRoundRobin
+        let policy = PolicyFactory::create_from_config(&PolicyConfig::StickyRoundRobin);
+        assert_eq!(policy.name(), "sticky_round_robin");
     }
 
     #[test]
@@ -110,6 +118,8 @@ mod tests {
         assert!(PolicyFactory::create_by_name("ConsistentHash").is_some());
         assert!(PolicyFactory::create_by_name("rendezvous_hash").is_some());
         assert!(PolicyFactory::create_by_name("RendezvousHash").is_some());
+        assert!(PolicyFactory::create_by_name("sticky_round_robin").is_some());
+        assert!(PolicyFactory::create_by_name("StickyRoundRobin").is_some());
         assert!(PolicyFactory::create_by_name("unknown").is_none());
     }
 }

--- a/src/policies/mod.rs
+++ b/src/policies/mod.rs
@@ -17,6 +17,7 @@ mod random;
 mod registry;
 mod rendezvous_hash;
 mod round_robin;
+mod sticky_round_robin;
 
 pub use cache_aware::CacheAwarePolicy;
 pub use consistent_hash::ConsistentHashPolicy;
@@ -27,6 +28,7 @@ pub use random::RandomPolicy;
 pub use registry::PolicyRegistry;
 pub use rendezvous_hash::RendezvousHashPolicy;
 pub use round_robin::RoundRobinPolicy;
+pub use sticky_round_robin::StickyRoundRobinPolicy;
 
 /// HTTP headers passed to policies for routing decisions
 /// Key is lowercase header name, value is header value

--- a/src/policies/registry.rs
+++ b/src/policies/registry.rs
@@ -6,7 +6,7 @@
 /// When the last worker of a model is removed, the policy mapping is cleaned up.
 use super::{
     CacheAwareConfig, CacheAwarePolicy, ConsistentHashPolicy, LoadBalancingPolicy,
-    PowerOfTwoPolicy, RandomPolicy, RendezvousHashPolicy, RoundRobinPolicy,
+    PowerOfTwoPolicy, RandomPolicy, RendezvousHashPolicy, RoundRobinPolicy, StickyRoundRobinPolicy,
 };
 use crate::config::types::PolicyConfig;
 use std::collections::HashMap;
@@ -173,6 +173,7 @@ impl PolicyRegistry {
             "cache_aware" => Arc::new(CacheAwarePolicy::new()),
             "power_of_two" => Arc::new(PowerOfTwoPolicy::new()),
             "rendezvous_hash" => Arc::new(RendezvousHashPolicy::new()),
+            "sticky_round_robin" => Arc::new(StickyRoundRobinPolicy::new()),
             _ => {
                 warn!("Unknown policy type '{}', using default", policy_type);
                 Arc::clone(&self.default_policy)
@@ -204,6 +205,7 @@ impl PolicyRegistry {
             PolicyConfig::PowerOfTwo { .. } => Arc::new(PowerOfTwoPolicy::new()),
             PolicyConfig::ConsistentHash { .. } => Arc::new(ConsistentHashPolicy::new()),
             PolicyConfig::RendezvousHash => Arc::new(RendezvousHashPolicy::new()),
+            PolicyConfig::StickyRoundRobin => Arc::new(StickyRoundRobinPolicy::new()),
         }
     }
 

--- a/src/policies/sticky_round_robin.rs
+++ b/src/policies/sticky_round_robin.rs
@@ -1,0 +1,280 @@
+//! Sticky round-robin load balancing policy.
+//!
+//! New sessions are assigned in round-robin order and remain pinned to that
+//! worker while it is healthy. Keyless requests use round-robin without
+//! creating an affinity entry.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use dashmap::mapref::entry::Entry;
+use dashmap::DashMap;
+
+use super::{get_healthy_worker_indices, hash_key, LoadBalancingPolicy, RequestHeaders};
+use crate::core::Worker;
+use crate::metrics::RouterMetrics;
+
+/// Strict per-session affinity with round-robin placement for new sessions.
+#[derive(Debug)]
+pub struct StickyRoundRobinPolicy {
+    /// Session key to assigned worker URL.
+    assignments: DashMap<String, String>,
+    /// Cursor used only when assigning a new session or remapping one.
+    session_counter: AtomicUsize,
+    /// Independent cursor for keyless traffic so it cannot shift session placement.
+    keyless_counter: AtomicUsize,
+}
+
+impl StickyRoundRobinPolicy {
+    pub fn new() -> Self {
+        Self {
+            assignments: DashMap::new(),
+            session_counter: AtomicUsize::new(0),
+            keyless_counter: AtomicUsize::new(0),
+        }
+    }
+
+    fn round_robin_pick(counter: &AtomicUsize, healthy_indices: &[usize]) -> usize {
+        let count = counter.fetch_add(1, Ordering::Relaxed);
+        healthy_indices[count % healthy_indices.len()]
+    }
+
+    fn healthy_index_for(&self, workers: &[Arc<dyn Worker>], url: &str) -> Option<usize> {
+        workers.iter().position(|worker| {
+            worker.url() == url && worker.is_healthy() && worker.circuit_breaker().can_execute()
+        })
+    }
+
+    fn record_selection(&self, workers: &[Arc<dyn Worker>], index: usize) {
+        let worker = &workers[index];
+        worker.increment_processed();
+        RouterMetrics::record_processed_request(worker.url());
+        RouterMetrics::record_policy_decision(self.name(), worker.url());
+    }
+
+    fn select_for_key(
+        &self,
+        workers: &[Arc<dyn Worker>],
+        key: &str,
+        sticky: bool,
+    ) -> Option<usize> {
+        if !sticky {
+            let healthy_indices = get_healthy_worker_indices(workers);
+            if healthy_indices.is_empty() {
+                return None;
+            }
+            let index = Self::round_robin_pick(&self.keyless_counter, &healthy_indices);
+            self.record_selection(workers, index);
+            return Some(index);
+        }
+
+        if let Some(url) = self
+            .assignments
+            .get(key)
+            .map(|assignment| assignment.value().clone())
+        {
+            if let Some(index) = self.healthy_index_for(workers, &url) {
+                self.record_selection(workers, index);
+                return Some(index);
+            }
+        }
+
+        let healthy_indices = get_healthy_worker_indices(workers);
+        if healthy_indices.is_empty() {
+            return None;
+        }
+
+        // The entry guard ensures concurrent first requests for one session
+        // agree on a single worker.
+        let index = match self.assignments.entry(key.to_string()) {
+            Entry::Occupied(mut entry) => {
+                if let Some(index) = self.healthy_index_for(workers, entry.get()) {
+                    index
+                } else {
+                    let index = Self::round_robin_pick(&self.session_counter, &healthy_indices);
+                    *entry.get_mut() = workers[index].url().to_string();
+                    index
+                }
+            }
+            Entry::Vacant(entry) => {
+                let index = Self::round_robin_pick(&self.session_counter, &healthy_indices);
+                entry.insert(workers[index].url().to_string());
+                index
+            }
+        };
+
+        self.record_selection(workers, index);
+        Some(index)
+    }
+}
+
+impl LoadBalancingPolicy for StickyRoundRobinPolicy {
+    fn select_worker_with_headers(
+        &self,
+        workers: &[Arc<dyn Worker>],
+        request_text: Option<&str>,
+        headers: Option<&RequestHeaders>,
+    ) -> Option<usize> {
+        if workers.is_empty() {
+            return None;
+        }
+
+        let key = hash_key::extract_hash_key(request_text, headers);
+        let sticky = !key.starts_with("request:") && !key.starts_with("request_hash:");
+        self.select_for_key(workers, &key, sticky)
+    }
+
+    fn name(&self) -> &'static str {
+        "sticky_round_robin"
+    }
+
+    fn needs_request_text(&self) -> bool {
+        true
+    }
+
+    fn needs_headers(&self) -> bool {
+        true
+    }
+
+    fn reset(&self) {
+        self.assignments.clear();
+        self.session_counter.store(0, Ordering::Relaxed);
+        self.keyless_counter.store(0, Ordering::Relaxed);
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
+impl Default for StickyRoundRobinPolicy {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::{BasicWorker, WorkerType};
+    use std::collections::HashMap;
+
+    fn workers(count: usize) -> Vec<Arc<dyn Worker>> {
+        (0..count)
+            .map(|index| {
+                Arc::new(BasicWorker::new(
+                    format!("http://w{index}:8000"),
+                    WorkerType::Regular,
+                )) as Arc<dyn Worker>
+            })
+            .collect()
+    }
+
+    fn session_headers(session_id: &str) -> RequestHeaders {
+        HashMap::from([("x-session-id".to_string(), session_id.to_string())])
+    }
+
+    #[test]
+    fn new_sessions_round_robin_across_workers() {
+        let policy = StickyRoundRobinPolicy::new();
+        let workers = workers(3);
+
+        let pick = |session_id: &str| {
+            policy.select_worker_with_headers(&workers, None, Some(&session_headers(session_id)))
+        };
+
+        assert_eq!(pick("s0"), Some(0));
+        assert_eq!(pick("s1"), Some(1));
+        assert_eq!(pick("s2"), Some(2));
+        assert_eq!(pick("s3"), Some(0));
+    }
+
+    #[test]
+    fn existing_session_stays_on_its_worker() {
+        let policy = StickyRoundRobinPolicy::new();
+        let workers = workers(3);
+
+        let first =
+            policy.select_worker_with_headers(&workers, None, Some(&session_headers("session-a")));
+        policy.select_worker_with_headers(&workers, None, Some(&session_headers("session-b")));
+        policy.select_worker_with_headers(&workers, None, Some(&session_headers("session-c")));
+
+        for _ in 0..5 {
+            assert_eq!(
+                policy.select_worker_with_headers(
+                    &workers,
+                    None,
+                    Some(&session_headers("session-a")),
+                ),
+                first
+            );
+        }
+    }
+
+    #[test]
+    fn unhealthy_assignment_is_remapped() {
+        let policy = StickyRoundRobinPolicy::new();
+        let workers = workers(3);
+        let headers = session_headers("session-a");
+
+        let first = policy
+            .select_worker_with_headers(&workers, None, Some(&headers))
+            .unwrap();
+        workers[first].set_healthy(false);
+
+        let remapped = policy
+            .select_worker_with_headers(&workers, None, Some(&headers))
+            .unwrap();
+
+        assert_ne!(remapped, first);
+        assert!(workers[remapped].is_healthy());
+        assert_eq!(
+            policy
+                .assignments
+                .get("header:x-session-id:session-a")
+                .map(|assignment| assignment.value().clone()),
+            Some(workers[remapped].url().to_string())
+        );
+    }
+
+    #[test]
+    fn keyless_requests_round_robin_without_affinity_entries() {
+        let policy = StickyRoundRobinPolicy::new();
+        let workers = workers(3);
+
+        assert_eq!(
+            policy.select_worker_with_headers(&workers, Some("null"), None),
+            Some(0)
+        );
+        assert_eq!(
+            policy.select_worker_with_headers(&workers, Some("null"), None),
+            Some(1)
+        );
+        assert!(policy.assignments.is_empty());
+
+        // Keyless traffic must not consume the cursor used to place sessions.
+        assert_eq!(
+            policy.select_worker_with_headers(&workers, None, Some(&session_headers("session-a")),),
+            Some(0)
+        );
+    }
+
+    #[test]
+    fn no_healthy_workers_returns_none() {
+        let policy = StickyRoundRobinPolicy::new();
+        let workers = workers(2);
+        for worker in &workers {
+            worker.set_healthy(false);
+        }
+        let headers = session_headers("session-a");
+
+        assert_eq!(
+            policy.select_worker_with_headers(&workers, None, Some(&headers)),
+            None
+        );
+        assert_eq!(
+            policy.select_worker_with_headers(&workers, Some("null"), None),
+            None
+        );
+    }
+}


### PR DESCRIPTION
Implement session based round robin. 

- Enforces session affinity unless worker becomes unhealthy
- Session selection is strictly round robin, filtering out /health or /metrics

Not included:
- Eviction still relies on rest