### PR TITLE
fix(router): strip inbound Host header so upstream receives its own Host

### DIFF
--- a/src/routers/http/router.rs
+++ b/src/routers/http/router.rs
@@ -18,7 +18,8 @@ use axum::{
     body::Body,
     extract::Request,
     http::{
-        header::CONTENT_LENGTH, header::CONTENT_TYPE, HeaderMap, HeaderValue, Method, StatusCode,
+        header::CONTENT_LENGTH, header::CONTENT_TYPE, header::HOST, HeaderMap, HeaderValue, Method,
+        StatusCode,
     },
     response::{IntoResponse, Response},
     Json,
@@ -435,6 +436,7 @@ impl Router {
                     let name_lc = name.to_lowercase();
                     if name_lc != "content-type"
                         && name_lc != "content-length"
+                        && name_lc != "host"
                         && !header_utils::TRACE_HEADER_NAMES.contains(&name_lc.as_str())
                     {
                         request_builder = request_builder.header(name, value);
@@ -687,6 +689,7 @@ impl Router {
                     let name_lc = name.as_str().to_lowercase();
                     if name_lc != "content-type"
                         && name_lc != "content-length"
+                        && name_lc != "host"
                         && !header_utils::TRACE_HEADER_NAMES.contains(&name_lc.as_str())
                     {
                         request_builder = request_builder.header(name, value);
@@ -823,6 +826,7 @@ impl Router {
             for (name, value) in headers {
                 if *name != CONTENT_TYPE
                     && *name != CONTENT_LENGTH
+                    && *name != HOST
                     && !header_utils::TRACE_HEADER_NAMES
                         .iter()
                         .any(|&th| name.as_str().eq_ignore_ascii_case(th))


### PR DESCRIPTION
## Purpose

When forwarding a request, the router copied the inbound `Host` header to the upstream. Behind a reverse proxy that routes by `server_name` (e.g. nginx), the upstream then received the router's own Host (its k8s Service name) instead of the backend's, and rejected the request with `400 Bad Request`.

This excludes `host` from the copied headers in all three forward paths (buffered, streaming, proxy), so `reqwest` sets `Host` from the target URL.

## Test Plan

- `cargo test --test test_transparent_proxy_routing --test streaming_tests`
- Manual: router -> HTTPS vLLM behind nginx (routes by `server_name`), `POST /v1/chat/completions`.

## Test Result

- All existing tests pass; header-forwarding and auth-forwarding tests unaffected.
- Before: `400 Bad Request` (nginx).
- After: `200` with a valid completion.