### PR TITLE
[ROCm] Support for the remote dp and tp size for vllm's moriio kv connector

### DIFF
--- a/src/routers/http/vllm_pd_router.rs
+++ b/src/routers/http/vllm_pd_router.rs
@@ -800,16 +800,17 @@ impl VllmPDRouter {
             extract_base_http_and_dp_rank(decode_http, self.intra_node_data_parallel_size);
 
         if self.intra_node_data_parallel_size > 1 && prefill_dp_rank.is_none() {
-            let rank = self
-                .prefill_dp_round_robin
-                .fetch_add(1, Ordering::Relaxed)
+            let rank = self.prefill_dp_round_robin.fetch_add(1, Ordering::Relaxed)
                 % self.intra_node_data_parallel_size;
             prefill_dp_rank = Some(rank);
         }
 
         // Add kv_transfer_params for KV connector support at top level
-        prefill_request["kv_transfer_params"] =
-            self.build_prefill_kv_transfer_params(transfer_id.as_deref(), Some(&decode_base_http), prefill_dp_rank)?;
+        prefill_request["kv_transfer_params"] = self.build_prefill_kv_transfer_params(
+            transfer_id.as_deref(),
+            Some(&decode_base_http),
+            prefill_dp_rank,
+        )?;
 
         debug!(
             "Added kv_transfer_params to prefill request for {:?} connector",
@@ -954,11 +955,12 @@ impl VllmPDRouter {
             .header("Content-Type", "application/json")
             .header("X-Request-Id", &request_id); // Same P2P coordination metadata in header
 
-        let effective_decode_dp_rank = if decode_dp_rank.is_none() && self.intra_node_data_parallel_size > 1 {
-            prefill_dp_rank
-        } else {
-            decode_dp_rank
-        };
+        let effective_decode_dp_rank =
+            if decode_dp_rank.is_none() && self.intra_node_data_parallel_size > 1 {
+                prefill_dp_rank
+            } else {
+                decode_dp_rank
+            };
         decode_request_builder =
             dp_utils::add_dp_rank_header(decode_request_builder, effective_decode_dp_rank);
         if let Some(rank) = effective_decode_dp_rank {
@@ -1191,7 +1193,11 @@ impl VllmPDRouter {
         // Add kv_transfer_params for KV connector support at top level
         let decode_base_url = decode_worker.base_url().to_string();
         prefill_request["kv_transfer_params"] = self
-            .build_prefill_kv_transfer_params(transfer_id.as_deref(), Some(&decode_base_url), decode_worker.dp_rank())
+            .build_prefill_kv_transfer_params(
+                transfer_id.as_deref(),
+                Some(&decode_base_url),
+                decode_worker.dp_rank(),
+            )
             .map_err(|reason| PDRouterError::InvalidConfiguration { reason })?;
 
         debug!(

--- a/src/routers/http/vllm_pd_router.rs
+++ b/src/routers/http/vllm_pd_router.rs
@@ -203,6 +203,7 @@ impl VllmPDRouter {
         &self,
         transfer_id: Option<&str>,
         decode_base: Option<&str>,
+        decode_dp_rank: Option<usize>,
     ) -> Result<Value, String> {
         match self.kv_connector {
             KvConnector::Mooncake => Ok(json!({
@@ -226,7 +227,7 @@ impl VllmPDRouter {
                                 .0
                         })
                         .unwrap_or(1);
-                    Ok(json!({
+                    let mut params = json!({
                         "do_remote_decode": true,
                         "do_remote_prefill": false,
                         "remote_engine_id": serde_json::Value::Null,
@@ -234,7 +235,11 @@ impl VllmPDRouter {
                         "remote_dp_size": self.intra_node_data_parallel_size,
                         "remote_tp_size": remote_tp_size,
                         "transfer_id": transfer_id.unwrap_or(""),
-                    }))
+                    });
+                    if self.intra_node_data_parallel_size > 1 {
+                        params["remote_dp_rank"] = json!(decode_dp_rank.unwrap_or(0));
+                    }
+                    Ok(params)
                 } else {
                     // READ mode: prefill waits for decode to pull blocks.
                     Ok(json!({
@@ -793,7 +798,7 @@ impl VllmPDRouter {
 
         // Add kv_transfer_params for KV connector support at top level
         prefill_request["kv_transfer_params"] =
-            self.build_prefill_kv_transfer_params(transfer_id.as_deref(), Some(&decode_base_http))?;
+            self.build_prefill_kv_transfer_params(transfer_id.as_deref(), Some(&decode_base_http), prefill_dp_rank)?;
 
         debug!(
             "Added kv_transfer_params to prefill request for {:?} connector",
@@ -938,10 +943,14 @@ impl VllmPDRouter {
             .header("Content-Type", "application/json")
             .header("X-Request-Id", &request_id); // Same P2P coordination metadata in header
 
-        // Add X-data-parallel-rank header using shared utilities
+        let effective_decode_dp_rank = if decode_dp_rank.is_none() && self.intra_node_data_parallel_size > 1 {
+            prefill_dp_rank
+        } else {
+            decode_dp_rank
+        };
         decode_request_builder =
-            dp_utils::add_dp_rank_header(decode_request_builder, decode_dp_rank);
-        if let Some(rank) = decode_dp_rank {
+            dp_utils::add_dp_rank_header(decode_request_builder, effective_decode_dp_rank);
+        if let Some(rank) = effective_decode_dp_rank {
             debug!(
                 "Added X-data-parallel-rank={} header to decode request",
                 rank
@@ -1171,7 +1180,7 @@ impl VllmPDRouter {
         // Add kv_transfer_params for KV connector support at top level
         let decode_base_url = decode_worker.base_url().to_string();
         prefill_request["kv_transfer_params"] = self
-            .build_prefill_kv_transfer_params(transfer_id.as_deref(), Some(&decode_base_url))
+            .build_prefill_kv_transfer_params(transfer_id.as_deref(), Some(&decode_base_url), decode_worker.dp_rank())
             .map_err(|reason| PDRouterError::InvalidConfiguration { reason })?;
 
         debug!(

--- a/src/routers/http/vllm_pd_router.rs
+++ b/src/routers/http/vllm_pd_router.rs
@@ -20,6 +20,7 @@ use axum::{
 };
 use serde_json::{json, Value};
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
 use tokio::sync::Mutex;
@@ -54,6 +55,8 @@ pub struct VllmPDRouter {
     profiling_tasks: Arc<Mutex<HashMap<String, tokio::task::AbortHandle>>>,
     /// Intra-node data parallel size for DP-aware routing (automatically enabled when > 1)
     intra_node_data_parallel_size: usize,
+    /// Round-robin counter for prefill DP rank selection
+    prefill_dp_round_robin: Arc<AtomicUsize>,
     /// KV connector type
     kv_connector: KvConnector,
     /// Mooncake bootstrap info: prefill base_url -> MooncakePrefillInfo
@@ -791,10 +794,18 @@ impl VllmPDRouter {
         // Generate a connector-specific transfer_id (None for NIXL)
         let transfer_id = self.generate_transfer_id();
 
-        let (prefill_base_http, prefill_dp_rank) =
+        let (prefill_base_http, mut prefill_dp_rank) =
             extract_base_http_and_dp_rank(prefill_http, self.intra_node_data_parallel_size);
         let (decode_base_http, decode_dp_rank) =
             extract_base_http_and_dp_rank(decode_http, self.intra_node_data_parallel_size);
+
+        if self.intra_node_data_parallel_size > 1 && prefill_dp_rank.is_none() {
+            let rank = self
+                .prefill_dp_round_robin
+                .fetch_add(1, Ordering::Relaxed)
+                % self.intra_node_data_parallel_size;
+            prefill_dp_rank = Some(rank);
+        }
 
         // Add kv_transfer_params for KV connector support at top level
         prefill_request["kv_transfer_params"] =
@@ -1593,6 +1604,7 @@ impl VllmPDRouter {
                 profile_timeout_secs: ctx.router_config.profile_timeout_secs,
                 profiling_tasks: Arc::new(Mutex::new(HashMap::new())),
                 intra_node_data_parallel_size: ctx.router_config.intra_node_data_parallel_size,
+                prefill_dp_round_robin: Arc::new(AtomicUsize::new(0)),
                 kv_connector,
                 mooncake_prefill_info: Arc::new(Mutex::new(HashMap::new())),
             })
@@ -1681,6 +1693,7 @@ impl VllmPDRouter {
                 profile_timeout_secs: ctx.router_config.profile_timeout_secs,
                 profiling_tasks: Arc::new(Mutex::new(HashMap::new())),
                 intra_node_data_parallel_size: ctx.router_config.intra_node_data_parallel_size,
+                prefill_dp_round_robin: Arc::new(AtomicUsize::new(0)),
                 kv_connector,
                 mooncake_prefill_info,
             })

--- a/src/routers/http/vllm_pd_router.rs
+++ b/src/routers/http/vllm_pd_router.rs
@@ -288,7 +288,9 @@ impl VllmPDRouter {
             KvConnector::MoriIO => {
                 if matches!(self.moriio_transfer_mode(), Some(MoriIOTransferMode::Write)) {
                     // WRITE mode: build decode params directly; decode does not need the prefill response.
-                    let prefill_base = prefill_url.trim_start_matches("http://").trim_start_matches("https://");
+                    let prefill_base = prefill_url
+                        .trim_start_matches("http://")
+                        .trim_start_matches("https://");
                     let (tp_size, _) = self
                         .service_registry
                         .get_tp_dp_size(prefill_base, ServiceType::Prefill);
@@ -2551,7 +2553,11 @@ mod tests {
 
     // --- MoRI-IO WRITE mode parameter tests ---
 
-    fn moriio_write_prefill_params(transfer_id: Option<&str>, dp_size: usize, tp_size: usize) -> Value {
+    fn moriio_write_prefill_params(
+        transfer_id: Option<&str>,
+        dp_size: usize,
+        tp_size: usize,
+    ) -> Value {
         // Mirror the WRITE mode branch in build_prefill_kv_transfer_params.
         json!({
             "do_remote_decode": true,

--- a/src/routers/http/vllm_pd_router.rs
+++ b/src/routers/http/vllm_pd_router.rs
@@ -199,7 +199,11 @@ impl VllmPDRouter {
     ///
     /// Returns an error for MoRI-IO when no transfer mode has been registered yet, so that
     /// requests are not silently dispatched in READ mode when no instances have registered.
-    fn build_prefill_kv_transfer_params(&self, transfer_id: Option<&str>) -> Result<Value, String> {
+    fn build_prefill_kv_transfer_params(
+        &self,
+        transfer_id: Option<&str>,
+        decode_base: Option<&str>,
+    ) -> Result<Value, String> {
         match self.kv_connector {
             KvConnector::Mooncake => Ok(json!({
                 "do_remote_decode": true,
@@ -215,15 +219,20 @@ impl VllmPDRouter {
                 if matches!(mode, MoriIOTransferMode::Write) {
                     // WRITE mode: prefill pushes KV blocks to decode.
                     // do_remote_decode=true tells the prefill connector to initiate the transfer.
+                    let remote_tp_size = decode_base
+                        .map(|base| {
+                            self.service_registry
+                                .get_tp_dp_size(base, ServiceType::Decode)
+                                .0
+                        })
+                        .unwrap_or(1);
                     Ok(json!({
                         "do_remote_decode": true,
                         "do_remote_prefill": false,
                         "remote_engine_id": serde_json::Value::Null,
                         "remote_block_ids": serde_json::Value::Null,
                         "remote_dp_size": self.intra_node_data_parallel_size,
-                        // remote_tp_size is not yet consumed by the vLLM MoRI-IO connector;
-                        // hardcoded to 1 until https://github.com/vllm-project/vllm/issues/41211 is resolved.
-                        "remote_tp_size": 1,
+                        "remote_tp_size": remote_tp_size,
                         "transfer_id": transfer_id.unwrap_or(""),
                     }))
                 } else {
@@ -279,6 +288,10 @@ impl VllmPDRouter {
             KvConnector::MoriIO => {
                 if matches!(self.moriio_transfer_mode(), Some(MoriIOTransferMode::Write)) {
                     // WRITE mode: build decode params directly; decode does not need the prefill response.
+                    let prefill_base = prefill_url.trim_start_matches("http://").trim_start_matches("https://");
+                    let (tp_size, _) = self
+                        .service_registry
+                        .get_tp_dp_size(prefill_base, ServiceType::Prefill);
                     let mut params = json!({
                         "do_remote_decode": false,
                         "do_remote_prefill": true,
@@ -286,9 +299,7 @@ impl VllmPDRouter {
                         "remote_block_ids": serde_json::Value::Null,
                         "transfer_id": transfer_id.unwrap_or(""),
                         "remote_dp_size": self.intra_node_data_parallel_size,
-                        // remote_tp_size is not yet consumed by the vLLM MoRI-IO connector;
-                        // hardcoded to 1 until https://github.com/vllm-project/vllm/issues/41211 is resolved.
-                        "remote_tp_size": 1,
+                        "remote_tp_size": tp_size,
                     });
                     if self.intra_node_data_parallel_size > 1 {
                         if let Some(rank) = prefill_dp_rank {
@@ -773,19 +784,19 @@ impl VllmPDRouter {
         // Generate a connector-specific transfer_id (None for NIXL)
         let transfer_id = self.generate_transfer_id();
 
+        let (prefill_base_http, prefill_dp_rank) =
+            extract_base_http_and_dp_rank(prefill_http, self.intra_node_data_parallel_size);
+        let (decode_base_http, decode_dp_rank) =
+            extract_base_http_and_dp_rank(decode_http, self.intra_node_data_parallel_size);
+
         // Add kv_transfer_params for KV connector support at top level
         prefill_request["kv_transfer_params"] =
-            self.build_prefill_kv_transfer_params(transfer_id.as_deref())?;
+            self.build_prefill_kv_transfer_params(transfer_id.as_deref(), Some(&decode_base_http))?;
 
         debug!(
             "Added kv_transfer_params to prefill request for {:?} connector",
             self.kv_connector
         );
-
-        let (prefill_base_http, prefill_dp_rank) =
-            extract_base_http_and_dp_rank(prefill_http, self.intra_node_data_parallel_size);
-        let (decode_base_http, decode_dp_rank) =
-            extract_base_http_and_dp_rank(decode_http, self.intra_node_data_parallel_size);
 
         // Concurrent dispatch: e.g. MoRI-IO WRITE mode
         let is_concurrent_dispatch = matches!(self.kv_connector, KvConnector::MoriIO)
@@ -1156,8 +1167,9 @@ impl VllmPDRouter {
         let transfer_id = self.generate_transfer_id();
 
         // Add kv_transfer_params for KV connector support at top level
+        let decode_base_url = decode_worker.base_url().to_string();
         prefill_request["kv_transfer_params"] = self
-            .build_prefill_kv_transfer_params(transfer_id.as_deref())
+            .build_prefill_kv_transfer_params(transfer_id.as_deref(), Some(&decode_base_url))
             .map_err(|reason| PDRouterError::InvalidConfiguration { reason })?;
 
         debug!(
@@ -2539,7 +2551,7 @@ mod tests {
 
     // --- MoRI-IO WRITE mode parameter tests ---
 
-    fn moriio_write_prefill_params(transfer_id: Option<&str>, dp_size: usize) -> Value {
+    fn moriio_write_prefill_params(transfer_id: Option<&str>, dp_size: usize, tp_size: usize) -> Value {
         // Mirror the WRITE mode branch in build_prefill_kv_transfer_params.
         json!({
             "do_remote_decode": true,
@@ -2547,9 +2559,7 @@ mod tests {
             "remote_engine_id": serde_json::Value::Null,
             "remote_block_ids": serde_json::Value::Null,
             "remote_dp_size": dp_size,
-            // remote_tp_size is not yet consumed by the vLLM MoRI-IO connector;
-            // hardcoded to 1 until https://github.com/vllm-project/vllm/issues/41211 is resolved.
-            "remote_tp_size": 1,
+            "remote_tp_size": tp_size,
             "transfer_id": transfer_id.unwrap_or(""),
         })
     }
@@ -2581,12 +2591,12 @@ mod tests {
 
     #[test]
     fn test_moriio_write_prefill_params_has_do_remote_decode_true() {
-        let params = moriio_write_prefill_params(Some("tx-abc"), 1);
+        let params = moriio_write_prefill_params(Some("tx-abc"), 1, 8);
         assert_eq!(params["do_remote_decode"], true);
         assert_eq!(params["do_remote_prefill"], false);
         assert!(params["remote_engine_id"].is_null());
         assert!(params["remote_block_ids"].is_null());
-        assert_eq!(params["remote_tp_size"], 1);
+        assert_eq!(params["remote_tp_size"], 8);
         assert_eq!(params["remote_dp_size"], 1);
         assert_eq!(params["transfer_id"], "tx-abc");
     }

--- a/src/routers/http/vllm_service_discovery.rs
+++ b/src/routers/http/vllm_service_discovery.rs
@@ -51,6 +51,14 @@ pub struct MoriIOServiceRegistration {
     #[serde(flatten)]
     pub base: ServiceRegistration,
     pub transfer_mode: String, // "READ" or "WRITE"
+    #[serde(default = "default_one")]
+    pub tp_size: usize,
+    #[serde(default = "default_one")]
+    pub dp_size: usize,
+}
+
+fn default_one() -> usize {
+    1
 }
 
 impl MoriIOServiceRegistration {
@@ -68,6 +76,8 @@ impl MoriIOServiceRegistration {
 pub struct ServiceInstance {
     pub zmq_address: String,
     pub expires_at: u64, // Unix timestamp
+    pub tp_size: usize,
+    pub dp_size: usize,
 }
 
 /// Service registry maintaining prefill and decode instances
@@ -90,7 +100,7 @@ fn parse_registration(
     remote_address: &[u8],
     kv_connector: KvConnector,
     stored_transfer_mode: Option<MoriIOTransferMode>,
-) -> Option<(ServiceRegistration, Option<MoriIOTransferMode>)> {
+) -> Option<(ServiceRegistration, Option<MoriIOTransferMode>, usize, usize)> {
     if matches!(kv_connector, KvConnector::MoriIO) {
         let reg: MoriIOServiceRegistration = match rmp_serde::from_slice(message_data) {
             Ok(r) => r,
@@ -122,10 +132,10 @@ fn parse_registration(
                 return None;
             }
         }
-        Some((reg.base, Some(mode)))
+        Some((reg.base, Some(mode), reg.tp_size, reg.dp_size))
     } else {
         match rmp_serde::from_slice(message_data) {
-            Ok(data) => Some((data, None)),
+            Ok(data) => Some((data, None, 1, 1)),
             Err(e) => {
                 warn!("Failed to parse service registration: {}", e);
                 None
@@ -237,7 +247,7 @@ impl ServiceRegistry {
         kv_connector: KvConnector,
         moriio_transfer_mode: &Arc<OnceLock<MoriIOTransferMode>>,
     ) {
-        let (data, parsed_mode) = match parse_registration(
+        let (data, parsed_mode, tp_size, dp_size) = match parse_registration(
             message_data,
             remote_address,
             kv_connector,
@@ -255,6 +265,8 @@ impl ServiceRegistry {
         let instance = ServiceInstance {
             zmq_address: data.zmq_address.clone(),
             expires_at: current_time + DEFAULT_PING_SECONDS,
+            tp_size,
+            dp_size,
         };
 
         let remote_addr_str = String::from_utf8_lossy(remote_address);
@@ -379,6 +391,8 @@ impl ServiceRegistry {
         let instance = ServiceInstance {
             zmq_address: zmq_address.clone(),
             expires_at: current_time + DEFAULT_PING_SECONDS,
+            tp_size: 1,
+            dp_size: 1,
         };
 
         match service_type {
@@ -399,6 +413,19 @@ impl ServiceRegistry {
                 );
             }
         }
+    }
+
+    /// Get tp_size and dp_size for a given HTTP address (from registration payload).
+    pub fn get_tp_dp_size(&self, http_address: &str, service_type: ServiceType) -> (usize, usize) {
+        let instances = match service_type {
+            ServiceType::Prefill => &self.prefill_instances,
+            ServiceType::Decode => &self.decode_instances,
+        };
+        let guard = instances.lock().unwrap();
+        guard
+            .get(http_address)
+            .map(|i| (i.tp_size, i.dp_size))
+            .unwrap_or((1, 1))
     }
 
     /// Get ZMQ address for a given HTTP address
@@ -509,7 +536,7 @@ mod tests {
             Some(MoriIOTransferMode::Write),
         );
         assert!(result.is_some());
-        let (_, mode) = result.unwrap();
+        let (_, mode, _, _) = result.unwrap();
         assert_eq!(mode, Some(MoriIOTransferMode::Write));
     }
 }

--- a/src/routers/http/vllm_service_discovery.rs
+++ b/src/routers/http/vllm_service_discovery.rs
@@ -100,7 +100,12 @@ fn parse_registration(
     remote_address: &[u8],
     kv_connector: KvConnector,
     stored_transfer_mode: Option<MoriIOTransferMode>,
-) -> Option<(ServiceRegistration, Option<MoriIOTransferMode>, usize, usize)> {
+) -> Option<(
+    ServiceRegistration,
+    Option<MoriIOTransferMode>,
+    usize,
+    usize,
+)> {
     if matches!(kv_connector, KvConnector::MoriIO) {
         let reg: MoriIOServiceRegistration = match rmp_serde::from_slice(message_data) {
             Ok(r) => r,


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose
This PR enables the support for VLLM MORI IO Connectors interface to communicate TP and DP sizes to the peers in PD Disaggregation Mode.

Related Feature PR on vLLM: https://github.com/vllm-project/vllm/pull/48989

Details:
The MORI IO Connector uses tp size for the remote port offset calculation. To provide a future-proof clean interface we are adding the support for additional registration parameters in the router.

Related vLLM MORI IO PORT offset calculation: [Port offset calculation](https://github.com/vllm-project/vllm/blob/df362b2d6d091771dbcc364b2fc96d17a78df274/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py#L1273)
Related vLLM MORI IO Connector Interface: [Interface with TP, DP size data](https://github.com/vllm-project/vllm/blob/df362b2d6d091771dbcc364b2fc96d17a78df274/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py#L1147)


## Test Plan
Verification steps on MI355X-AINIC
STEP 1: Build ROCm VLLM Image
```
docker build --no-cache  -f ./docker/Dockerfile.rocm_base -t  <IMG_VLLM_ROCM_BASE>  . 

DOCKER_BUILDKIT=1 docker build --no-cache  --target final --progress=plain -t  <FINAL_VLLM_IMAGE_NAME>  -f ./docker/Dockerfile.rocm  --build-
arg BASE_IMAGE=<IMG_VLLM_ROCM_BASE>   .
```
STEP 1: Build VLLM Router Image
```
docker build --no-cache  -f Dockerfile.router -t  <VLLM_ROUTER_IMAGE_NAME> . 
```
STEP 3: Please use below commands to start Prefill and Decode servers
```
## PREFILL
docker run --rm -i \
    --user "$(id -u):$(id -g)" \
    --device /dev/dri \
    --device /dev/kfd \
    --device /dev/infiniband \
    --network host \
    --ipc host \
    --group-add "$(getent group video | cut -d: -f3)" \
    --group-add "$(getent group render | cut -d: -f3)" \
    --cap-add SYS_PTRACE \
    --cap-add IPC_LOCK \
    --security-opt seccomp=unconfined \
    --shm-size 64G \
    --ulimit nofile=1048576:1048576 \
    --ulimit memlock=-1:-1 \
    -v <DATA_ROOT>:<DATA_ROOT> \
    -v <MORI_DIR>:/tmp/mori \
    -e HOME=<HOME_DIR> \
    -e USER="$(id -un)" \
    -e AITER_JIT_DIR=<JIT_CACHE_DIR> \
    -e FLYDSL_RUNTIME_CACHE_DIR=<FLYDSL_CACHE_DIR> \
    -e VLLM_ROCM_USE_AITER=1 \
    -e TRITON_CACHE_DIR=/tmp/triton_cache \
    -e VLLM_CACHE_ROOT=/tmp/vllm_cache \
    -e MORI_RDMA_DEVICES=<RDMA_DEVICE_LIST> \
    -e MORI_IB_GID_INDEX=1 \
    -e MORI_SHMEM_HEAP_SIZE=16G \
    -e MORI_GPU_ARCHS=<GPU_ARCH> \
    -e NCCL_IB_GID_INDEX=1 \
    --entrypoint bash \
    --name prefill \
    <CONTAINER_IMAGE> \
    -c 'vllm serve <MODEL_PATH> \
        -tp 8 \
        --port <HTTP_PORT> \
        --max-model-len 65536 \
        --gpu-memory-utilization 0.85 \
        --enforce-eager \
        --kv-cache-dtype fp8 \
        --kv-transfer-config "{
            \"kv_connector\": \"MoRIIOConnector\",
            \"kv_role\": \"kv_producer\",
            \"kv_connector_extra_config\": {
                \"proxy_ip\": \"<PROXY_IP>\",
                \"proxy_ping_port\": \"<PROXY_PING_PORT>\",
                \"http_port\": \"<HTTP_PORT>\",
                \"handshake_port\": \"<HANDSHAKE_PORT>\",
                \"notify_port\": \"<NOTIFY_PORT>\"
            }
        }"' \
    2>&1 | tee <LOG_FILE> >/dev/null
    
## DECODE
    docker run --rm -i \
    --user "$(id -u):$(id -g)" \
    --device /dev/dri \
    --device /dev/kfd \
    --device /dev/infiniband \
    --network host \
    --ipc host \
    --group-add "$(getent group video | cut -d: -f3)" \
    --group-add "$(getent group render | cut -d: -f3)" \
    --cap-add SYS_PTRACE \
    --cap-add IPC_LOCK \
    --security-opt seccomp=unconfined \
    --shm-size 64G \
    --ulimit nofile=1048576:1048576 \
    --ulimit memlock=-1:-1 \
    -v <DATA_ROOT>:<DATA_ROOT> \
    -v <MORI_DIR>:/tmp/mori \
    -e HOME=<HOME_DIR> \
    -e USER="$(id -un)" \
    -e AITER_JIT_DIR=<AITER_JIT_DIR> \
    -e FLYDSL_RUNTIME_CACHE_DIR=<FLYDSL_CACHE_DIR> \
    -e VLLM_ROCM_USE_AITER=1 \
    -e TRITON_CACHE_DIR=/tmp/triton_cache \
    -e VLLM_CACHE_ROOT=/tmp/vllm_cache \
    -e MORI_RDMA_DEVICES=<RDMA_DEVICE_LIST> \
    -e MORI_IB_GID_INDEX=1 \
    -e MORI_SHMEM_HEAP_SIZE=16G \
    -e MORI_GPU_ARCHS=<GPU_ARCH> \
    -e NCCL_IB_GID_INDEX=1 \
    --entrypoint bash \
    --name decode \
    <CONTAINER_IMAGE> \
    -c 'vllm serve <MODEL_PATH> \
        -tp 8 \
        --port <HTTP_PORT> \
        --max-model-len 65536 \
        --gpu-memory-utilization 0.85 \
        --enforce-eager \
        --kv-cache-dtype fp8 \
        --kv-transfer-config "{
            \"kv_connector\": \"MoRIIOConnector\",
            \"kv_role\": \"kv_consumer\",
            \"kv_connector_extra_config\": {
                \"proxy_ip\": \"<PROXY_IP>\",
                \"proxy_ping_port\": \"<PROXY_PING_PORT>\",
                \"http_port\": \"<HTTP_PORT>\",
                \"handshake_port\": \"<HANDSHAKE_PORT>\",
                \"notify_port\": \"<NOTIFY_PORT>\"
            }
        }"' \
    2>&1 | tee <LOG_FILE> >/dev/null &
`
```
STEP 4: Please run the following to start the vLLM Router
```
docker run --rm \
    --network host \
    --name proxy \
   <VLLM_ROUTER_IMAGE_NAME> \
    vllm-router \
    --vllm-pd-disaggregation \
    --kv-connector moriio \
    --vllm-discovery-address "0.0.0.0:36367" \
    --host 0.0.0.0 \
    --port 30000  2>&1 | tee <LOG_FILE> >/dev/null &
```
STEP 5: Please run the following to perform the accuracy test
```
## Exec to prefill node container
docker exec -it prefill bash

## lm-eval command
python3 -m lm_eval \
        --model local-completions \
        --tasks gsm8k \
        --model_args 'model=/data/models2/DeepSeek-V4-Pro,base_url=http://165.245.133.211:30000/v1/completions,num_concurrent=64,max_retries=3,tokenized_requests=False,trust_remote_code=True'
```

## Test Result
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9492|±  | 0.006|
|     |       |strict-match    |     5|exact_match|↑  |0.9492|±  | 0.006|
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
