### PR TITLE
ci(lint): pin ruff ruleset to historical default (fix repo-wide py lint)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,3 +47,12 @@ license-files = []
 [tool.distutils.bdist_wheel]
 py_limited_api = "cp38"
 
+
+# Lint config for `ruff check py_src/ py_test/` (CI: .buildkite/pipeline.yml).
+# The CI installs ruff unpinned; newer ruff releases expanded the *default*
+# ruleset, which reddened py_src/py_test repo-wide even though nothing in the
+# code changed. Pin the selection to ruff's historical default (E4/E7/E9 + F)
+# so the lint is deterministic across ruff versions. A broader ruleset +
+# cleanup can be adopted separately.
+[tool.ruff.lint]
+select = ["E4", "E7", "E9", "F"]


### PR DESCRIPTION
## Summary
`ruff check py_src/ py_test/` (in `.buildkite/pipeline.yml`) fails **repo-wide with 174 errors**, even on PRs that don't touch Python. Root cause: the CI step installs ruff **unpinned** (`pip install black ruff`) and the repo has **no `[tool.ruff]` config**, so the check uses whatever ruleset the *latest* ruff defaults to. Recent ruff releases expanded the default ruleset (`FA100`, `BLE001`, `S110`, `C408`, `UP035`, …), so the lint went red without any code change.

## Fix
Add to `pyproject.toml`:
```toml
[tool.ruff.lint]
select = ["E4", "E7", "E9", "F"]
```
This is ruff's **historical default** ruleset — the one the repo was implicitly relying on and passing before the default expanded — so the lint becomes deterministic across ruff versions.

## Verification (ruff 0.16.0)
```
$ ruff check py_src/ py_test/     ->  All checks passed!
$ black --check py_src/ py_test/  ->  42 files unchanged
```

## Notes
- Minimal unblock: restores the previously-green behavior; **no source changes**, config-only.
- If maintainers prefer the broader modern ruleset (it flags real issues like blind-except / try-except-pass), that can be adopted in a follow-up with the corresponding cleanup (72 of the 174 are `ruff --fix`-able).
- Optional extra hardening: also pin the ruff version in the CI step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ccyYZCbycaMRgaJj2kE9z
