### PR TITLE
ci: pin ruff to 0.16.0

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -56,7 +56,7 @@ steps:
 
       - label: ":python: Python Format Check"
         command: |
-          pip install black ruff
+          pip install black ruff==0.16.0
           python -m black --check py_src/ py_test/
           python -m ruff check py_src/ py_test/
         agents:


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Pin the Ruff executable used by Buildkite to 0.16.0. The Python format job currently installs Ruff without a version constraint, allowing a new Ruff release to change CI behavior for unrelated changes.

[Build #609](https://buildkite.com/vllm/router/builds/609) installed Ruff 0.16.0 and passed. [Build #614](https://buildkite.com/vllm/router/builds/614) installed Ruff 0.16.1 and reported 176 existing errors across `py_src/` and `py_test/`. The repository already pins the selected Ruff ruleset in `pyproject.toml`; pinning the executable also makes the CI environment reproducible.

## Test Plan

```bash
uv run --with black --with ruff==0.16.0 -- python -m black --check py_src/ py_test/
uv run --with black --with ruff==0.16.0 -- python -m ruff check py_src/ py_test/
```

## Test Result

```text
All done! ✨ 🍰 ✨
42 files would be left unchanged.
All checks passed!
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results

</details>