### PR TITLE
feat(router): add load-aware generate paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,20 @@ vllm-router \
     --intra-node-data-parallel-size 8
 ```
 
+#### Additional Generate Paths
+
+Register extension endpoints that use the `/inference/v1/generate` request
+schema. Configured paths get typed routing, active-load accounting, retries,
+and circuit breaking. Built-in routes keep their existing handlers. Workers
+must expose same paths.
+
+```bash
+vllm-router \
+  --worker-urls http://worker1:8000 http://worker2:8000 \
+  --policy cache_aware \
+  --extra-generate-paths /custom/v1/generate
+```
+
 #### Prefill-Decode Disaggregation
 ```bash
 # When vLLM runs the NIXL connector, prefill/decode URLs are required.

--- a/py_src/vllm_router/router.py
+++ b/py_src/vllm_router/router.py
@@ -26,6 +26,8 @@ class Router:
     Args:
         worker_urls: List of URLs for worker nodes that will handle requests. Each URL should include
             the protocol, host, and port (e.g., ['http://worker1:8000', 'http://worker2:8000'])
+        extra_generate_paths: Additional HTTP paths that use the inference-generate request schema.
+            Requests on these paths use typed routing, retries, circuit breaking, and load tracking.
         policy: Load balancing policy to use. Options:
             - PolicyType.Random: Randomly select workers
             - PolicyType.RoundRobin: Distribute requests in round-robin fashion

--- a/py_src/vllm_router/router_args.py
+++ b/py_src/vllm_router/router_args.py
@@ -89,6 +89,8 @@ class RouterArgs:
     cb_timeout_duration_secs: int = 60
     cb_window_duration_secs: int = 120
     disable_circuit_breaker: bool = False
+    # Additional typed inference-generate routes
+    extra_generate_paths: List[str] = dataclasses.field(default_factory=list)
 
     @staticmethod
     def add_cli_args(
@@ -127,6 +129,13 @@ class RouterArgs:
             nargs="*",
             default=[],
             help="List of worker URLs (e.g., http://worker1:8000 http://worker2:8000)",
+        )
+        parser.add_argument(
+            f"--{prefix}extra-generate-paths",
+            type=str,
+            nargs="*",
+            default=[],
+            help="Additional HTTP paths using the inference-generate request schema",
         )
 
         # Routing policy configuration
@@ -518,6 +527,16 @@ class RouterArgs:
         return cls(**args_dict)
 
     def _validate_router_args(self):
+        if len(set(self.extra_generate_paths)) != len(self.extra_generate_paths):
+            raise ValueError("extra_generate_paths must not contain duplicates")
+        for path in self.extra_generate_paths:
+            if (
+                len(path) < 2
+                or not path.startswith("/")
+                or any(character in path for character in "?#{}*")
+            ):
+                raise ValueError(f"invalid extra generate path: {path}")
+
         # Validate configuration based on mode
         if self.vllm_pd_disaggregation:
             # Validate PD configuration - skip URL requirements if using service discovery

--- a/py_test/unit/test_arg_parser.py
+++ b/py_test/unit/test_arg_parser.py
@@ -24,6 +24,7 @@ class TestRouterArgs:
         assert args.port == 30000
         assert args.policy == "cache_aware"
         assert args.worker_urls == []
+        assert args.extra_generate_paths == []
         assert args.vllm_pd_disaggregation is False
         assert args.prefill_urls == []
         assert args.decode_urls == []
@@ -439,6 +440,22 @@ class TestParseRouterArgs:
         assert router_args.port == 30001
         assert router_args.worker_urls == ["http://worker1:8000", "http://worker2:8000"]
         assert router_args.policy == "round_robin"
+
+    def test_parse_extra_generate_paths(self):
+        router_args = parse_router_args(
+            [
+                "--worker-urls",
+                "http://worker1:8000",
+                "--extra-generate-paths",
+                "/custom/v1/generate",
+                "/extension/generate",
+            ]
+        )
+
+        assert router_args.extra_generate_paths == [
+            "/custom/v1/generate",
+            "/extension/generate",
+        ]
 
     def test_parse_pd_args(self):
         """Test parsing PD disaggregated mode arguments."""

--- a/py_test/unit/test_validation.py
+++ b/py_test/unit/test_validation.py
@@ -399,6 +399,29 @@ class TestConfigurationValidation:
 class TestLaunchValidation:
     """Test launch-time validation logic."""
 
+    def test_extra_generate_paths_accept_distinct_extension_routes(self):
+        args = RouterArgs(
+            extra_generate_paths=["/custom/v1/generate", "/extension/generate"]
+        )
+
+        args._validate_router_args()
+
+    @pytest.mark.parametrize(
+        "paths",
+        [
+            ["custom/v1/generate"],
+            ["/custom/{path}"],
+            ["/custom/v1/generate", "/custom/v1/generate"],
+        ],
+    )
+    def test_extra_generate_paths_reject_invalid_or_duplicate_routes(self, paths):
+        args = RouterArgs(extra_generate_paths=paths)
+
+        with pytest.raises(
+            ValueError, match="extra_generate_paths|extra generate path"
+        ):
+            args._validate_router_args()
+
     def test_pd_mode_requires_urls(self):
         """Test that PD mode requires prefill and decode URLs."""
         # PD mode without URLs should fail

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@ struct Router {
     host: String,
     port: u16,
     worker_urls: Vec<String>,
+    extra_generate_paths: Vec<String>,
     policy: PolicyType,
     worker_startup_timeout_secs: u64,
     worker_startup_check_interval: u64,
@@ -310,6 +311,7 @@ impl Router {
         otlp_traces_endpoint = None,
         // KV connector default (PD disaggregation)
         kv_connector = String::from("nixl"),
+        extra_generate_paths = vec![],
     ))]
     #[allow(clippy::too_many_arguments)]
     fn new(
@@ -372,11 +374,13 @@ impl Router {
         enable_trace: bool,
         otlp_traces_endpoint: Option<String>,
         kv_connector: String,
+        extra_generate_paths: Vec<String>,
     ) -> PyResult<Self> {
         Ok(Router {
             host,
             port,
             worker_urls,
+            extra_generate_paths,
             policy,
             worker_startup_timeout_secs,
             worker_startup_check_interval,
@@ -483,26 +487,29 @@ impl Router {
 
         // Block on the async startup function
         runtime.block_on(async move {
-            server::startup(server::ServerConfig {
-                host: self.host.clone(),
-                port: self.port,
-                router_config,
-                max_payload_size: self.max_payload_size,
-                log_dir: self.log_dir.clone(),
-                log_level: self.log_level.clone(),
-                service_discovery_config,
-                prometheus_config,
-                request_timeout_secs: self.request_timeout_secs,
-                request_id_headers: self.request_id_headers.clone(),
-                trace_config: if self.enable_trace {
-                    Some(config::TraceConfig {
-                        otlp_traces_endpoint: self.otlp_traces_endpoint.clone(),
-                        ..Default::default()
-                    })
-                } else {
-                    None
+            server::startup_with_generate_paths(
+                server::ServerConfig {
+                    host: self.host.clone(),
+                    port: self.port,
+                    router_config,
+                    max_payload_size: self.max_payload_size,
+                    log_dir: self.log_dir.clone(),
+                    log_level: self.log_level.clone(),
+                    service_discovery_config,
+                    prometheus_config,
+                    request_timeout_secs: self.request_timeout_secs,
+                    request_id_headers: self.request_id_headers.clone(),
+                    trace_config: if self.enable_trace {
+                        Some(config::TraceConfig {
+                            otlp_traces_endpoint: self.otlp_traces_endpoint.clone(),
+                            ..Default::default()
+                        })
+                    } else {
+                        None
+                    },
                 },
-            })
+                self.extra_generate_paths.clone(),
+            )
             .await
             .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))
         })

--- a/src/main.rs
+++ b/src/main.rs
@@ -106,6 +106,10 @@ struct CliArgs {
     #[arg(long, num_args = 0..)]
     worker_urls: Vec<String>,
 
+    /// Additional HTTP paths using the inference-generate request schema
+    #[arg(long, num_args = 0..)]
+    extra_generate_paths: Vec<String>,
+
     /// Load balancing policy to use
     #[arg(long, default_value = "cache_aware", value_parser = ["random", "round_robin", "cache_aware", "power_of_two", "consistent_hash", "rendezvous_hash"])]
     policy: String,
@@ -713,6 +717,7 @@ Provide --worker-urls or PD flags as usual.",
         "DEBUG: CLI host: {}, port: {}",
         cli_args.host, cli_args.port
     );
+    let extra_generate_paths = cli_args.extra_generate_paths.clone();
     let server_config = cli_args.to_server_config(router_config);
     println!(
         "DEBUG: ServerConfig created successfully - host: {}, port: {}",
@@ -727,7 +732,7 @@ Provide --worker-urls or PD flags as usual.",
     // Block on the async startup function
     println!("DEBUG: Starting server startup function");
     runtime.block_on(async move {
-        let result = server::startup(server_config).await;
+        let result = server::startup_with_generate_paths(server_config, extra_generate_paths).await;
         // Shut down OTel while the Tokio runtime is still alive so the
         // BatchSpanProcessor can flush its final batch.
         if vllm_router_rs::otel_trace::is_otel_enabled() {

--- a/src/routers/http/router.rs
+++ b/src/routers/http/router.rs
@@ -1458,6 +1458,17 @@ impl RouterTrait for Router {
             .await
     }
 
+    async fn route_inference_generate_path(
+        &self,
+        headers: Option<&HeaderMap>,
+        body: &InferenceGenerateRequest,
+        path: &str,
+        model_id: Option<&str>,
+    ) -> Response {
+        self.route_typed_request(headers, body, path, model_id)
+            .await
+    }
+
     async fn route_chat(
         &self,
         headers: Option<&HeaderMap>,

--- a/src/routers/http/vllm_pd_router.rs
+++ b/src/routers/http/vllm_pd_router.rs
@@ -463,13 +463,13 @@ impl VllmPDRouter {
     }
 
     /// Modify request for prefill stage (limit output to 1 token)
-    /// - For inference/v1/generate: patch sampling_params.max_tokens and sampling_params.min_tokens
+    /// - For generate endpoints: patch sampling_params.max_tokens and sampling_params.min_tokens
     /// - For /v1/responses: patch max_output_tokens (the only token-limit field for Responses API)
     /// - For other OpenAI endpoints (chat/completions): patch max_tokens, max_completion_tokens, min_tokens
     ///
     /// stream=false and stream_options removal are always applied at top level.
     fn prepare_prefill_request(mut request: Value, path: &str) -> Value {
-        if path.contains("inference/v1/generate") {
+        if request.get("token_ids").is_some() {
             // Generate API: max_tokens and min_tokens are in sampling_params
             if let Some(sampling_params) = request.get_mut("sampling_params") {
                 sampling_params["max_tokens"] = json!(1);
@@ -1836,6 +1836,27 @@ impl RouterTrait for VllmPDRouter {
         .await
     }
 
+    async fn route_inference_generate_path(
+        &self,
+        headers: Option<&HeaderMap>,
+        body: &crate::protocols::spec::InferenceGenerateRequest,
+        path: &str,
+        _model_id: Option<&str>,
+    ) -> Response {
+        let request_json = match serde_json::to_value(body) {
+            Ok(json) => json,
+            Err(e) => {
+                return (
+                    axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("Serialization error: {}", e),
+                )
+                    .into_response()
+            }
+        };
+        self.route_transparent(headers, path, &Method::POST, request_json)
+            .await
+    }
+
     // Override OpenAI-compatible routes for vLLM two-stage processing
     async fn route_chat(
         &self,
@@ -2544,6 +2565,23 @@ mod tests {
         // temperature should be preserved
         assert_eq!(result["sampling_params"]["temperature"], 0.7);
         // top-level max_tokens should NOT be set
+        assert!(result.get("max_tokens").is_none());
+    }
+
+    #[test]
+    fn test_prefill_additional_generate_path_patches_sampling_params() {
+        let request = json!({
+            "token_ids": [123, 456],
+            "sampling_params": {
+                "max_tokens": 512,
+                "min_tokens": 50,
+                "temperature": 0.7
+            }
+        });
+        let result = VllmPDRouter::prepare_prefill_request(request, "/custom/v1/generate");
+        assert_eq!(result["sampling_params"]["max_tokens"], 1);
+        assert_eq!(result["sampling_params"]["min_tokens"], 1);
+        assert_eq!(result["sampling_params"]["temperature"], 0.7);
         assert!(result.get("max_tokens").is_none());
     }
 

--- a/src/routers/mod.rs
+++ b/src/routers/mod.rs
@@ -79,6 +79,21 @@ pub trait RouterTrait: Send + Sync + Debug + WorkerManagement {
         model_id: Option<&str>,
     ) -> Response;
 
+    /// Route an inference-generate request on an additional configured path.
+    async fn route_inference_generate_path(
+        &self,
+        _headers: Option<&HeaderMap>,
+        _body: &InferenceGenerateRequest,
+        _path: &str,
+        _model_id: Option<&str>,
+    ) -> Response {
+        (
+            StatusCode::NOT_IMPLEMENTED,
+            "Additional generate paths are not supported by this router",
+        )
+            .into_response()
+    }
+
     /// Route a chat completion request
     async fn route_chat(
         &self,

--- a/src/routers/router_manager.rs
+++ b/src/routers/router_manager.rs
@@ -591,6 +591,29 @@ impl RouterTrait for RouterManager {
         }
     }
 
+    async fn route_inference_generate_path(
+        &self,
+        headers: Option<&HeaderMap>,
+        body: &InferenceGenerateRequest,
+        path: &str,
+        _model_id: Option<&str>,
+    ) -> Response {
+        let model_id = body.model.as_deref();
+        let router = self.select_router_for_request(headers, model_id);
+
+        if let Some(router) = router {
+            router
+                .route_inference_generate_path(headers, body, path, model_id)
+                .await
+        } else {
+            (
+                StatusCode::NOT_FOUND,
+                "No router available for this request",
+            )
+                .into_response()
+        }
+    }
+
     /// Route a chat completion request
     async fn route_chat(
         &self,

--- a/src/server.rs
+++ b/src/server.rs
@@ -20,7 +20,7 @@ use crate::{
     service_discovery::{start_service_discovery, ServiceDiscoveryConfig},
 };
 use axum::{
-    extract::{DefaultBodyLimit, Path, Query, Request, State},
+    extract::{DefaultBodyLimit, OriginalUri, Path, Query, Request, State},
     http::StatusCode,
     response::{IntoResponse, Response},
     routing::{delete, get, post},
@@ -30,7 +30,7 @@ use reqwest::Client;
 use serde::Deserialize;
 use serde_json::json;
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     sync::atomic::{AtomicBool, Ordering},
     sync::Arc,
     time::Duration,
@@ -239,6 +239,22 @@ async fn inference_generate(
     state
         .router
         .route_inference_generate(Some(&headers), &body, None)
+        .await
+}
+
+async fn extra_inference_generate(
+    State(state): State<Arc<AppState>>,
+    OriginalUri(uri): OriginalUri,
+    headers: http::HeaderMap,
+    Json(body): Json<InferenceGenerateRequest>,
+) -> Response {
+    if let Err(response) = authorize_request(&state, &headers).await {
+        return response;
+    }
+
+    state
+        .router
+        .route_inference_generate_path(Some(&headers), &body, uri.path(), None)
         .await
 }
 
@@ -689,6 +705,48 @@ pub struct ServerConfig {
     pub trace_config: Option<TraceConfig>,
 }
 
+fn validate_extra_generate_paths(paths: &[String]) -> std::io::Result<()> {
+    const RESERVED_PATHS: &[&str] = &[
+        "/generate",
+        "/inference/v1/generate",
+        "/v1/chat/completions",
+        "/v1/completions",
+        "/rerank",
+        "/v1/rerank",
+        "/v1/responses",
+        "/v1/embeddings",
+        "/liveness",
+        "/readiness",
+        "/health",
+        "/health_generate",
+        "/v1/models",
+        "/get_model_info",
+        "/get_server_info",
+        "/add_worker",
+        "/remove_worker",
+        "/list_workers",
+        "/flush_cache",
+        "/get_loads",
+        "/workers",
+    ];
+
+    let mut seen = HashSet::new();
+    for path in paths {
+        let invalid_shape =
+            path.len() < 2 || !path.starts_with('/') || path.contains(['?', '#', '{', '}', '*']);
+        let conflicts_with_builtin = RESERVED_PATHS.contains(&path.as_str())
+            || path.starts_with("/v1/responses/")
+            || path.starts_with("/workers/");
+        if invalid_shape || conflicts_with_builtin || !seen.insert(path) {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!("invalid or conflicting extra generate path: {path}"),
+            ));
+        }
+    }
+    Ok(())
+}
+
 /// Build the Axum application with all routes and middleware using the
 /// current runtime OpenTelemetry state.
 pub fn build_app(
@@ -698,13 +756,32 @@ pub fn build_app(
     cors_allowed_origins: Vec<String>,
     enable_transparent_proxy: bool,
 ) -> Router {
-    build_app_with_request_tracing(
+    build_app_with_generate_paths(
+        app_state,
+        max_payload_size,
+        request_id_headers,
+        cors_allowed_origins,
+        enable_transparent_proxy,
+        &[],
+    )
+}
+
+pub fn build_app_with_generate_paths(
+    app_state: Arc<AppState>,
+    max_payload_size: usize,
+    request_id_headers: Vec<String>,
+    cors_allowed_origins: Vec<String>,
+    enable_transparent_proxy: bool,
+    extra_generate_paths: &[String],
+) -> Router {
+    build_app_with_request_tracing_and_generate_paths(
         app_state,
         max_payload_size,
         request_id_headers,
         cors_allowed_origins,
         enable_transparent_proxy,
         crate::otel_trace::is_otel_enabled(),
+        extra_generate_paths,
     )
 }
 
@@ -717,8 +794,28 @@ pub fn build_app_with_request_tracing(
     enable_transparent_proxy: bool,
     enable_request_tracing: bool,
 ) -> Router {
+    build_app_with_request_tracing_and_generate_paths(
+        app_state,
+        max_payload_size,
+        request_id_headers,
+        cors_allowed_origins,
+        enable_transparent_proxy,
+        enable_request_tracing,
+        &[],
+    )
+}
+
+pub fn build_app_with_request_tracing_and_generate_paths(
+    app_state: Arc<AppState>,
+    max_payload_size: usize,
+    request_id_headers: Vec<String>,
+    cors_allowed_origins: Vec<String>,
+    enable_transparent_proxy: bool,
+    enable_request_tracing: bool,
+    extra_generate_paths: &[String],
+) -> Router {
     // Create routes
-    let protected_routes = Router::new()
+    let mut protected_routes = Router::new()
         .route("/generate", post(generate))
         .route("/inference/v1/generate", post(inference_generate))
         .route("/v1/chat/completions", post(v1_chat_completions))
@@ -736,11 +833,16 @@ pub fn build_app_with_request_tracing(
         .route(
             "/v1/responses/{response_id}/input",
             get(v1_responses_list_input_items),
-        )
-        .route_layer(axum::middleware::from_fn_with_state(
-            app_state.clone(),
-            middleware::concurrency_limit_middleware,
-        ));
+        );
+
+    for path in extra_generate_paths {
+        protected_routes = protected_routes.route(path, post(extra_inference_generate));
+    }
+
+    let protected_routes = protected_routes.route_layer(axum::middleware::from_fn_with_state(
+        app_state.clone(),
+        middleware::concurrency_limit_middleware,
+    ));
 
     let public_routes = Router::new()
         .route("/liveness", get(liveness))
@@ -798,7 +900,16 @@ pub fn build_app_with_request_tracing(
 }
 
 pub async fn startup(config: ServerConfig) -> Result<(), Box<dyn std::error::Error>> {
+    startup_with_generate_paths(config, vec![]).await
+}
+
+pub async fn startup_with_generate_paths(
+    config: ServerConfig,
+    extra_generate_paths: Vec<String>,
+) -> Result<(), Box<dyn std::error::Error>> {
     println!("DEBUG: Server startup function called");
+
+    validate_extra_generate_paths(&extra_generate_paths)?;
 
     // Only initialize logging if not already done (for Python bindings support)
     static LOGGING_INITIALIZED: AtomicBool = AtomicBool::new(false);
@@ -1023,13 +1134,14 @@ pub async fn startup(config: ServerConfig) -> Result<(), Box<dyn std::error::Err
     // Enable transparent proxy for all routing modes
     let enable_transparent_proxy = true;
 
-    let app = build_app_with_request_tracing(
+    let app = build_app_with_request_tracing_and_generate_paths(
         app_state,
         config.max_payload_size,
         request_id_headers,
         config.router_config.cors_allowed_origins.clone(),
         enable_transparent_proxy,
         crate::otel_trace::is_otel_enabled(),
+        &extra_generate_paths,
     );
 
     let addr = format!("{}:{}", config.host, config.port);
@@ -1098,4 +1210,21 @@ fn create_cors_layer(allowed_origins: Vec<String>) -> tower_http::cors::CorsLaye
     };
 
     cors.max_age(Duration::from_secs(3600))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_extra_generate_paths;
+
+    #[test]
+    fn validates_extra_generate_paths() {
+        assert!(validate_extra_generate_paths(&["/custom/v1/generate".to_string()]).is_ok());
+        assert!(validate_extra_generate_paths(&["custom/v1/generate".to_string()]).is_err());
+        assert!(validate_extra_generate_paths(&["/inference/v1/generate".to_string()]).is_err());
+        assert!(validate_extra_generate_paths(&[
+            "/custom/v1/generate".to_string(),
+            "/custom/v1/generate".to_string(),
+        ])
+        .is_err());
+    }
 }

--- a/tests/api_endpoints_test.rs
+++ b/tests/api_endpoints_test.rs
@@ -25,8 +25,11 @@ struct TestContext {
 
 impl TestContext {
     async fn new(worker_configs: Vec<MockWorkerConfig>) -> Self {
-        // Create default router config
-        let config = RouterConfig {
+        Self::new_with_config(Self::default_config(), worker_configs).await
+    }
+
+    fn default_config() -> RouterConfig {
+        RouterConfig {
             mode: RoutingMode::Regular {
                 worker_urls: vec![],
             },
@@ -61,9 +64,7 @@ impl TestContext {
             enable_profiling: false,
             profile_timeout_secs: 30,
             kv_connector: vllm_router_rs::config::KvConnector::Nixl,
-        };
-
-        Self::new_with_config(config, worker_configs).await
+        }
     }
 
     async fn new_with_config(
@@ -125,6 +126,16 @@ impl TestContext {
             Arc::clone(&self.router),
             self.client.clone(),
             &self.config,
+        )
+    }
+
+    async fn create_app_with_generate_paths(&self, paths: &[String]) -> axum::Router {
+        common::test_app::create_test_app_with_tracing_and_generate_paths(
+            Arc::clone(&self.router),
+            self.client.clone(),
+            &self.config,
+            false,
+            paths,
         )
     }
 
@@ -276,6 +287,7 @@ mod health_tests {
 #[cfg(test)]
 mod generation_tests {
     use super::*;
+    use common::mock_worker::{clear_captured_requests, get_captured_requests};
 
     #[tokio::test]
     async fn test_generate_success() {
@@ -314,6 +326,91 @@ mod generation_tests {
         let meta_info = &body_json["meta_info"];
         assert!(meta_info.get("finish_reason").is_some());
         assert_eq!(meta_info["finish_reason"]["type"], "stop");
+
+        ctx.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn test_extra_generate_path_cache_aware_tracks_inflight_load() {
+        let config = RouterConfig {
+            policy: PolicyConfig::CacheAware {
+                cache_threshold: 0.0,
+                balance_abs_threshold: 0,
+                balance_rel_threshold: 1.0,
+                eviction_interval_secs: 30,
+                max_tree_size: 10_000,
+            },
+            ..TestContext::default_config()
+        };
+
+        let ctx = TestContext::new_with_config(
+            config,
+            (0..2)
+                .map(|_| MockWorkerConfig {
+                    port: 0,
+                    worker_type: WorkerType::Regular,
+                    health_status: HealthStatus::Healthy,
+                    response_delay_ms: 500,
+                    fail_rate: 0.0,
+                })
+                .collect(),
+        )
+        .await;
+        let ports = [ctx.workers[0].port().await, ctx.workers[1].port().await];
+        for port in ports {
+            clear_captured_requests(port);
+        }
+        let app = ctx
+            .create_app_with_generate_paths(&["/custom/v1/generate".to_string()])
+            .await;
+
+        let request = || {
+            Request::builder()
+                .method("POST")
+                .uri("/custom/v1/generate")
+                .header(CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    json!({
+                        "token_ids": [1, 2, 3],
+                        "sampling_params": {"max_tokens": 4},
+                        "custom_request_field": "preserved"
+                    })
+                    .to_string(),
+                ))
+                .unwrap()
+        };
+
+        let first = tokio::spawn(app.clone().oneshot(request()));
+        tokio::time::timeout(tokio::time::Duration::from_secs(2), async {
+            loop {
+                if ports
+                    .iter()
+                    .map(|port| get_captured_requests(*port).len())
+                    .sum::<usize>()
+                    == 1
+                {
+                    break;
+                }
+                tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .unwrap();
+
+        let second = tokio::spawn(app.oneshot(request()));
+        let first_response = first.await.unwrap().unwrap();
+        assert_eq!(first_response.status(), StatusCode::OK);
+        let first_body = axum::body::to_bytes(first_response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let first_body: serde_json::Value = serde_json::from_slice(&first_body).unwrap();
+        assert_eq!(first_body["choices"][0]["token_ids"], json!([1, 2, 3]));
+        assert_eq!(first_body["custom_request_field"], "preserved");
+
+        assert_eq!(second.await.unwrap().unwrap().status(), StatusCode::OK);
+
+        assert_eq!(get_captured_requests(ports[0]).len(), 1);
+        assert_eq!(get_captured_requests(ports[1]).len(), 1);
 
         ctx.shutdown().await;
     }

--- a/tests/common/mock_worker.rs
+++ b/tests/common/mock_worker.rs
@@ -58,6 +58,10 @@ impl MockWorker {
         }
     }
 
+    pub async fn port(&self) -> u16 {
+        self.config.read().await.port
+    }
+
     /// Start the mock worker server
     pub async fn start(&mut self) -> Result<String, Box<dyn std::error::Error>> {
         let config = self.config.clone();
@@ -76,6 +80,7 @@ impl MockWorker {
             .route("/get_server_info", get(server_info_handler))
             .route("/get_model_info", get(model_info_handler))
             .route("/generate", post(generate_handler))
+            .route("/custom/v1/generate", post(custom_generate_handler))
             .route("/v1/chat/completions", post(chat_completions_handler))
             .route("/v1/completions", post(completions_handler))
             .route("/v1/rerank", post(rerank_handler))
@@ -380,6 +385,29 @@ async fn generate_handler(
         }))
         .into_response()
     }
+}
+
+async fn custom_generate_handler(
+    State(config): State<Arc<RwLock<MockWorkerConfig>>>,
+    headers: axum::http::HeaderMap,
+    Json(payload): Json<serde_json::Value>,
+) -> Response {
+    let config = config.read().await;
+
+    capture_request(config.port, "/custom/v1/generate", &headers);
+
+    if config.response_delay_ms > 0 {
+        tokio::time::sleep(tokio::time::Duration::from_millis(config.response_delay_ms)).await;
+    }
+
+    Json(json!({
+        "choices": [{
+            "token_ids": payload["token_ids"],
+            "finish_reason": "stop"
+        }],
+        "custom_request_field": payload["custom_request_field"]
+    }))
+    .into_response()
 }
 
 async fn chat_completions_handler(

--- a/tests/common/test_app.rs
+++ b/tests/common/test_app.rs
@@ -5,7 +5,7 @@ use vllm_router_rs::{
     config::RouterConfig,
     otel_trace,
     routers::RouterTrait,
-    server::{build_app_with_request_tracing, AppContext, AppState},
+    server::{build_app_with_request_tracing_and_generate_paths, AppContext, AppState},
 };
 
 /// Create a test Axum application using the actual server's build_app function
@@ -25,6 +25,23 @@ pub fn create_test_app_with_tracing(
     client: Client,
     router_config: &RouterConfig,
     enable_request_tracing: bool,
+) -> Router {
+    create_test_app_with_tracing_and_generate_paths(
+        router,
+        client,
+        router_config,
+        enable_request_tracing,
+        &[],
+    )
+}
+
+#[allow(dead_code)]
+pub fn create_test_app_with_tracing_and_generate_paths(
+    router: Arc<dyn RouterTrait>,
+    client: Client,
+    router_config: &RouterConfig,
+    enable_request_tracing: bool,
+    extra_generate_paths: &[String],
 ) -> Router {
     // Create AppContext
     let app_context = Arc::new(
@@ -57,12 +74,13 @@ pub fn create_test_app_with_tracing(
     });
 
     // Use the actual server's build_app function
-    build_app_with_request_tracing(
+    build_app_with_request_tracing_and_generate_paths(
         app_state,
         router_config.max_payload_size,
         request_id_headers,
         router_config.cors_allowed_origins.clone(),
         true, // enable_transparent_proxy
         enable_request_tracing,
+        extra_generate_paths,
     )
 }


### PR DESCRIPTION
## Purpose

Extensions can expose inference-generate-compatible endpoints beyond `/inference/v1/generate`. Add `extra_generate_paths` and `--extra-generate-paths` so configured endpoints use existing typed routing instead of transparent fallback.

Configured paths:

- validate with `InferenceGenerateRequest`
- extract `token_ids` for cache-aware routing
- forward to same worker path
- use existing retries, circuit breaking, load accounting, authorization, and concurrency limits
- support regular and prefill/decode routers

Built-in handlers and unconfigured fallback behavior remain unchanged. Invalid, duplicate, dynamic, or conflicting paths fail startup validation.

Cancellation-safe global load accounting remains separate in #200. Related consumer update: [NovaSky-AI/SkyRL#1988](https://github.com/NovaSky-AI/SkyRL/pull/1988).

## Test Plan

- Register `/custom/v1/generate` against two delayed workers.
- Send overlapping requests and verify cache-aware routing accounts for in-flight load.
- Verify extension JSON fields survive typed forwarding.
- Verify prefill/decode routing clamps nested sampling limits.
- Validate Python and Rust configuration surfaces and reserved-route rejection.

## Test Result

- `make fmt`: passed.
- `make check`: passed with three existing Clippy warnings.
- `cargo test --all-features`: passed, including 486 library tests and 48 API endpoint tests.
- `uv run --extra dev pytest py_test/unit -q`: 109 passed, 4 skipped.
- `uvx black --check`: passed for touched Python files.
- `uvx ruff check`: passed for touched Python files.
- `git diff --check`: passed.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] Purpose documented.
- [x] Test plan documented.
- [x] Test results documented.
</details>