### PR TITLE
fix(router): make load accounting cancellation-safe

### DIFF
--- a/src/core/worker.rs
+++ b/src/core/worker.rs
@@ -884,10 +884,6 @@ pub fn start_health_checker(
         let mut interval =
             tokio::time::interval(tokio::time::Duration::from_secs(check_interval_secs));
 
-        // Counter for periodic load reset (every 10 health check cycles)
-        let mut check_count = 0u64;
-        const LOAD_RESET_INTERVAL: u64 = 10;
-
         loop {
             interval.tick().await;
 
@@ -897,8 +893,6 @@ pub fn start_health_checker(
                 break;
             }
 
-            check_count += 1;
-
             // Check health of all workers
             let workers_to_check = match workers.read() {
                 Ok(guard) => guard.clone(),
@@ -907,22 +901,6 @@ pub fn start_health_checker(
                     continue;
                 }
             };
-
-            // Periodically reset load counters to prevent drift
-            // Only do this when we believe all workers should be idle
-            if check_count.is_multiple_of(LOAD_RESET_INTERVAL) {
-                let max_load = workers_to_check.iter().map(|w| w.load()).max().unwrap_or(0);
-                // Only reset if load appears to be very low (likely drift)
-                if max_load <= 2 {
-                    tracing::debug!(
-                        "Resetting load counters to prevent drift (max_load: {})",
-                        max_load
-                    );
-                    for worker in &workers_to_check {
-                        worker.reset_load();
-                    }
-                }
-            }
 
             // Perform health checks concurrently
             let health_checks = workers_to_check.iter().map(|worker| {

--- a/src/core/worker.rs
+++ b/src/core/worker.rs
@@ -815,6 +815,7 @@ pub fn workers_to_urls(workers: &[Box<dyn Worker>]) -> Vec<String> {
 /// RAII guard for worker load management
 pub struct WorkerLoadGuard<'a> {
     workers: Vec<&'a dyn Worker>,
+    owned_worker: Option<Arc<dyn Worker>>,
 }
 
 impl<'a> WorkerLoadGuard<'a> {
@@ -823,6 +824,7 @@ impl<'a> WorkerLoadGuard<'a> {
         worker.increment_load();
         Self {
             workers: vec![worker],
+            owned_worker: None,
         }
     }
 
@@ -832,7 +834,21 @@ impl<'a> WorkerLoadGuard<'a> {
         for worker in &workers {
             worker.increment_load();
         }
-        Self { workers }
+        Self {
+            workers,
+            owned_worker: None,
+        }
+    }
+}
+
+impl WorkerLoadGuard<'static> {
+    /// Create an owned guard that can follow a worker into a response body.
+    pub fn new_owned(worker: Arc<dyn Worker>) -> Self {
+        worker.increment_load();
+        Self {
+            workers: Vec::new(),
+            owned_worker: Some(worker),
+        }
     }
 }
 
@@ -840,6 +856,9 @@ impl<'a> Drop for WorkerLoadGuard<'a> {
     fn drop(&mut self) {
         // Decrement load counters for all workers
         for worker in &self.workers {
+            worker.decrement_load();
+        }
+        if let Some(worker) = &self.owned_worker {
             worker.decrement_load();
         }
     }

--- a/src/core/worker_registry.rs
+++ b/src/core/worker_registry.rs
@@ -364,10 +364,6 @@ impl WorkerRegistry {
             let mut interval =
                 tokio::time::interval(tokio::time::Duration::from_secs(check_interval_secs));
 
-            // Counter for periodic load reset (every 10 health check cycles)
-            let mut check_count = 0u64;
-            const LOAD_RESET_INTERVAL: u64 = 10;
-
             loop {
                 interval.tick().await;
 
@@ -386,15 +382,6 @@ impl WorkerRegistry {
                 // Perform health checks
                 for worker in &workers {
                     let _ = worker.check_health_async().await; // Use async version directly
-                }
-
-                // Reset loads periodically
-                check_count += 1;
-                if check_count.is_multiple_of(LOAD_RESET_INTERVAL) {
-                    tracing::debug!("Resetting worker loads (cycle {})", check_count);
-                    for worker in &workers {
-                        worker.reset_load();
-                    }
                 }
             }
         });

--- a/src/routers/http/router.rs
+++ b/src/routers/http/router.rs
@@ -47,6 +47,25 @@ pub struct Router {
     _load_monitor_handle: Option<Arc<tokio::task::JoinHandle<()>>>,
 }
 
+struct RequestLoadGuard {
+    worker: Arc<dyn Worker>,
+}
+
+impl RequestLoadGuard {
+    fn new(worker: Arc<dyn Worker>) -> Self {
+        worker.increment_load();
+        RouterMetrics::set_running_requests(worker.url(), worker.load());
+        Self { worker }
+    }
+}
+
+impl Drop for RequestLoadGuard {
+    fn drop(&mut self) {
+        self.worker.decrement_load();
+        RouterMetrics::set_running_requests(self.worker.url(), self.worker.load());
+    }
+}
+
 impl Router {
     /// Create a new router with injected policy and client
     #[allow(clippy::too_many_arguments)]
@@ -545,7 +564,6 @@ impl Router {
         model_id: Option<&str>,
     ) -> Response {
         let start = Instant::now();
-        let is_stream = typed_req.is_stream();
         let text = typed_req.extract_text_for_routing();
 
         let response = RetryExecutor::execute_response_with_retry(
@@ -571,48 +589,20 @@ impl Router {
                     None => self.policy_registry.get_default_policy(),
                 };
 
-                let load_incremented = if policy.name() == "cache_aware" {
-                    worker.increment_load();
-                    RouterMetrics::set_running_requests(worker.url(), worker.load());
-                    true
-                } else {
-                    false
-                };
-
-                // Keep a clone for potential cleanup on retry
-                let worker_for_cleanup = if load_incremented {
-                    Some(worker.clone())
+                let load_guard = if policy.name() == "cache_aware" {
+                    Some(RequestLoadGuard::new(worker.clone()))
                 } else {
                     None
                 };
 
                 let response = self
-                    .send_typed_request(
-                        headers,
-                        typed_req,
-                        route,
-                        worker.url(),
-                        is_stream,
-                        load_incremented,
-                    )
+                    .send_typed_request(headers, typed_req, route, worker.url(), load_guard)
                     .await;
 
                 // Client errors (4xx) are not worker failures - only server errors (5xx)
                 // should count against the circuit breaker.
                 let status = response.status();
                 worker.record_outcome(status.is_success() || status.is_client_error());
-
-                // For retryable failures, we need to decrement load since send_typed_request
-                // won't have done it (it only decrements on success or non-retryable failures)
-                if is_retryable_status(response.status()) && load_incremented {
-                    if let Some(cleanup_worker) = worker_for_cleanup {
-                        cleanup_worker.decrement_load();
-                        RouterMetrics::set_running_requests(
-                            cleanup_worker.url(),
-                            cleanup_worker.load(),
-                        );
-                    }
-                }
 
                 response
             },
@@ -764,15 +754,15 @@ impl Router {
     }
 
     // Send typed request directly without conversion
-    async fn send_typed_request<T: serde::Serialize>(
+    async fn send_typed_request<T: GenerationRequest + serde::Serialize>(
         &self,
         headers: Option<&HeaderMap>,
         typed_req: &T,
         route: &str,
         worker_url: &str,
-        is_stream: bool,
-        load_incremented: bool, // Whether load was incremented for this request
+        load_guard: Option<RequestLoadGuard>,
     ) -> Response {
+        let is_stream = typed_req.is_stream();
         let (mut request_builder, extracted_dp_rank, request_url) =
             if self.intra_node_data_parallel_size > 1 {
                 let (worker_url_prefix, dp_rank) = match dp_utils::extract_dp_rank(worker_url) {
@@ -856,14 +846,6 @@ impl Router {
                     worker_url, route, e
                 );
 
-                // Decrement load on error if it was incremented
-                if load_incremented {
-                    if let Some(worker) = self.worker_registry.get_by_url(worker_url) {
-                        worker.decrement_load();
-                        RouterMetrics::set_running_requests(worker_url, worker.load());
-                    }
-                }
-
                 return (
                     StatusCode::INTERNAL_SERVER_ERROR,
                     format!("Request failed: {}", e),
@@ -887,87 +869,12 @@ impl Router {
                     response
                 }
                 Err(e) => {
-                    // IMPORTANT: Decrement load on error before returning
-                    if load_incremented {
-                        if let Some(worker) = self.worker_registry.get_by_url(worker_url) {
-                            worker.decrement_load();
-                            RouterMetrics::set_running_requests(worker_url, worker.load());
-                        }
-                    }
-
                     let error_msg = format!("Failed to get response body: {}", e);
                     (StatusCode::INTERNAL_SERVER_ERROR, error_msg).into_response()
                 }
             };
-
-            // Decrement load counter for non-streaming requests if it was incremented
-            if load_incremented {
-                if let Some(worker) = self.worker_registry.get_by_url(worker_url) {
-                    worker.decrement_load();
-                    RouterMetrics::set_running_requests(worker_url, worker.load());
-                }
-            }
-
-            response
-        } else if load_incremented {
-            // For streaming with load tracking, we need to manually decrement when done
-            let registry = Arc::clone(&self.worker_registry);
-            let worker_url = worker_url.to_string();
-
-            // Preserve headers for streaming response
-            let mut response_headers = header_utils::preserve_response_headers(res.headers());
-            // Ensure we set the correct content-type for SSE
-            response_headers.insert(CONTENT_TYPE, HeaderValue::from_static("text/event-stream"));
-
-            let stream = res.bytes_stream();
-            let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
-
-            // Spawn task to forward stream and detect completion
-            tokio::spawn(async move {
-                let mut stream = stream;
-                let mut decremented = false;
-                while let Some(chunk) = stream.next().await {
-                    match chunk {
-                        Ok(bytes) => {
-                            // Check for stream end marker
-                            if bytes
-                                .as_ref()
-                                .windows(12)
-                                .any(|window| window == b"data: [DONE]")
-                            {
-                                if let Some(worker) = registry.get_by_url(&worker_url) {
-                                    worker.decrement_load();
-                                    RouterMetrics::set_running_requests(&worker_url, worker.load());
-                                    decremented = true;
-                                }
-                            }
-                            if tx.send(Ok(bytes)).is_err() {
-                                break;
-                            }
-                        }
-                        Err(e) => {
-                            let _ = tx.send(Err(format!("Stream error: {}", e)));
-                            break;
-                        }
-                    }
-                }
-                if !decremented {
-                    if let Some(worker) = registry.get_by_url(&worker_url) {
-                        worker.decrement_load();
-                        RouterMetrics::set_running_requests(&worker_url, worker.load());
-                    }
-                }
-            });
-
-            let stream = UnboundedReceiverStream::new(rx);
-            let body = Body::from_stream(stream);
-
-            let mut response = Response::new(body);
-            *response.status_mut() = status;
-            *response.headers_mut() = response_headers;
             response
         } else {
-            // For requests without load tracking, just stream
             // Preserve headers for streaming response
             let mut response_headers = header_utils::preserve_response_headers(res.headers());
             // Ensure we set the correct content-type for SSE
@@ -978,6 +885,7 @@ impl Router {
 
             // Spawn task to forward stream
             tokio::spawn(async move {
+                let _load_guard = load_guard;
                 let mut stream = stream;
                 while let Some(chunk) = stream.next().await {
                     match chunk {
@@ -1777,6 +1685,43 @@ impl RouterTrait for Router {
 mod tests {
     use super::*;
     use std::collections::HashMap;
+
+    #[test]
+    fn request_load_guard_preserves_concurrent_load() {
+        let worker = Arc::new(BasicWorker::new(
+            "http://worker:8080".to_string(),
+            WorkerType::Regular,
+        ));
+        worker.increment_load();
+
+        {
+            let _guard = RequestLoadGuard::new(worker.clone());
+            assert_eq!(worker.load(), 2);
+        }
+
+        assert_eq!(worker.load(), 1);
+    }
+
+    #[tokio::test]
+    async fn request_load_guard_releases_load_when_request_is_cancelled() {
+        let worker = Arc::new(BasicWorker::new(
+            "http://worker:8080".to_string(),
+            WorkerType::Regular,
+        ));
+        let worker_for_request: Arc<dyn Worker> = worker.clone();
+        let request = tokio::spawn(async move {
+            let _guard = RequestLoadGuard::new(worker_for_request);
+            std::future::pending::<()>().await;
+        });
+
+        while worker.load() == 0 {
+            tokio::task::yield_now().await;
+        }
+        request.abort();
+        let _ = request.await;
+
+        assert_eq!(worker.load(), 0);
+    }
 
     fn create_test_regular_router() -> Router {
         // Create registries

--- a/src/routers/http/router.rs
+++ b/src/routers/http/router.rs
@@ -887,16 +887,22 @@ impl Router {
             tokio::spawn(async move {
                 let _load_guard = load_guard;
                 let mut stream = stream;
-                while let Some(chunk) = stream.next().await {
-                    match chunk {
-                        Ok(bytes) => {
-                            if tx.send(Ok(bytes)).is_err() {
-                                break;
+                loop {
+                    tokio::select! {
+                        _ = tx.closed() => break,
+                        chunk = stream.next() => {
+                            match chunk {
+                                Some(Ok(bytes)) => {
+                                    if tx.send(Ok(bytes)).is_err() {
+                                        break;
+                                    }
+                                }
+                                Some(Err(e)) => {
+                                    let _ = tx.send(Err(format!("Stream error: {}", e)));
+                                    break;
+                                }
+                                None => break,
                             }
-                        }
-                        Err(e) => {
-                            let _ = tx.send(Err(format!("Stream error: {}", e)));
-                            break;
                         }
                     }
                 }
@@ -1721,6 +1727,78 @@ mod tests {
         let _ = request.await;
 
         assert_eq!(worker.load(), 0);
+    }
+
+    #[tokio::test]
+    async fn streaming_client_drop_releases_load_while_upstream_stalls() {
+        use axum::{routing::post, Router as AxumRouter};
+        use std::convert::Infallible;
+        use tokio::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let worker_url = format!("http://{}", listener.local_addr().unwrap());
+        let app = AxumRouter::new().route(
+            "/generate",
+            post(|| async {
+                let body = Body::from_stream(futures_util::stream::pending::<
+                    Result<bytes::Bytes, Infallible>,
+                >());
+                Response::builder()
+                    .status(StatusCode::OK)
+                    .header(CONTENT_TYPE, "text/event-stream")
+                    .body(body)
+                    .unwrap()
+            }),
+        );
+        let _server = tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        let worker_registry = Arc::new(WorkerRegistry::new());
+        let worker = Arc::new(BasicWorker::new(worker_url, WorkerType::Regular));
+        worker_registry.register(worker.clone());
+        let policy_registry = Arc::new(PolicyRegistry::new(
+            crate::config::types::PolicyConfig::CacheAware {
+                cache_threshold: 0.5,
+                balance_abs_threshold: 32,
+                balance_rel_threshold: 1.5,
+                eviction_interval_secs: 60,
+                max_tree_size: 1000,
+            },
+        ));
+        let (_, rx) = tokio::sync::watch::channel(HashMap::new());
+        let router = Router {
+            worker_registry,
+            policy_registry,
+            client: Client::new(),
+            worker_startup_timeout_secs: 5,
+            worker_startup_check_interval_secs: 1,
+            intra_node_data_parallel_size: 1,
+            api_key: None,
+            retry_config: RetryConfig::default(),
+            circuit_breaker_config: CircuitBreakerConfig::default(),
+            _worker_loads: Arc::new(rx),
+            _load_monitor_handle: None,
+        };
+        let request: GenerateRequest =
+            serde_json::from_str(r#"{"text":"hello","stream":true}"#).unwrap();
+
+        let response = tokio::time::timeout(
+            Duration::from_secs(5),
+            router.route_typed_request(None, &request, "/generate", None),
+        )
+        .await
+        .expect("response headers should arrive while the body is stalled");
+        assert_eq!(worker.load(), 1);
+
+        drop(response);
+        tokio::time::timeout(Duration::from_secs(5), async {
+            while worker.load() != 0 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("client disconnect should release the worker load");
     }
 
     fn create_test_regular_router() -> Router {

--- a/src/routers/http/vllm_pd_router.rs
+++ b/src/routers/http/vllm_pd_router.rs
@@ -6,7 +6,7 @@ use super::pd_router::PdRouterBase;
 use super::pd_types::{error_chain, PDRouterError};
 use super::vllm_service_discovery::{MoriIOTransferMode, ServiceRegistry, ServiceType};
 use crate::config::KvConnector;
-use crate::core::{BasicWorker, Worker, WorkerType};
+use crate::core::{BasicWorker, Worker, WorkerLoadGuard, WorkerType};
 use crate::metrics::RouterMetrics;
 use crate::otel_http::{self, ClientRequestOptions};
 use crate::policies::PolicyRegistry;
@@ -1174,8 +1174,7 @@ impl VllmPDRouter {
             path
         );
 
-        // Increment prefill load at the start of the prefill phase
-        prefill_worker.increment_load();
+        let prefill_load = WorkerLoadGuard::new(prefill_worker.as_ref());
 
         let prefill_zmq_addr =
             self.get_zmq_address(prefill_worker.base_url(), ServiceType::Prefill);
@@ -1270,7 +1269,6 @@ impl VllmPDRouter {
         {
             Ok(resp) => resp,
             Err(e) => {
-                prefill_worker.decrement_load();
                 let full_error = error_chain(&e);
                 let duration = start_time.elapsed();
                 RouterMetrics::record_pd_prefill_error(&prefill_base_url);
@@ -1292,7 +1290,6 @@ impl VllmPDRouter {
         let prefill_bytes = match prefill_response.bytes().await {
             Ok(bytes) => bytes,
             Err(e) => {
-                prefill_worker.decrement_load();
                 let full_error = error_chain(&e);
                 let duration = start_time.elapsed();
                 RouterMetrics::record_pd_prefill_error(&prefill_base_url);
@@ -1322,7 +1319,6 @@ impl VllmPDRouter {
         let prefill_response_json: Value = match serde_json::from_slice(&prefill_bytes) {
             Ok(json) => json,
             Err(e) => {
-                prefill_worker.decrement_load();
                 let duration = start_time.elapsed();
                 RouterMetrics::record_pd_prefill_error(&prefill_base_url);
                 RouterMetrics::record_pd_request(path);
@@ -1348,9 +1344,8 @@ impl VllmPDRouter {
         // Stop profiling on prefill server after its work is done
         self.stop_profiling(&prefill_base_url).await;
 
-        // Prefill phase complete: decrement prefill load, increment decode load
-        prefill_worker.decrement_load();
-        decode_worker.increment_load();
+        drop(prefill_load);
+        let decode_load = WorkerLoadGuard::new(decode_worker.as_ref());
 
         debug!("✅ vLLM Stage 1 completed, starting Stage 2 - Decode");
 
@@ -1451,7 +1446,6 @@ impl VllmPDRouter {
         {
             Ok(resp) => resp,
             Err(e) => {
-                decode_worker.decrement_load();
                 let full_error = error_chain(&e);
                 let duration = start_time.elapsed();
                 RouterMetrics::record_pd_decode_error(&decode_base_url);
@@ -1467,8 +1461,7 @@ impl VllmPDRouter {
         // Stop profiling on decode server after response received
         self.stop_profiling(&decode_base_url).await;
 
-        // Decode phase complete: decrement decode load
-        decode_worker.decrement_load();
+        drop(decode_load);
 
         let status = decode_response.status();
         let headers = decode_response.headers().clone();
@@ -2419,6 +2412,29 @@ impl WorkerManagement for VllmPDRouter {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[tokio::test]
+    async fn worker_load_guard_releases_load_when_cancelled() {
+        let worker = Arc::new(BasicWorker::new(
+            "http://worker:8080".to_string(),
+            WorkerType::Prefill {
+                bootstrap_port: None,
+            },
+        ));
+        let worker_for_request = worker.clone();
+        let request = tokio::spawn(async move {
+            let _guard = WorkerLoadGuard::new(worker_for_request.as_ref());
+            std::future::pending::<()>().await;
+        });
+
+        while worker.load() == 0 {
+            tokio::task::yield_now().await;
+        }
+        request.abort();
+        let _ = request.await;
+
+        assert_eq!(worker.load(), 0);
+    }
 
     #[test]
     fn test_discovery_health_requires_prefill_and_decode_workers() {

--- a/src/routers/http/vllm_pd_router.rs
+++ b/src/routers/http/vllm_pd_router.rs
@@ -18,10 +18,14 @@ use axum::{
     http::{HeaderMap, Method, StatusCode},
     response::{IntoResponse, Response},
 };
+use bytes::Bytes;
+use futures_util::Stream;
 use serde_json::{json, Value};
 use std::collections::HashMap;
+use std::pin::Pin;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
+use std::task::{Context, Poll};
 use std::time::Instant;
 use tokio::sync::Mutex;
 use tracing::{debug, error, info, warn};
@@ -66,6 +70,35 @@ pub struct VllmPDRouter {
 /// Transfer ID prefix used by MoRI-IO to correlate prefill and decode legs.
 /// Must match `MoRIIOConstants.TRANSFER_PREFIX` in the vLLM Python connector.
 const MORIIO_TRANSFER_PREFIX: &str = "tx";
+
+struct LoadTrackedDecodeStream<E> {
+    inner: Pin<Box<dyn Stream<Item = Result<Bytes, E>> + Send>>,
+    load_guard: Option<WorkerLoadGuard<'static>>,
+}
+
+impl<E: 'static> LoadTrackedDecodeStream<E> {
+    fn new(
+        stream: impl Stream<Item = Result<Bytes, E>> + Send + 'static,
+        load_guard: WorkerLoadGuard<'static>,
+    ) -> Self {
+        Self {
+            inner: Box::pin(stream),
+            load_guard: Some(load_guard),
+        }
+    }
+}
+
+impl<E: 'static> Stream for LoadTrackedDecodeStream<E> {
+    type Item = Result<Bytes, E>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let poll = self.inner.as_mut().poll_next(cx);
+        if matches!(&poll, Poll::Ready(None) | Poll::Ready(Some(Err(_)))) {
+            self.load_guard.take();
+        }
+        poll
+    }
+}
 
 /// Discovery-backed P/D routing is ready only after both worker types register.
 /// Without this guard, `PdRouterBase::health` sees the unused static registry and
@@ -1345,7 +1378,7 @@ impl VllmPDRouter {
         self.stop_profiling(&prefill_base_url).await;
 
         drop(prefill_load);
-        let decode_load = WorkerLoadGuard::new(decode_worker.as_ref());
+        let decode_load = WorkerLoadGuard::new_owned(decode_worker.clone());
 
         debug!("✅ vLLM Stage 1 completed, starting Stage 2 - Decode");
 
@@ -1461,8 +1494,6 @@ impl VllmPDRouter {
         // Stop profiling on decode server after response received
         self.stop_profiling(&decode_base_url).await;
 
-        drop(decode_load);
-
         let status = decode_response.status();
         let headers = decode_response.headers().clone();
 
@@ -1506,6 +1537,7 @@ impl VllmPDRouter {
                             decode_url, e
                         ),
                     })?;
+            drop(decode_load);
 
             // Parse decode response as JSON
             let mut decode_json: Value =
@@ -1541,7 +1573,6 @@ impl VllmPDRouter {
                 }
             })
         } else {
-            // No logprobs merging needed - return decode response as-is (streaming or no logprobs)
             debug!(
                 "No logprobs merging needed (streaming={}, needs_logprobs={})",
                 is_streaming, needs_logprobs
@@ -1554,7 +1585,10 @@ impl VllmPDRouter {
                 }
             }
 
-            let body = Body::from_stream(decode_response.bytes_stream());
+            let body = Body::from_stream(LoadTrackedDecodeStream::new(
+                decode_response.bytes_stream(),
+                decode_load,
+            ));
             response_builder
                 .body(body)
                 .map_err(|e| PDRouterError::NetworkError {
@@ -2413,6 +2447,46 @@ mod tests {
     use super::*;
     use serde_json::json;
 
+    fn test_vllm_pd_router() -> VllmPDRouter {
+        let worker_registry = Arc::new(crate::core::WorkerRegistry::new());
+        let policy_registry =
+            Arc::new(PolicyRegistry::new(crate::config::PolicyConfig::RoundRobin));
+        let pd_router = PdRouterBase {
+            worker_registry,
+            policy_registry: policy_registry.clone(),
+            worker_startup_timeout_secs: 5,
+            worker_startup_check_interval_secs: 1,
+            worker_loads: Arc::new(tokio::sync::watch::channel(HashMap::new()).1),
+            load_monitor_handle: None,
+            client: reqwest::Client::new(),
+            circuit_breaker_config: crate::core::CircuitBreakerConfig::default(),
+            dp_size: 1,
+        };
+        VllmPDRouter {
+            pd_router,
+            service_registry: Arc::new(ServiceRegistry::new()),
+            http_client: reqwest::Client::new(),
+            policy_registry,
+            use_discovery: false,
+            enable_profiling: false,
+            profile_timeout_secs: 0,
+            profiling_tasks: Arc::new(Mutex::new(HashMap::new())),
+            intra_node_data_parallel_size: 1,
+            prefill_dp_round_robin: Arc::new(AtomicUsize::new(0)),
+            kv_connector: KvConnector::Nixl,
+            mooncake_prefill_info: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    async fn spawn_test_server(app: axum::Router) -> String {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = format!("http://{}", listener.local_addr().unwrap());
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        url
+    }
+
     #[tokio::test]
     async fn worker_load_guard_releases_load_when_cancelled() {
         let worker = Arc::new(BasicWorker::new(
@@ -2433,6 +2507,107 @@ mod tests {
         request.abort();
         let _ = request.await;
 
+        assert_eq!(worker.load(), 0);
+    }
+
+    #[tokio::test]
+    async fn decode_load_follows_stalled_response_body() {
+        use axum::{http::header::CONTENT_TYPE, routing::post};
+        use std::convert::Infallible;
+
+        let prefill_url = spawn_test_server(axum::Router::new().route(
+            "/v1/chat/completions",
+            post(|| async { axum::Json(json!({"kv_transfer_params": {}})) }),
+        ))
+        .await;
+        let decode_url = spawn_test_server(axum::Router::new().route(
+            "/v1/chat/completions",
+            post(|| async {
+                let body =
+                    Body::from_stream(futures_util::stream::pending::<Result<Bytes, Infallible>>());
+                Response::builder()
+                    .status(StatusCode::OK)
+                    .header(CONTENT_TYPE, "text/event-stream")
+                    .body(body)
+                    .unwrap()
+            }),
+        ))
+        .await;
+
+        let prefill_worker: Arc<dyn Worker> = Arc::new(BasicWorker::new(
+            prefill_url,
+            WorkerType::Prefill {
+                bootstrap_port: None,
+            },
+        ));
+        let decode_worker: Arc<dyn Worker> =
+            Arc::new(BasicWorker::new(decode_url, WorkerType::Decode));
+        let response = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            test_vllm_pd_router().process_vllm_two_stage_request(
+                json!({
+                    "model": "test",
+                    "messages": [{"role": "user", "content": "hi"}],
+                    "stream": true,
+                }),
+                prefill_worker.clone(),
+                decode_worker.clone(),
+                "/v1/chat/completions",
+                None,
+            ),
+        )
+        .await
+        .expect("decode headers should arrive while the body is stalled")
+        .unwrap();
+
+        assert_eq!(prefill_worker.load(), 0);
+        assert_eq!(decode_worker.load(), 1);
+
+        drop(response);
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            while decode_worker.load() != 0 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("dropping the response body should release decode load");
+    }
+
+    #[tokio::test]
+    async fn decode_load_releases_at_response_eof() {
+        use futures_util::StreamExt;
+
+        let worker: Arc<dyn Worker> = Arc::new(BasicWorker::new(
+            "http://decode".to_string(),
+            WorkerType::Decode,
+        ));
+        let guard = WorkerLoadGuard::new_owned(worker.clone());
+        let mut stream = LoadTrackedDecodeStream::new(
+            futures_util::stream::empty::<Result<Bytes, reqwest::Error>>(),
+            guard,
+        );
+
+        assert_eq!(worker.load(), 1);
+        assert!(stream.next().await.is_none());
+        assert_eq!(worker.load(), 0);
+    }
+
+    #[tokio::test]
+    async fn decode_load_releases_on_response_error() {
+        use futures_util::StreamExt;
+
+        let worker: Arc<dyn Worker> = Arc::new(BasicWorker::new(
+            "http://decode".to_string(),
+            WorkerType::Decode,
+        ));
+        let guard = WorkerLoadGuard::new_owned(worker.clone());
+        let mut stream = LoadTrackedDecodeStream::new(
+            futures_util::stream::iter([Err::<Bytes, _>(std::io::Error::other("disconnected"))]),
+            guard,
+        );
+
+        assert_eq!(worker.load(), 1);
+        assert!(stream.next().await.unwrap().is_err());
         assert_eq!(worker.load(), 0);
     }
 


### PR DESCRIPTION
## Purpose

Cache-aware routing increments worker load before each typed request. Manual cleanup can miss cancellation paths, double-decrement some failures, and release streaming load before response body lifetime ends. Health checkers currently mask drift by resetting counters periodically, which can also erase valid load from long-running requests.

Use scoped load guards for regular and prefill/decode routing. Each request or phase now releases its counter exactly once when scope ends, including errors, retries, task cancellation, stream completion, and client disconnect. Remove periodic resets because counters now follow request lifetimes.

Endpoint registration remains separate in #199.

## Test Plan

- Cancel a regular typed request while its load guard is active and verify load returns to zero.
- Drop a regular streaming response after headers while the backend body stalls and verify load returns to zero.
- Cancel a prefill/decode phase while its guard is active and verify load returns to zero.
- Verify decode load remains active after headers until the response body is dropped.
- Verify decode EOF and body errors release load exactly once.
- Preserve concurrent pre-existing worker load when one request guard exits.
- Run the full Rust lint and test suite.

## Test Result

- `cargo fmt --all -- --check`: passed.
- `cargo clippy --all-targets --all-features -- -A clippy::result_unit_err -A clippy::chunks_exact_to_as_chunks -A clippy::result_large_err -A clippy::for_kv_map -D warnings`: passed. The four allowed lints are unrelated Rust 1.98 warnings in existing code.
- `cargo test --all-features`: passed, including 491 library tests, every integration suite, and 4 documentation tests; 1 documentation test was ignored.
- Focused response-lifetime regressions for regular and prefill/decode routing: passed.
- `git diff --check`: passed.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] Purpose documented.
- [x] Test plan documented.
- [x] Test results documented.
</details>