### PR TITLE
[CI][ROCm] Add MoRI XGMI and RDMA coverage

### DIFF
--- a/.buildkite/README.md
+++ b/.buildkite/README.md
@@ -64,6 +64,25 @@ The test runs in the pipeline at `.buildkite/pipeline.yml:97-132`:
 - Automatic retry (up to 2 attempts) for flaky failures
 - Manual retry option available
 
+### ROCm MoRI coverage
+
+The dedicated `router_rocm_mi300_2` queue adds two MI300X matrices, each with
+`read_mode=true` and `read_mode=false`:
+
+- `run_moriio_accuracy_test.sh` uses two GPUs on one host with the xGMI backend.
+- `run_moriio_rdma_accuracy_test.sh` uses one GPU on each of two hosts with the
+  RDMA backend.
+
+The xGMI group runs for same-repository pull requests, the default branch, and
+merge-queue builds. Trusted manual/API builds can set `RUN_ROCM_XGMI=1`. The
+RDMA matrix runs for scheduled builds with `NIGHTLY=1`, or trusted manual/API
+builds with `RUN_ROCM_RDMA=1`. Group-level filtering prevents Docker plugin
+hooks from running for untrusted fork pull requests.
+
+Both matrices use a digest-pinned ROCm vLLM image and run health, sanity, and
+500-example GSM8K accuracy checks. The RDMA job is coordinator-owned and
+controls the second host through the strict `vllm-router-rocm-worker` SSH alias.
+
 ### Environment Variables
 
 The test script supports these environment variables for customization:
@@ -145,6 +164,7 @@ Builds Docker image for the router.
 
 - `cpu_queue_premerge`: CPU-only tasks (builds, lints, unit tests)
 - `gpu_4_queue`: GPU tests requiring 4+ GPUs
+- `router_rocm_mi300_2`: dedicated two-node MI300X MoRI tests (`spawn=1`)
 - `default`: General purpose queue
 
 ## Adding New Tests

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,6 +3,8 @@
 
 env:
   RUST_IMAGE: "rust:1.95.0-bullseye"
+  # Pin the ROCm nightly used by the MoRI lane so dependency changes are explicit.
+  ROCM_VLLM_IMAGE: "vllm/vllm-openai-rocm:nightly@sha256:d22922d540810d90c5a3eafe91d3b4a62c2b881f3e990d0b7180b2875a5d176d"
   # Disable incremental compilation for consistent CI builds
   CARGO_INCREMENTAL: "0"
   # Enable full Rust backtraces for debugging
@@ -292,6 +294,140 @@ steps:
     depends_on: "build"
     artifact_paths:
       - "/tmp/router.log"
+
+  # This queue is intentionally separate from the shared amd_mi300_* queues.
+  # Those agents run with --no-plugins, while this lane needs the Docker plugin
+  # to provide the pinned vLLM/MoRI userspace on a two-GPU xGMI host. Put the
+  # condition on the group so fork builds cannot run plugin hooks.
+  - group: ":large_purple_circle: ROCm MoRI XGMI P/D"
+    key: "pd-disagg-moriio-tests"
+    if: |
+      build.branch == pipeline.default_branch ||
+      build.merge_queue.base_branch == pipeline.default_branch ||
+      (build.pull_request.id != null && build.pull_request.repository.fork == false) ||
+      ((build.source == "ui" || build.source == "api") &&
+       build.env("RUN_ROCM_XGMI") == "1")
+    steps:
+      - label: "ROCm MoRI XGMI (read_mode={{matrix.read_mode}}, 2 GPUs)"
+        key: "pd-disagg-moriio-test"
+        timeout_in_minutes: 60
+        matrix:
+          setup:
+            read_mode:
+              - "true"
+              - "false"
+        retry:
+          automatic:
+            - exit_status: "*"
+              limit: 1
+          manual:
+            allowed: true
+            reason: "Retry transient GPU-agent failures after inspecting the logs"
+        plugins:
+          - docker#v5.14.0:
+              image: "$ROCM_VLLM_IMAGE"
+              # vllm-openai images default to `vllm serve`; run the CI shell instead.
+              entrypoint: ""
+              workdir: /workdir
+              volumes:
+                - "/var/lib/buildkite-agent/.cache/huggingface:/root/.cache/huggingface"
+              devices:
+                - "/dev/kfd"
+                - "/dev/dri"
+              privileged: true
+              init: true
+              tty: false
+              ipc: host
+              mount-buildkite-agent: true
+              chown: true
+              chown-image: "busybox@sha256:dc2d74b28e4cf8984fa52af1f39bc7c3d9c73760b41a74d629f5d11b1ab28616"
+              shm-size: "256g"
+              security-opts:
+                - "seccomp=unconfined"
+              ulimits:
+                - "memlock=-1"
+                - "stack=67108864"
+              environment:
+                - "MORIIO_READ_MODE={{matrix.read_mode}}"
+                - "MORIIO_BACKEND=xgmi"
+                - "MODEL_NAMES=Qwen/Qwen3-0.6B"
+                - "ROUTER_BIN=/workdir/target/release/vllm-router"
+                - "LOG_DIR=/workdir/target/ci-logs/moriio-{{matrix.read_mode}}"
+                - "ENGINE_STARTUP_TIMEOUT=3600"
+              propagate-environment: true
+              command:
+                - bash
+                - -c
+                - |
+                  set -euo pipefail
+
+                  # Reuse the release binary produced by the CPU build step.
+                  buildkite-agent artifact download "target/release/vllm-router" .
+                  chmod +x target/release/vllm-router
+                  ldd target/release/vllm-router
+                  target/release/vllm-router --version
+
+                  # Pin the evaluation harness; vLLM and MoRI come from the pinned image.
+                  python3 -m pip install --no-cache-dir \
+                    requests \
+                    openai \
+                    'lm-eval[api]==0.4.12'
+
+                  bash py_test/e2e/pd_disagg_vllm/run_moriio_accuracy_test.sh
+        agents:
+          queue: "router_rocm_mi300_2"
+        depends_on: "build"
+        artifact_paths:
+          - "target/ci-logs/moriio-*/*.log"
+
+  # One coordinator agent owns the paired MI300X worker over a dedicated SSH
+  # link. Keeping this as one Buildkite job avoids coupled two-agent scheduling
+  # and guarantees that both halves are cleaned up together.
+  - label: ":large_purple_circle: ROCm MoRI RDMA P/D (read_mode={{matrix.read_mode}}, 2 nodes)"
+    key: "pd-disagg-moriio-rdma-test"
+    if: |
+      (build.source == "schedule" && build.env("NIGHTLY") == "1") ||
+      ((build.source == "ui" || build.source == "api") &&
+       build.env("RUN_ROCM_RDMA") == "1")
+    timeout_in_minutes: 75
+    matrix:
+      setup:
+        read_mode:
+          - "true"
+          - "false"
+    retry:
+      automatic:
+        - exit_status: "*"
+          limit: 1
+      manual:
+        allowed: true
+        reason: "Retry transient two-node GPU or RDMA failures after inspecting both node logs"
+    command: |
+      set -euo pipefail
+
+      buildkite-agent artifact download "target/release/vllm-router" .
+      chmod +x target/release/vllm-router
+      ldd target/release/vllm-router
+      target/release/vllm-router --version
+
+      export MORIIO_READ_MODE="{{matrix.read_mode}}"
+      export MODEL_NAMES="Qwen/Qwen3-0.6B"
+      export ROUTER_BIN="$$PWD/target/release/vllm-router"
+      export LOG_DIR="$$PWD/target/ci-logs/moriio-rdma-{{matrix.read_mode}}"
+      export ENGINE_STARTUP_TIMEOUT=3600
+      # amd_mori 1.0.0 is stable for sequential cross-node transfers on this
+      # cluster. Concurrency 10 remains covered by the same-host XGMI lane.
+      export NUM_LM_EVAL_CONCURRENT=1
+      export WORKER_SSH_HOST=vllm-router-rocm-worker
+      export COORDINATOR_FABRIC_IP=192.168.200.1
+      export WORKER_FABRIC_IP=192.168.200.2
+
+      bash py_test/e2e/pd_disagg_vllm/run_moriio_rdma_accuracy_test.sh
+    agents:
+      queue: "router_rocm_mi300_2"
+    depends_on: "build"
+    artifact_paths:
+      - "target/ci-logs/moriio-rdma-*/*"
 
   # ============================================================================
   # Docker Build - Parallel with tests

--- a/py_test/e2e/pd_disagg_vllm/README.md
+++ b/py_test/e2e/pd_disagg_vllm/README.md
@@ -42,6 +42,23 @@ Wrapper script that runs tests with multiple TP configurations:
 - Baseline single TP configuration
 - Various block size configurations
 
+### 4. ROCm MoRI runners
+
+`run_moriio_accuracy_test.sh` runs TP1 prefill and TP1 decode on two GPUs of
+one ROCm host with MoRI's xGMI backend. `run_moriio_rdma_accuracy_test.sh` runs
+prefill on the coordinator and decode on a second ROCm host over GPU-memory
+RDMA. Both runners cover MoRI read and write modes, Router discovery, sanity
+requests, and a bounded GSM8K accuracy evaluation with `Qwen/Qwen3-0.6B`.
+
+The two-node runner requires the coordinator's `vllm-router-rocm-worker` SSH
+alias, the pinned ROCm vLLM image and model cache on both hosts, and access to
+`/dev/kfd`, `/dev/dri`, and `/dev/infiniband`. For example:
+
+```bash
+MORIIO_READ_MODE=true bash ./run_moriio_accuracy_test.sh
+MORIIO_READ_MODE=false bash ./run_moriio_rdma_accuracy_test.sh
+```
+
 ## Running Tests
 
 ### Prerequisites

--- a/py_test/e2e/pd_disagg_vllm/run_moriio_accuracy_test.sh
+++ b/py_test/e2e/pd_disagg_vllm/run_moriio_accuracy_test.sh
@@ -1,0 +1,279 @@
+#!/usr/bin/env bash
+# Same-host ROCm P/D disaggregation coverage using vLLM's MoRIIOConnector.
+# The CI matrix runs this script once in READ mode and once in WRITE mode.
+
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+
+MODEL_NAMES=${MODEL_NAMES:-"Qwen/Qwen3-0.6B"}
+MORIIO_READ_MODE=${MORIIO_READ_MODE:-"true"}
+MORIIO_BACKEND=${MORIIO_BACKEND:-"xgmi"}
+PREFILLER_TP_SIZE=${PREFILLER_TP_SIZE:-1}
+DECODER_TP_SIZE=${DECODER_TP_SIZE:-1}
+GPU_MEMORY_UTILIZATION=${GPU_MEMORY_UTILIZATION:-0.6}
+BLOCK_SIZE=${BLOCK_SIZE:-16}
+ENGINE_STARTUP_TIMEOUT=${ENGINE_STARTUP_TIMEOUT:-900}
+ROUTER_STARTUP_TIMEOUT=${ROUTER_STARTUP_TIMEOUT:-180}
+NUM_SANITY_REQUESTS=${NUM_SANITY_REQUESTS:-20}
+NUM_LM_EVAL_CONCURRENT=${NUM_LM_EVAL_CONCURRENT:-10}
+LM_EVAL_LIMIT=${LM_EVAL_LIMIT:-500}
+LM_EVAL_LOG_SAMPLES=${LM_EVAL_LOG_SAMPLES:-false}
+
+PREFILL_PORT=${PREFILL_PORT:-8100}
+DECODE_PORT=${DECODE_PORT:-8200}
+ROUTER_PORT=${ROUTER_PORT:-8300}
+PROXY_PING_PORT=${PROXY_PING_PORT:-36367}
+PREFILL_HANDSHAKE_PORT=${PREFILL_HANDSHAKE_PORT:-6301}
+DECODE_HANDSHAKE_PORT=${DECODE_HANDSHAKE_PORT:-7301}
+PREFILL_NOTIFY_PORT=${PREFILL_NOTIFY_PORT:-61005}
+DECODE_NOTIFY_PORT=${DECODE_NOTIFY_PORT:-62005}
+LOG_DIR=${LOG_DIR:-/tmp/vllm-router-moriio}
+
+case "${MORIIO_READ_MODE}" in
+  true|false) ;;
+  *)
+    echo "ERROR: MORIIO_READ_MODE must be 'true' or 'false', got '${MORIIO_READ_MODE}'" >&2
+    exit 2
+    ;;
+esac
+
+if [[ "${MORIIO_BACKEND}" != "xgmi" ]]; then
+  echo "ERROR: this single-host CI lane requires MORIIO_BACKEND=xgmi" >&2
+  exit 2
+fi
+
+for command_name in curl python3 vllm; do
+  if ! command -v "${command_name}" >/dev/null 2>&1; then
+    echo "ERROR: required command '${command_name}' is unavailable" >&2
+    exit 2
+  fi
+done
+
+mkdir -p "${LOG_DIR}"
+
+PREFILL_PID=""
+DECODE_PID=""
+ROUTER_PID=""
+
+terminate_process_tree() {
+  local pid=$1
+  local child
+
+  [[ -n "${pid}" ]] || return 0
+  kill -0 "${pid}" 2>/dev/null || return 0
+
+  while read -r child; do
+    [[ -n "${child}" ]] && terminate_process_tree "${child}"
+  done < <(ps -o pid= --ppid "${pid}" 2>/dev/null || true)
+
+  kill -TERM "${pid}" 2>/dev/null || true
+}
+
+show_logs() {
+  local log_file
+  for log_file in "${LOG_DIR}"/*.log; do
+    [[ -e "${log_file}" ]] || continue
+    echo "===== ${log_file} (last 200 lines) ====="
+    tail -n 200 "${log_file}" || true
+  done
+}
+
+cleanup() {
+  local exit_code=$?
+  trap - EXIT INT TERM
+  set +e
+
+  if (( exit_code != 0 )); then
+    show_logs
+  fi
+
+  terminate_process_tree "${PREFILL_PID}"
+  terminate_process_tree "${DECODE_PID}"
+  terminate_process_tree "${ROUTER_PID}"
+
+  # Bound shutdown time. The Docker plugin removes the container after this
+  # command exits, but a stuck engine must not hold the CI job open forever.
+  for _ in 1 2 3 4 5 6 7 8 9 10; do
+    if ! kill -0 "${PREFILL_PID}" 2>/dev/null \
+      && ! kill -0 "${DECODE_PID}" 2>/dev/null \
+      && ! kill -0 "${ROUTER_PID}" 2>/dev/null; then
+      break
+    fi
+    sleep 1
+  done
+
+  [[ -z "${PREFILL_PID}" ]] || kill -KILL "${PREFILL_PID}" 2>/dev/null
+  [[ -z "${DECODE_PID}" ]] || kill -KILL "${DECODE_PID}" 2>/dev/null
+  [[ -z "${ROUTER_PID}" ]] || kill -KILL "${ROUTER_PID}" 2>/dev/null
+
+  [[ -z "${PREFILL_PID}" ]] || wait "${PREFILL_PID}" 2>/dev/null
+  [[ -z "${DECODE_PID}" ]] || wait "${DECODE_PID}" 2>/dev/null
+  [[ -z "${ROUTER_PID}" ]] || wait "${ROUTER_PID}" 2>/dev/null
+  exit "${exit_code}"
+}
+
+trap cleanup EXIT
+trap 'exit 130' INT TERM
+
+wait_for_health() {
+  local name=$1
+  local port=$2
+  local timeout=$3
+  local pid=$4
+  local start_time
+  local elapsed
+
+  start_time=$(date +%s)
+  until curl --fail --silent --show-error "http://127.0.0.1:${port}/health" >/dev/null 2>&1; do
+    if ! kill -0 "${pid}" 2>/dev/null; then
+      echo "ERROR: ${name} exited before becoming healthy" >&2
+      return 1
+    fi
+
+    elapsed=$(( $(date +%s) - start_time ))
+    if (( elapsed >= timeout )); then
+      echo "ERROR: ${name} did not become healthy within ${timeout}s" >&2
+      return 1
+    fi
+    sleep 5
+  done
+
+  echo "${name} is healthy"
+}
+
+if [[ -n "${ROUTER_BIN:-}" ]]; then
+  if [[ ! -x "${ROUTER_BIN}" ]]; then
+    echo "ERROR: ROUTER_BIN is not executable: ${ROUTER_BIN}" >&2
+    exit 2
+  fi
+elif command -v vllm-router >/dev/null 2>&1; then
+  ROUTER_BIN=$(command -v vllm-router)
+elif [[ -x "${REPO_ROOT}/target/release/vllm-router" ]]; then
+  ROUTER_BIN="${REPO_ROOT}/target/release/vllm-router"
+else
+  if ! command -v cargo >/dev/null 2>&1; then
+    echo "ERROR: vllm-router is unavailable and cargo is not installed" >&2
+    exit 2
+  fi
+  cargo build --release --manifest-path "${REPO_ROOT}/Cargo.toml"
+  ROUTER_BIN="${REPO_ROOT}/target/release/vllm-router"
+fi
+
+read -r AVAILABLE_GPUS ROCM_VERSION < <(
+  python3 - <<'PY'
+import torch
+
+if not torch.version.hip:
+    raise SystemExit("ERROR: PyTorch does not report a ROCm runtime")
+print(torch.cuda.device_count(), torch.version.hip)
+PY
+)
+
+REQUIRED_GPUS=$((PREFILLER_TP_SIZE + DECODER_TP_SIZE))
+if (( AVAILABLE_GPUS < REQUIRED_GPUS )); then
+  echo "ERROR: ${REQUIRED_GPUS} GPUs are required, but PyTorch sees ${AVAILABLE_GPUS}" >&2
+  exit 2
+fi
+
+PREFILL_GPU_END=$((PREFILLER_TP_SIZE - 1))
+DECODE_GPU_START=${PREFILLER_TP_SIZE}
+DECODE_GPU_END=$((REQUIRED_GPUS - 1))
+PREFILL_GPUS=$(seq -s, 0 "${PREFILL_GPU_END}")
+DECODE_GPUS=$(seq -s, "${DECODE_GPU_START}" "${DECODE_GPU_END}")
+
+echo "ROCm ${ROCM_VERSION}; MoRI ${MORIIO_BACKEND}; read_mode=${MORIIO_READ_MODE}"
+echo "Model: ${MODEL_NAMES}"
+echo "Prefill GPUs: ${PREFILL_GPUS}; decode GPUs: ${DECODE_GPUS}"
+if command -v rocm-smi >/dev/null 2>&1; then
+  rocm-smi --showtopo || true
+fi
+
+make_kv_config() {
+  local role=$1
+  local http_port=$2
+  local handshake_port=$3
+  local notify_port=$4
+
+  printf '{"kv_connector":"MoRIIOConnector","kv_role":"%s","kv_connector_extra_config":{"proxy_ip":"127.0.0.1","proxy_ping_port":%s,"http_port":%s,"handshake_port":%s,"notify_port":%s,"read_mode":%s,"backend":"%s"}}' \
+    "${role}" \
+    "${PROXY_PING_PORT}" \
+    "${http_port}" \
+    "${handshake_port}" \
+    "${notify_port}" \
+    "${MORIIO_READ_MODE}" \
+    "${MORIIO_BACKEND}"
+}
+
+PREFILL_KV_CONFIG=$(make_kv_config \
+  kv_producer "${PREFILL_PORT}" "${PREFILL_HANDSHAKE_PORT}" "${PREFILL_NOTIFY_PORT}")
+DECODE_KV_CONFIG=$(make_kv_config \
+  kv_consumer "${DECODE_PORT}" "${DECODE_HANDSHAKE_PORT}" "${DECODE_NOTIFY_PORT}")
+
+# Start the discovery proxy first. vLLM workers retry registration while their
+# HTTP engines initialize, and Router health stays unavailable until both roles
+# have registered.
+"${ROUTER_BIN}" \
+  --port "${ROUTER_PORT}" \
+  --policy consistent_hash \
+  --prefill-policy consistent_hash \
+  --decode-policy consistent_hash \
+  --vllm-pd-disaggregation \
+  --kv-connector moriio \
+  --vllm-discovery-address "0.0.0.0:${PROXY_PING_PORT}" \
+  --worker-startup-check-interval 1 \
+  >"${LOG_DIR}/router.log" 2>&1 &
+ROUTER_PID=$!
+
+HIP_VISIBLE_DEVICES="${PREFILL_GPUS}" \
+VLLM_ROCM_USE_AITER=1 \
+VLLM_LOGGING_LEVEL=INFO \
+vllm serve "${MODEL_NAMES}" \
+  --port "${PREFILL_PORT}" \
+  --tensor-parallel-size "${PREFILLER_TP_SIZE}" \
+  --block-size "${BLOCK_SIZE}" \
+  --gpu-memory-utilization "${GPU_MEMORY_UTILIZATION}" \
+  --enforce-eager \
+  --kv-transfer-config "${PREFILL_KV_CONFIG}" \
+  >"${LOG_DIR}/prefill.log" 2>&1 &
+PREFILL_PID=$!
+
+HIP_VISIBLE_DEVICES="${DECODE_GPUS}" \
+VLLM_ROCM_USE_AITER=1 \
+VLLM_LOGGING_LEVEL=INFO \
+vllm serve "${MODEL_NAMES}" \
+  --port "${DECODE_PORT}" \
+  --tensor-parallel-size "${DECODER_TP_SIZE}" \
+  --block-size "${BLOCK_SIZE}" \
+  --gpu-memory-utilization "${GPU_MEMORY_UTILIZATION}" \
+  --enforce-eager \
+  --kv-transfer-config "${DECODE_KV_CONFIG}" \
+  >"${LOG_DIR}/decode.log" 2>&1 &
+DECODE_PID=$!
+
+wait_for_health "prefill" "${PREFILL_PORT}" "${ENGINE_STARTUP_TIMEOUT}" "${PREFILL_PID}"
+wait_for_health "decode" "${DECODE_PORT}" "${ENGINE_STARTUP_TIMEOUT}" "${DECODE_PID}"
+wait_for_health "router discovery" "${ROUTER_PORT}" "${ROUTER_STARTUP_TIMEOUT}" "${ROUTER_PID}"
+
+python3 "${SCRIPT_DIR}/test_pd_accuracy.py" \
+  --router-url "http://127.0.0.1:${ROUTER_PORT}" \
+  --model "${MODEL_NAMES}" \
+  --num-requests "${NUM_SANITY_REQUESTS}" \
+  --skip-streaming
+
+LM_EVAL_ARGS=(
+  --router-url "http://127.0.0.1:${ROUTER_PORT}"
+  --model "${MODEL_NAMES}"
+  --num-concurrent "${NUM_LM_EVAL_CONCURRENT}"
+  --max-gen-toks 512
+  --limit "${LM_EVAL_LIMIT}"
+  --filter "exact_match,flexible-extract"
+  --disable-thinking
+)
+if [[ "${LM_EVAL_LOG_SAMPLES}" == "true" ]]; then
+  LM_EVAL_ARGS+=(--log-samples)
+fi
+python3 "${SCRIPT_DIR}/test_lm_eval_accuracy.py" "${LM_EVAL_ARGS[@]}"
+
+echo "MoRI XGMI P/D accuracy passed (read_mode=${MORIIO_READ_MODE})"

--- a/py_test/e2e/pd_disagg_vllm/run_moriio_rdma_accuracy_test.sh
+++ b/py_test/e2e/pd_disagg_vllm/run_moriio_rdma_accuracy_test.sh
@@ -1,0 +1,345 @@
+#!/usr/bin/env bash
+# Two-host ROCm P/D disaggregation coverage using MoRI GPU-memory RDMA.
+# Run this script on the coordinator; it controls the decode host over SSH.
+
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+
+MODEL_NAMES=${MODEL_NAMES:-"Qwen/Qwen3-0.6B"}
+ROCM_VLLM_IMAGE=${ROCM_VLLM_IMAGE:-"vllm/vllm-openai-rocm:nightly@sha256:d22922d540810d90c5a3eafe91d3b4a62c2b881f3e990d0b7180b2875a5d176d"}
+WORKER_SSH_HOST=${WORKER_SSH_HOST:-"vllm-router-rocm-worker"}
+COORDINATOR_FABRIC_IP=${COORDINATOR_FABRIC_IP:-"192.168.200.1"}
+WORKER_FABRIC_IP=${WORKER_FABRIC_IP:-"192.168.200.2"}
+HF_CACHE_DIR=${HF_CACHE_DIR:-"/var/lib/buildkite-agent/.cache/huggingface"}
+WORKER_HF_CACHE_DIR=${WORKER_HF_CACHE_DIR:-"/var/lib/buildkite-agent/.cache/huggingface"}
+MORIIO_READ_MODE=${MORIIO_READ_MODE:-"true"}
+MORIIO_QP_PER_TRANSFER=${MORIIO_QP_PER_TRANSFER:-1}
+MORIIO_POST_BATCH_SIZE=${MORIIO_POST_BATCH_SIZE:-1}
+MORIIO_NUM_WORKERS=${MORIIO_NUM_WORKERS:-1}
+GPU_MEMORY_UTILIZATION=${GPU_MEMORY_UTILIZATION:-0.6}
+ATTENTION_BACKEND=${ATTENTION_BACKEND:-ROCM_AITER_FA}
+ENABLE_PREFIX_CACHING=${ENABLE_PREFIX_CACHING:-false}
+ENABLE_CHUNKED_PREFILL=${ENABLE_CHUNKED_PREFILL:-false}
+HSA_NO_SCRATCH_RECLAIM=${HSA_NO_SCRATCH_RECLAIM:-0}
+ENGINE_STARTUP_TIMEOUT=${ENGINE_STARTUP_TIMEOUT:-1800}
+ROUTER_STARTUP_TIMEOUT=${ROUTER_STARTUP_TIMEOUT:-180}
+NUM_SANITY_REQUESTS=${NUM_SANITY_REQUESTS:-20}
+NUM_LM_EVAL_CONCURRENT=${NUM_LM_EVAL_CONCURRENT:-1}
+LM_EVAL_LIMIT=${LM_EVAL_LIMIT:-500}
+LM_EVAL_LOG_SAMPLES=${LM_EVAL_LOG_SAMPLES:-false}
+SMOKE_ONLY=${SMOKE_ONLY:-false}
+SKIP_LM_EVAL=${SKIP_LM_EVAL:-false}
+REQUEST_TIMEOUT=${REQUEST_TIMEOUT:-300}
+EVAL_PIP_CACHE_VOLUME=${EVAL_PIP_CACHE_VOLUME:-"vllm-router-rocm-pip-cache"}
+
+PREFILL_PORT=${PREFILL_PORT:-8100}
+DECODE_PORT=${DECODE_PORT:-8200}
+ROUTER_PORT=${ROUTER_PORT:-8300}
+PROXY_PING_PORT=${PROXY_PING_PORT:-36367}
+PREFILL_HANDSHAKE_PORT=${PREFILL_HANDSHAKE_PORT:-6301}
+DECODE_HANDSHAKE_PORT=${DECODE_HANDSHAKE_PORT:-7301}
+PREFILL_NOTIFY_PORT=${PREFILL_NOTIFY_PORT:-61005}
+DECODE_NOTIFY_PORT=${DECODE_NOTIFY_PORT:-62005}
+LOG_DIR=${LOG_DIR:-"${REPO_ROOT}/target/ci-logs/moriio-rdma-${MORIIO_READ_MODE}"}
+
+PREFILL_CONTAINER="vllm-router-mori-rdma-prefill"
+DECODE_CONTAINER="vllm-router-mori-rdma-decode"
+EVAL_CONTAINER="vllm-router-mori-rdma-eval"
+
+case "${MORIIO_READ_MODE}" in
+  true|false) ;;
+  *)
+    echo "ERROR: MORIIO_READ_MODE must be 'true' or 'false', got '${MORIIO_READ_MODE}'" >&2
+    exit 2
+    ;;
+esac
+
+for integer_setting in \
+  MORIIO_QP_PER_TRANSFER \
+  MORIIO_POST_BATCH_SIZE \
+  MORIIO_NUM_WORKERS; do
+  if ! [[ "${!integer_setting}" =~ ^[1-9][0-9]*$ ]]; then
+    echo "ERROR: ${integer_setting} must be a positive integer, got '${!integer_setting}'" >&2
+    exit 2
+  fi
+done
+
+case "${HSA_NO_SCRATCH_RECLAIM}" in
+  0|1) ;;
+  *)
+    echo "ERROR: HSA_NO_SCRATCH_RECLAIM must be '0' or '1', got '${HSA_NO_SCRATCH_RECLAIM}'" >&2
+    exit 2
+    ;;
+esac
+
+for command_name in curl docker ssh; do
+  if ! command -v "${command_name}" >/dev/null 2>&1; then
+    echo "ERROR: required command '${command_name}' is unavailable" >&2
+    exit 2
+  fi
+done
+
+if [[ -n "${ROUTER_BIN:-}" ]]; then
+  if [[ ! -x "${ROUTER_BIN}" ]]; then
+    echo "ERROR: ROUTER_BIN is not executable: ${ROUTER_BIN}" >&2
+    exit 2
+  fi
+elif [[ -x "${REPO_ROOT}/target/release/vllm-router" ]]; then
+  ROUTER_BIN="${REPO_ROOT}/target/release/vllm-router"
+else
+  echo "ERROR: set ROUTER_BIN or build ${REPO_ROOT}/target/release/vllm-router" >&2
+  exit 2
+fi
+
+mkdir -p "${LOG_DIR}"
+docker volume create "${EVAL_PIP_CACHE_VOLUME}" >/dev/null
+
+# OpenSSH joins command arguments without preserving their boundaries. Render a
+# Bash-escaped command so JSON connector configuration remains one argument.
+worker_run() {
+  local command_string
+  printf -v command_string '%q ' "$@"
+  ssh -o BatchMode=yes "${WORKER_SSH_HOST}" "exec ${command_string}"
+}
+
+ROUTER_PID=""
+
+show_logs() {
+  local log_file
+  for log_file in "${LOG_DIR}"/*.log; do
+    [[ -e "${log_file}" ]] || continue
+    echo "===== ${log_file} (last 200 lines) ====="
+    tail -n 200 "${log_file}" || true
+  done
+}
+
+cleanup() {
+  local exit_code=$?
+  trap - EXIT INT TERM
+  set +e
+
+  docker logs "${PREFILL_CONTAINER}" >"${LOG_DIR}/prefill.log" 2>&1
+  worker_run docker logs "${DECODE_CONTAINER}" >"${LOG_DIR}/decode.log" 2>&1
+
+  docker rm -f "${EVAL_CONTAINER}" "${PREFILL_CONTAINER}" >/dev/null 2>&1
+  worker_run docker rm -f "${DECODE_CONTAINER}" >/dev/null 2>&1
+
+  if [[ -n "${ROUTER_PID}" ]]; then
+    kill -TERM "${ROUTER_PID}" 2>/dev/null
+    wait "${ROUTER_PID}" 2>/dev/null
+  fi
+
+  if (( exit_code != 0 )); then
+    show_logs
+  fi
+  exit "${exit_code}"
+}
+
+trap cleanup EXIT
+trap 'exit 130' INT TERM
+
+wait_for_health() {
+  local name=$1
+  local url=$2
+  local timeout=$3
+  local start_time
+  local elapsed
+
+  start_time=$(date +%s)
+  until curl --fail --silent --show-error "${url}" >/dev/null 2>&1; do
+    case "${name}" in
+      prefill)
+        if [[ "$(docker inspect --format '{{.State.Running}}' "${PREFILL_CONTAINER}" 2>/dev/null || true)" != "true" ]]; then
+          echo "ERROR: prefill container exited during startup" >&2
+          return 1
+        fi
+        ;;
+      decode)
+        if [[ "$(worker_run docker inspect --format '{{.State.Running}}' "${DECODE_CONTAINER}" 2>/dev/null || true)" != "true" ]]; then
+          echo "ERROR: decode container exited during startup" >&2
+          return 1
+        fi
+        ;;
+      "router discovery")
+        if ! kill -0 "${ROUTER_PID}" 2>/dev/null; then
+          echo "ERROR: router exited during startup" >&2
+          return 1
+        fi
+        ;;
+    esac
+
+    elapsed=$(( $(date +%s) - start_time ))
+    if (( elapsed >= timeout )); then
+      echo "ERROR: ${name} did not become healthy within ${timeout}s" >&2
+      return 1
+    fi
+    sleep 5
+  done
+  echo "${name} is healthy at ${url}"
+}
+
+docker info >/dev/null
+worker_run docker info >/dev/null
+test -d "${HF_CACHE_DIR}"
+worker_run test -d "${WORKER_HF_CACHE_DIR}"
+
+# Refuse to reuse stale processes or containers from an interrupted CI job.
+docker rm -f "${EVAL_CONTAINER}" "${PREFILL_CONTAINER}" >/dev/null 2>&1 || true
+worker_run docker rm -f "${DECODE_CONTAINER}" >/dev/null 2>&1 || true
+
+"${ROUTER_BIN}" \
+  --port "${ROUTER_PORT}" \
+  --policy consistent_hash \
+  --prefill-policy consistent_hash \
+  --decode-policy consistent_hash \
+  --vllm-pd-disaggregation \
+  --kv-connector moriio \
+  --vllm-discovery-address "0.0.0.0:${PROXY_PING_PORT}" \
+  --worker-startup-check-interval 1 \
+  >"${LOG_DIR}/router.log" 2>&1 &
+ROUTER_PID=$!
+
+PREFILL_KV_CONFIG=$(printf '{"kv_connector":"MoRIIOConnector","kv_role":"kv_producer","kv_connector_extra_config":{"proxy_ip":"%s","proxy_ping_port":%s,"http_port":%s,"handshake_port":%s,"notify_port":%s,"host_ip":"%s","read_mode":%s,"backend":"rdma","qp_per_transfer":%s,"post_batch_size":%s,"num_workers":%s}}' \
+  "${COORDINATOR_FABRIC_IP}" "${PROXY_PING_PORT}" "${PREFILL_PORT}" \
+  "${PREFILL_HANDSHAKE_PORT}" "${PREFILL_NOTIFY_PORT}" \
+  "${COORDINATOR_FABRIC_IP}" "${MORIIO_READ_MODE}" \
+  "${MORIIO_QP_PER_TRANSFER}" "${MORIIO_POST_BATCH_SIZE}" \
+  "${MORIIO_NUM_WORKERS}")
+
+DECODE_KV_CONFIG=$(printf '{"kv_connector":"MoRIIOConnector","kv_role":"kv_consumer","kv_connector_extra_config":{"proxy_ip":"%s","proxy_ping_port":%s,"http_port":%s,"handshake_port":%s,"notify_port":%s,"host_ip":"%s","read_mode":%s,"backend":"rdma","qp_per_transfer":%s,"post_batch_size":%s,"num_workers":%s}}' \
+  "${COORDINATOR_FABRIC_IP}" "${PROXY_PING_PORT}" "${DECODE_PORT}" \
+  "${DECODE_HANDSHAKE_PORT}" "${DECODE_NOTIFY_PORT}" \
+  "${WORKER_FABRIC_IP}" "${MORIIO_READ_MODE}" \
+  "${MORIIO_QP_PER_TRANSFER}" "${MORIIO_POST_BATCH_SIZE}" \
+  "${MORIIO_NUM_WORKERS}")
+
+COMMON_DOCKER_ARGS=(
+  run -d
+  --network host
+  --ipc host
+  --privileged
+  --init
+  --shm-size 256g
+  --ulimit memlock=-1
+  --ulimit stack=67108864
+  -e HF_HOME=/root/.cache/huggingface
+  -e HIP_VISIBLE_DEVICES=0
+  -e MORI_DEVICE_NIC=mlx5
+  # MoRI otherwise auto-creates an XGMI backend and may prefer it when remote
+  # node identity is ambiguous. This lane must prove RDMA, so make the backend
+  # selection exclusive and deterministic.
+  -e MORI_DISABLE_AUTO_XGMI=1
+  -e GLOO_SOCKET_IFNAME=eth2
+  # The upstream image defaults this to 1 for older firmware. Retaining scratch
+  # allocations indefinitely can exhaust HSA resources under concurrent decode.
+  -e HSA_NO_SCRATCH_RECLAIM="${HSA_NO_SCRATCH_RECLAIM}"
+  -e VLLM_ROCM_USE_AITER=1
+  -e VLLM_LOGGING_LEVEL=INFO
+  --entrypoint vllm
+)
+
+PREFIX_CACHING_ARGS=(--no-enable-prefix-caching)
+if [[ "${ENABLE_PREFIX_CACHING}" == "true" ]]; then
+  PREFIX_CACHING_ARGS=(--enable-prefix-caching)
+fi
+
+CHUNKED_PREFILL_ARGS=(--no-enable-chunked-prefill)
+if [[ "${ENABLE_CHUNKED_PREFILL}" == "true" ]]; then
+  CHUNKED_PREFILL_ARGS=(--enable-chunked-prefill)
+fi
+
+docker "${COMMON_DOCKER_ARGS[@]}" \
+  --name "${PREFILL_CONTAINER}" \
+  --hostname vllm-router-rocm-node-a \
+  -v "${HF_CACHE_DIR}:/root/.cache/huggingface" \
+  "${ROCM_VLLM_IMAGE}" \
+  serve "${MODEL_NAMES}" \
+  --host 0.0.0.0 \
+  --port "${PREFILL_PORT}" \
+  --tensor-parallel-size 1 \
+  --block-size 16 \
+  --attention-backend "${ATTENTION_BACKEND}" \
+  "${PREFIX_CACHING_ARGS[@]}" \
+  "${CHUNKED_PREFILL_ARGS[@]}" \
+  --gpu-memory-utilization "${GPU_MEMORY_UTILIZATION}" \
+  --enforce-eager \
+  --kv-transfer-config "${PREFILL_KV_CONFIG}" >/dev/null
+
+worker_run docker "${COMMON_DOCKER_ARGS[@]}" \
+  --name "${DECODE_CONTAINER}" \
+  --hostname vllm-router-rocm-node-b \
+  -v "${WORKER_HF_CACHE_DIR}:/root/.cache/huggingface" \
+  "${ROCM_VLLM_IMAGE}" \
+  serve "${MODEL_NAMES}" \
+  --host 0.0.0.0 \
+  --port "${DECODE_PORT}" \
+  --tensor-parallel-size 1 \
+  --block-size 16 \
+  --attention-backend "${ATTENTION_BACKEND}" \
+  "${PREFIX_CACHING_ARGS[@]}" \
+  "${CHUNKED_PREFILL_ARGS[@]}" \
+  --gpu-memory-utilization "${GPU_MEMORY_UTILIZATION}" \
+  --enforce-eager \
+  --kv-transfer-config "${DECODE_KV_CONFIG}" >/dev/null
+
+wait_for_health "prefill" "http://${COORDINATOR_FABRIC_IP}:${PREFILL_PORT}/health" "${ENGINE_STARTUP_TIMEOUT}"
+wait_for_health "decode" "http://${WORKER_FABRIC_IP}:${DECODE_PORT}/health" "${ENGINE_STARTUP_TIMEOUT}"
+wait_for_health "router discovery" "http://127.0.0.1:${ROUTER_PORT}/health" "${ROUTER_STARTUP_TIMEOUT}"
+
+# This request must traverse prefill on node A and decode on node B. A correct
+# response therefore proves that MoRI registered and transferred GPU KV memory
+# across the RDMA fabric, not merely that host-memory verbs work.
+curl --fail --silent --show-error \
+  --max-time "${REQUEST_TIMEOUT}" \
+  -H 'Content-Type: application/json' \
+  -d "{\"model\":\"${MODEL_NAMES}\",\"prompt\":\"The capital of France is\",\"max_tokens\":8,\"temperature\":0}" \
+  "http://127.0.0.1:${ROUTER_PORT}/v1/completions" \
+  | tee "${LOG_DIR}/smoke-response.json"
+echo
+
+if [[ "${SMOKE_ONLY}" == "true" ]]; then
+  echo "MoRI RDMA cross-node smoke passed (read_mode=${MORIIO_READ_MODE})"
+  exit 0
+fi
+
+EVAL_COMMAND=$(cat <<EOF
+set -Eeuo pipefail
+export PIP_ROOT_USER_ACTION=ignore
+export PIP_CACHE_DIR=/root/.cache/pip
+python3 -m pip install --disable-pip-version-check --quiet requests
+if [[ ${SKIP_LM_EVAL} != true ]]; then
+  python3 -m pip install --disable-pip-version-check --quiet openai 'lm-eval[api]==0.4.12'
+fi
+python3 py_test/e2e/pd_disagg_vllm/test_pd_accuracy.py \\
+  --router-url http://127.0.0.1:${ROUTER_PORT} \\
+  --model ${MODEL_NAMES} \\
+  --num-requests ${NUM_SANITY_REQUESTS} \\
+  --skip-streaming
+if [[ ${SKIP_LM_EVAL} == true ]]; then exit 0; fi
+args=(
+  --router-url http://127.0.0.1:${ROUTER_PORT}
+  --model ${MODEL_NAMES}
+  --num-concurrent ${NUM_LM_EVAL_CONCURRENT}
+  --max-gen-toks 512
+  --limit ${LM_EVAL_LIMIT}
+  --filter "exact_match,flexible-extract"
+  --disable-thinking
+)
+if [[ ${LM_EVAL_LOG_SAMPLES} == true ]]; then args+=(--log-samples); fi
+python3 py_test/e2e/pd_disagg_vllm/test_lm_eval_accuracy.py "\${args[@]}"
+EOF
+)
+
+docker run --rm \
+  --name "${EVAL_CONTAINER}" \
+  --network host \
+  -v "${REPO_ROOT}:/workdir" \
+  -v "${EVAL_PIP_CACHE_VOLUME}:/root/.cache/pip" \
+  -w /workdir \
+  --entrypoint bash \
+  "${ROCM_VLLM_IMAGE}" \
+  -lc "${EVAL_COMMAND}"
+
+echo "MoRI RDMA cross-node accuracy passed (read_mode=${MORIIO_READ_MODE})"

--- a/py_test/e2e/pd_disagg_vllm/run_moriio_rdma_accuracy_test.sh
+++ b/py_test/e2e/pd_disagg_vllm/run_moriio_rdma_accuracy_test.sh
@@ -233,7 +233,7 @@ COMMON_DOCKER_ARGS=(
   -e MORI_DISABLE_AUTO_XGMI=1
   -e GLOO_SOCKET_IFNAME=eth2
   # The upstream image defaults this to 1 for older firmware. Retaining scratch
-  # allocations indefinitely can exhaust HSA resources under concurrent decode.
+  # allocations indefinitely can exhaust runtime resources under concurrent decode.
   -e HSA_NO_SCRATCH_RECLAIM="${HSA_NO_SCRATCH_RECLAIM}"
   -e VLLM_ROCM_USE_AITER=1
   -e VLLM_LOGGING_LEVEL=INFO

--- a/py_test/e2e/pd_disagg_vllm/test_lm_eval_accuracy.py
+++ b/py_test/e2e/pd_disagg_vllm/test_lm_eval_accuracy.py
@@ -17,16 +17,16 @@ import openai
 
 # Test configuration
 TASK = "gsm8k"
-FILTER = "exact_match,strict-match"
+DEFAULT_FILTER = "exact_match,strict-match"
 RTOL = 0.03  # Relative tolerance for accuracy comparison
 
 # Model-specific expected values (from vLLM benchmarks)
 EXPECTED_VALUES = {
-    "meta-llama/Llama-3.2-1B-Instruct": 0.33,  # Lowered to accept >30% accuracy
-    "Qwen/Qwen3-0.6B": 0.41,
-    "deepseek-ai/deepseek-vl2-small": 0.59,
-    "deepseek-ai/deepseek-vl2-tiny": 0.19,
-    "deepseek-ai/DeepSeek-V2-Lite-Chat": 0.65,
+    ("meta-llama/Llama-3.2-1B-Instruct", DEFAULT_FILTER): 0.33,
+    ("Qwen/Qwen3-0.6B", "exact_match,flexible-extract"): 0.41,
+    ("deepseek-ai/deepseek-vl2-small", DEFAULT_FILTER): 0.59,
+    ("deepseek-ai/deepseek-vl2-tiny", DEFAULT_FILTER): 0.19,
+    ("deepseek-ai/DeepSeek-V2-Lite-Chat", DEFAULT_FILTER): 0.65,
 }
 
 # Simple prompt for connectivity test
@@ -62,7 +62,11 @@ def print_warning(msg: str):
     print(f"{Colors.YELLOW}⚠ {msg}{Colors.RESET}")
 
 
-def run_simple_prompt(base_url: str, model_name: str) -> bool:
+def run_simple_prompt(
+    base_url: str,
+    model_name: str,
+    disable_thinking: bool = False,
+) -> bool:
     """
     Run a simple prompt to verify connectivity before running full evaluation.
 
@@ -79,10 +83,16 @@ def run_simple_prompt(base_url: str, model_name: str) -> bool:
         # Use a very long timeout (10 minutes) for connectivity test
         client = openai.OpenAI(api_key="EMPTY", base_url=base_url, timeout=600.0)
         # Use chat completions for Instruct models
+        extra_body = None
+        if disable_thinking:
+            extra_body = {"chat_template_kwargs": {"enable_thinking": False}}
+
         completion = client.chat.completions.create(
             model=model_name,
             messages=[{"role": "user", "content": SIMPLE_PROMPT}],
             max_tokens=50,
+            temperature=0.0,
+            extra_body=extra_body,
         )
 
         output = completion.choices[0].message.content if completion.choices else ""
@@ -109,6 +119,11 @@ def run_accuracy_evaluation(
     base_url: str,
     model_name: str,
     num_concurrent: int = 20,
+    max_gen_toks: int = 256,
+    disable_thinking: bool = False,
+    sample: bool = False,
+    limit: int = 500,
+    log_samples: bool = False,
 ) -> dict:
     """
     Run LM Evaluation Harness on gsm8k task.
@@ -127,6 +142,28 @@ def run_accuracy_evaluation(
     # Use Chat Completions API for Instruct models (native format)
     # This fixes 422 errors from endpoint mismatch
     try:
+        gen_kwargs = {
+            "max_gen_toks": max_gen_toks,
+            "do_sample": sample,
+        }
+        if disable_thinking:
+            # Qwen3 defaults to thinking mode, which can consume the entire
+            # short CI generation budget before emitting a final answer.
+            gen_kwargs["chat_template_kwargs"] = {"enable_thinking": False}
+        if sample:
+            gen_kwargs.update(
+                {
+                    "temperature": 0.7,
+                    "top_p": 0.8,
+                    "top_k": 20,
+                    "min_p": 0.0,
+                }
+            )
+        else:
+            # Accuracy gates should be reproducible. This also avoids compiling
+            # vLLM's top-k/top-p sampling kernel for every dynamic batch shape.
+            gen_kwargs["temperature"] = 0.0
+
         results = lm_eval.simple_evaluate(
             model="local-chat-completions",
             model_args={
@@ -138,10 +175,11 @@ def run_accuracy_evaluation(
             },
             tasks=TASK,
             num_fewshot=5,
-            limit=500,
+            limit=limit,
             apply_chat_template=True,  # Enable chat template for Instruct models
             fewshot_as_multiturn=True,  # Format few-shot examples as conversation turns
-            log_samples=False,
+            gen_kwargs=gen_kwargs,
+            log_samples=log_samples,
         )
         return results
 
@@ -153,6 +191,7 @@ def run_accuracy_evaluation(
 def validate_accuracy(
     results: dict,
     model_name: str,
+    filter_name: str,
 ) -> bool:
     """
     Validate that accuracy meets expected thresholds.
@@ -164,15 +203,15 @@ def validate_accuracy(
     Returns:
         True if accuracy is within acceptable range, False otherwise
     """
-    measured_value = results["results"][TASK][FILTER]
-    expected_value = EXPECTED_VALUES.get(model_name)
+    measured_value = results["results"][TASK][filter_name]
+    expected_value = EXPECTED_VALUES.get((model_name, filter_name))
 
     print()
     print("=" * 60)
     print_info("Accuracy Results:")
     print_info(f"  Model:              {model_name}")
     print_info(f"  Task:               {TASK}")
-    print_info(f"  Metric:             {FILTER}")
+    print_info(f"  Metric:             {filter_name}")
     print_info(f"  Measured Accuracy:  {measured_value:.4f}")
 
     if expected_value is None:
@@ -242,6 +281,39 @@ def main():
         action="store_true",
         help="Skip initial connectivity test",
     )
+    parser.add_argument(
+        "--max-gen-toks",
+        type=int,
+        default=256,
+        help="Maximum generated tokens per benchmark request (default: 256)",
+    )
+    parser.add_argument(
+        "--disable-thinking",
+        action="store_true",
+        help="Pass enable_thinking=false to chat templates for bounded CI runs",
+    )
+    parser.add_argument(
+        "--sample",
+        action="store_true",
+        help="Use Qwen's top-k/top-p sampling settings instead of greedy decoding",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=500,
+        help="Number of benchmark examples to evaluate (default: 500)",
+    )
+    parser.add_argument(
+        "--log-samples",
+        action="store_true",
+        help="Print the first three benchmark responses and filtered values",
+    )
+    parser.add_argument(
+        "--filter",
+        choices=("exact_match,strict-match", "exact_match,flexible-extract"),
+        default=DEFAULT_FILTER,
+        help="LM-Eval GSM8K metric key to validate",
+    )
 
     args = parser.parse_args()
 
@@ -263,12 +335,20 @@ def main():
     print_info(f"Model:              {model_name}")
     print_info(f"Task:               {TASK}")
     print_info(f"Concurrent Reqs:    {args.num_concurrent}")
+    print_info(f"Max Generated Toks: {args.max_gen_toks}")
+    print_info(f"Thinking Enabled:   {not args.disable_thinking}")
+    print_info(f"Sampling Enabled:   {args.sample}")
+    print_info(f"Example Limit:      {args.limit}")
     print("=" * 60)
     print()
 
     # Step 1: Connectivity test (optional)
     if not args.skip_connectivity:
-        if not run_simple_prompt(base_url, model_name):
+        if not run_simple_prompt(
+            base_url,
+            model_name,
+            disable_thinking=args.disable_thinking,
+        ):
             print_error("Connectivity test failed. Aborting evaluation.")
             return 1
         print()
@@ -279,13 +359,25 @@ def main():
             base_url=base_url,
             model_name=model_name,
             num_concurrent=args.num_concurrent,
+            max_gen_toks=args.max_gen_toks,
+            disable_thinking=args.disable_thinking,
+            sample=args.sample,
+            limit=args.limit,
+            log_samples=args.log_samples,
         )
     except Exception as e:
         print_error(f"Evaluation failed: {e}")
         return 1
 
+    if args.log_samples:
+        print_info("First benchmark samples:")
+        for sample in results.get("samples", {}).get(TASK, [])[:3]:
+            print_info(f"  Target:   {sample.get('target')}")
+            print_info(f"  Response: {sample.get('resps')}")
+            print_info(f"  Filtered: {sample.get('filtered_resps')}")
+
     # Step 3: Validate accuracy
-    if not validate_accuracy(results, model_name):
+    if not validate_accuracy(results, model_name, args.filter):
         print_error("Accuracy validation failed!")
         return 1
 

--- a/src/routers/http/vllm_pd_router.rs
+++ b/src/routers/http/vllm_pd_router.rs
@@ -67,6 +67,13 @@ pub struct VllmPDRouter {
 /// Must match `MoRIIOConstants.TRANSFER_PREFIX` in the vLLM Python connector.
 const MORIIO_TRANSFER_PREFIX: &str = "tx";
 
+/// Discovery-backed P/D routing is ready only after both worker types register.
+/// Without this guard, `PdRouterBase::health` sees the unused static registry and
+/// reports success before a discovered prefill/decode pair can serve requests.
+fn discovery_is_ready(prefill_count: usize, decode_count: usize) -> bool {
+    prefill_count > 0 && decode_count > 0
+}
+
 /// Strip the DP-rank suffix from a worker's HTTP address and return the base address
 /// plus the parsed rank. Returns `(original, None)` when DP is disabled.
 fn extract_base_http_and_dp_rank(
@@ -1750,6 +1757,21 @@ impl RouterTrait for VllmPDRouter {
     }
 
     async fn health(&self, req: Request<Body>) -> Response {
+        if self.use_discovery {
+            let (prefill_count, decode_count) = self.service_registry.get_instance_counts();
+            if !discovery_is_ready(prefill_count, decode_count) {
+                return (
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    format!(
+                        "Waiting for discovered workers: {prefill_count} prefill, {decode_count} decode"
+                    ),
+                )
+                    .into_response();
+            }
+
+            return (StatusCode::OK, "OK").into_response();
+        }
+
         self.pd_router.health(req).await
     }
 
@@ -2397,6 +2419,15 @@ impl WorkerManagement for VllmPDRouter {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn test_discovery_health_requires_prefill_and_decode_workers() {
+        assert!(!discovery_is_ready(0, 0));
+        assert!(!discovery_is_ready(1, 0));
+        assert!(!discovery_is_ready(0, 1));
+        assert!(discovery_is_ready(1, 1));
+        assert!(discovery_is_ready(2, 3));
+    }
 
     // --- OpenAI-style endpoint tests (chat/completions, completions) ---
 


### PR DESCRIPTION
## Summary

- add same-host ROCm MoRI XGMI P/D coverage for read and write modes
- add two-node MI300X MoRI RDMA P/D coverage for read and write modes
- pin the ROCm vLLM image and use a dedicated plugin-enabled Buildkite queue
- make discovery health wait for both prefill and decode registrations
- make the GSM8K harness deterministic for Qwen3 and support the flexible numeric extractor

This addresses the MoRI portion of #142 and extends the approach in #164 with a validated cross-host RDMA tier. This is a separate PR because I cannot push to the original contributor's branch; the changes can be consolidated if preferred.

## Scheduling and trust boundary

- XGMI: same-repository PRs, the default branch, and merge-queue builds
- RDMA: scheduled builds with `NIGHTLY=1`
- trusted UI/API validation: `RUN_ROCM_XGMI=1` and/or `RUN_ROCM_RDMA=1`
- fork PRs cannot instantiate the privileged Docker plugin group
- the dedicated `router_rocm_mi300_2` agent uses `spawn=1`

## Validation

On two 8x MI300X nodes:

- XGMI read: 500 GSM8K examples, accuracy 0.480
- XGMI write: 500 GSM8K examples, accuracy 0.476
- RDMA read: 500 GSM8K examples, accuracy 0.478
- RDMA write: 500 GSM8K examples, accuracy 0.478
- 20/20 sanity requests passed in every mode
- live MoRI traffic used distinct cross-host fabric addresses and changed RDMA counters

Local/static checks:

- Buildkite agent dry-run parse with warning rejection
- ShellCheck for both runners
- Black and Ruff for the evaluation harness
- `cargo fmt --check`
- focused discovery-health unit test on Rust 1.95

## Operational note

The current pinned `amd_mori` runtime is stable for sequential cross-node evaluation. Ten-way RDMA concurrency produced `HSA_STATUS_ERROR_OUT_OF_RESOURCES`, while the no-connector control passed, so the RDMA gate intentionally runs at concurrency 1. XGMI retains concurrency 10.

The dedicated Buildkite agent is registered and waiting on `router_rocm_mi300_2`.

## Current CI status

- the two-node reboot test passed: the worker restored Docker, 8 GPUs, 8 HCAs, and all 8 MTU-9000 rails; the coordinator then passed its boot-time cluster preflight, registered the agent, and returned to `Waiting for instructions`
- fork build [#636](https://buildkite.com/vllm/router/builds/636) correctly ignored the privileged ROCm lanes; the trusted UI build requested from `@khluu` is still pending
- the failing Trivy check is unrelated to this diff: it reports existing `msgpack` and `setuptools` findings in the generic `Dockerfile.router` image and reproduces on unrelated upstream PRs
- Buildkite #636 is also waiting on the existing NVIDIA P/D disaggregation lane