### PR TITLE
[CI][ROCm] Skip NVIDIA P/D in ROCm-only builds

### DIFF
--- a/.buildkite/README.md
+++ b/.buildkite/README.md
@@ -79,6 +79,10 @@ RDMA matrix runs for scheduled builds with `NIGHTLY=1`, or trusted manual/API
 builds with `RUN_ROCM_RDMA=1`. Group-level filtering prevents Docker plugin
 hooks from running for untrusted fork pull requests.
 
+ROCm-only scheduled builds should set both `NIGHTLY=1` and `ROCM_ONLY=1`.
+`ROCM_ONLY=1` skips the unrelated NVIDIA four-GPU P/D step while retaining the
+CPU build that supplies the router artifact to both ROCm matrices.
+
 Both matrices use a digest-pinned ROCm vLLM image and run health, sanity, and
 500-example GSM8K accuracy checks. The RDMA job is coordinator-owned and
 controls the second host through the strict `vllm-router-rocm-worker` SSH alias.

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -195,6 +195,9 @@ steps:
   # ============================================================================
   - label: ":satellite: P/D Disaggregation Test (4 GPUs)"
     key: "pd-disagg-test"
+    # ROCm-only scheduled builds use the dedicated MI300X queue and should not
+    # wait for an unrelated NVIDIA worker before the build can finish.
+    if: build.env("ROCM_ONLY") != "1"
     timeout_in_minutes: 60
     retry:
       automatic:


### PR DESCRIPTION
## Summary

- add a `ROCM_ONLY=1` guard to the NVIDIA four-GPU P/D step
- document the `NIGHTLY=1` and `ROCM_ONLY=1` environment for the ROCm nightly schedule
- retain the CPU build and test stages that produce the router artifact consumed by the ROCm matrices

## Why

The two-node ROCm RDMA lane is selected by a Buildkite scheduled build with `NIGHTLY=1`. Without this guard, that ROCm nightly also instantiates the unrelated NVIDIA P/D job and can remain pending on `gpu_4_queue` after the ROCm jobs finish.

## Validation

- Buildkite agent pipeline dry-run parse with `--reject-parse-warnings`
- `git diff --check`

Follow-up to #202.