### PR TITLE
test: remove integration test network races

### DIFF
--- a/tests/common/mock_worker.rs
+++ b/tests/common/mock_worker.rs
@@ -61,18 +61,14 @@ impl MockWorker {
     /// Start the mock worker server
     pub async fn start(&mut self) -> Result<String, Box<dyn std::error::Error>> {
         let config = self.config.clone();
-        let port = config.read().await.port;
+        let requested_port = config.read().await.port;
 
-        // If port is 0, find an available port
-        let port = if port == 0 {
-            let listener = std::net::TcpListener::bind("127.0.0.1:0")?;
-            let port = listener.local_addr()?.port();
-            drop(listener);
-            config.write().await.port = port;
-            port
-        } else {
-            port
-        };
+        // Bind once and pass the listener directly to axum. Reserving a port
+        // with a temporary listener and rebinding it later creates a TOCTOU
+        // race when integration tests start mock workers concurrently.
+        let listener = tokio::net::TcpListener::bind(("127.0.0.1", requested_port)).await?;
+        let port = listener.local_addr()?.port();
+        config.write().await.port = port;
 
         let app = Router::new()
             .route("/health", get(health_handler))
@@ -98,14 +94,6 @@ impl MockWorker {
 
         // Spawn the server in a separate task
         let handle = tokio::spawn(async move {
-            let listener = match tokio::net::TcpListener::bind(("127.0.0.1", port)).await {
-                Ok(l) => l,
-                Err(e) => {
-                    eprintln!("Failed to bind to port {}: {}", port, e);
-                    return;
-                }
-            };
-
             let server = axum::serve(listener, app).with_graceful_shutdown(async move {
                 let _ = shutdown_rx.await;
             });

--- a/tests/test_openai_routing.rs
+++ b/tests/test_openai_routing.rs
@@ -90,7 +90,8 @@ async fn test_openai_router_creation() {
 /// Test health endpoints
 #[tokio::test]
 async fn test_openai_router_health() {
-    let router = OpenAIRouter::new("https://api.openai.com".to_string(), None)
+    let mock_server = MockOpenAIServer::new().await;
+    let router = OpenAIRouter::new(mock_server.base_url(), None)
         .await
         .unwrap();
 

--- a/tests/test_openai_routing.rs
+++ b/tests/test_openai_routing.rs
@@ -90,7 +90,10 @@ async fn test_openai_router_creation() {
 /// Test health endpoints
 #[tokio::test]
 async fn test_openai_router_health() {
-    let mock_server = MockOpenAIServer::new().await;
+    // Health probes intentionally omit auth. An auth-required upstream should
+    // return 401, which still proves the endpoint is reachable and healthy.
+    let mock_server =
+        MockOpenAIServer::new_with_auth(Some("Bearer health-test-token".to_string())).await;
     let router = OpenAIRouter::new(mock_server.base_url(), None)
         .await
         .unwrap();


### PR DESCRIPTION
## What changed

- keep the mock worker's ephemeral TCP listener bound and pass it directly to Axum
- run the OpenAI health test against an auth-required local mock server

## Root cause

`MockWorker::start` previously bound port `0`, recorded the assigned port,
dropped the listener, and rebound the port in a spawned task. Parallel tests
could claim the port during that gap, producing `Address already in use` and a
downstream HTTP 500.

The OpenAI health test also called `api.openai.com` directly. A transient
network failure produced HTTP 503 even though the Router code was unchanged.

## Impact

Rust integration tests no longer depend on an external service or use a
time-of-check/time-of-use port reservation. The local health fixture requires
auth, preserving coverage that an unauthenticated 401 response still proves
the upstream endpoint is reachable.

## Validation

Run in `rust:1.95.0-bullseye`, matching Buildkite:

- `cargo fmt --check`
- each formerly failing test passed 20 consecutive repetitions
- authenticated health test passed 20 consecutive repetitions after review update
- `test_openai_routing`: 12 passed
- `test_dp_routing`: 16 passed
