### PR TITLE
ci: serialize ROCm cluster jobs

### DIFF
--- a/.buildkite/README.md
+++ b/.buildkite/README.md
@@ -83,6 +83,14 @@ ROCm-only scheduled builds should set both `NIGHTLY=1` and `ROCM_ONLY=1`.
 `ROCM_ONLY=1` skips the unrelated NVIDIA four-GPU P/D step while retaining the
 CPU build that supplies the router artifact to both ROCm matrices.
 
+Both ROCm steps share the organization-wide concurrency group
+`vllm/router-rocm-mi300x-pair` with a limit of one. This prevents jobs from
+different builds or pipelines from owning the coordinator/worker pair at the
+same time, even if the queue gains more agents later. Automatic retries are
+limited to Buildkite's lost-agent exit status (`-1`); test, GPU, and RDMA
+failures require an inspected manual retry so regressions cannot be hidden by a
+second green attempt.
+
 Both matrices use a digest-pinned ROCm vLLM image and run health, sanity, and
 500-example GSM8K accuracy checks. The RDMA job is coordinator-owned and
 controls the second host through the strict `vllm-router-rocm-worker` SSH alias.

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -321,7 +321,9 @@ steps:
               - "false"
         retry:
           automatic:
-            - exit_status: "*"
+            # Retry only when Buildkite loses the agent. Test, GPU, and
+            # transport failures must remain visible for inspection.
+            - exit_status: -1
               limit: 1
           manual:
             allowed: true
@@ -379,6 +381,10 @@ steps:
                   bash py_test/e2e/pd_disagg_vllm/run_moriio_accuracy_test.sh
         agents:
           queue: "router_rocm_mi300_2"
+        # Serialize every job that owns the paired MI300X cluster, including
+        # jobs from separate builds and other pipelines in the organization.
+        concurrency: 1
+        concurrency_group: "vllm/router-rocm-mi300x-pair"
         depends_on: "build"
         artifact_paths:
           - "target/ci-logs/moriio-*/*.log"
@@ -400,7 +406,9 @@ steps:
           - "false"
     retry:
       automatic:
-        - exit_status: "*"
+        # Retry only when Buildkite loses the agent. A functional RDMA failure
+        # should fail the nightly and alert an operator.
+        - exit_status: -1
           limit: 1
       manual:
         allowed: true
@@ -428,6 +436,8 @@ steps:
       bash py_test/e2e/pd_disagg_vllm/run_moriio_rdma_accuracy_test.sh
     agents:
       queue: "router_rocm_mi300_2"
+    concurrency: 1
+    concurrency_group: "vllm/router-rocm-mi300x-pair"
     depends_on: "build"
     artifact_paths:
       - "target/ci-logs/moriio-rdma-*/*"


### PR DESCRIPTION
## What changed

- serialize XGMI and two-node RDMA jobs through one organization-wide
  `vllm/router-rocm-mi300x-pair` concurrency group
- automatically retry only Buildkite's lost-agent exit status (`-1`)
- retain inspected manual retries for GPU and RDMA failures

## Why

The queue currently has one coordinator agent, but queue size alone is not a
durable resource lock. A future agent or another pipeline could otherwise own
the same coordinator/worker pair concurrently.

Wildcard automatic retries also allow a functional GPU or RDMA regression to
finish green on a second attempt. Limiting automatic retry to a lost agent keeps
infrastructure recovery while preserving real failures for triage.

## Validation

- generic YAML parsing passed
- the live Buildkite agent accepted the complete pipeline with
  `pipeline upload --dry-run --no-interpolation`
- rendered output contained `concurrency: 1`, the shared concurrency group, and
  `exit_status: -1` on both ROCm steps
