### PR TITLE
feat: concurrent P/D dispatch for NIXL (decode prepares while prefill runs)

### DIFF
--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -80,6 +80,9 @@ pub struct RouterConfig {
     /// KV connector type for PD disaggregation
     #[serde(default)]
     pub kv_connector: KvConnector,
+    /// Enable concurrent P/D dispatch for the NIXL pull connector
+    #[serde(default)]
+    pub pd_concurrent_dispatch: bool,
 }
 
 fn default_profile_timeout_secs() -> u64 {
@@ -479,6 +482,7 @@ impl Default for RouterConfig {
             enable_profiling: false,
             profile_timeout_secs: default_profile_timeout_secs(),
             kv_connector: KvConnector::default(),
+            pd_concurrent_dispatch: false,
         }
     }
 }
@@ -1053,6 +1057,7 @@ mod tests {
             enable_profiling: false,
             profile_timeout_secs: default_profile_timeout_secs(),
             kv_connector: KvConnector::default(),
+            pd_concurrent_dispatch: false,
         };
 
         assert!(config.mode.is_pd_mode());
@@ -1119,6 +1124,7 @@ mod tests {
             enable_profiling: false,
             profile_timeout_secs: default_profile_timeout_secs(),
             kv_connector: KvConnector::default(),
+            pd_concurrent_dispatch: false,
         };
 
         assert!(!config.mode.is_pd_mode());
@@ -1181,6 +1187,7 @@ mod tests {
             enable_profiling: false,
             profile_timeout_secs: default_profile_timeout_secs(),
             kv_connector: KvConnector::default(),
+            pd_concurrent_dispatch: false,
         };
 
         assert!(config.has_service_discovery());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -237,6 +237,7 @@ impl Router {
                     });
                 }
             },
+            pd_concurrent_dispatch: false, // Not exposed in the Python binding
         })
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -338,6 +338,11 @@ struct CliArgs {
     /// KV connector type for PD disaggregation (nixl or mooncake)
     #[arg(long, value_enum, default_value_t = KvConnector::Nixl)]
     kv_connector: KvConnector,
+
+    /// Enable concurrent P/D dispatch for the NIXL pull connector (requires
+    /// vLLM-side prepare-parking support: POST /v1/pd_kv_ready)
+    #[arg(long, default_value_t = false)]
+    pd_concurrent_dispatch: bool,
 }
 
 impl CliArgs {
@@ -557,6 +562,7 @@ impl CliArgs {
             enable_profiling: self.profile,
             profile_timeout_secs: 10, // Default profiling timeout
             kv_connector: self.kv_connector,
+            pd_concurrent_dispatch: self.pd_concurrent_dispatch,
         })
     }
 

--- a/src/routers/http/vllm_pd_router.rs
+++ b/src/routers/http/vllm_pd_router.rs
@@ -21,7 +21,7 @@ use axum::{
 use serde_json::{json, Value};
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use std::time::Instant;
 use tokio::sync::Mutex;
 use tracing::{debug, error, info, warn};
@@ -61,6 +61,12 @@ pub struct VllmPDRouter {
     kv_connector: KvConnector,
     /// Mooncake bootstrap info: prefill base_url -> MooncakePrefillInfo
     mooncake_prefill_info: Arc<Mutex<HashMap<String, MooncakePrefillInfo>>>,
+    /// Enable concurrent P/D dispatch (NIXL pull mode only)
+    pd_concurrent_dispatch: bool,
+    /// NIXL transfer mode ("pull"/"push") learned from the first prefill
+    /// response's kv_transfer_params; concurrent dispatch stays off until
+    /// pull mode is confirmed.
+    nixl_transfer_mode: Arc<OnceLock<String>>,
 }
 
 /// Transfer ID prefix used by MoRI-IO to correlate prefill and decode legs.
@@ -331,7 +337,11 @@ impl VllmPDRouter {
                     Some(params)
                 }
             }
-            KvConnector::Nixl => Some(prefill_response_json?.get("kv_transfer_params")?.clone()),
+            KvConnector::Nixl => {
+                let params = prefill_response_json?.get("kv_transfer_params")?.clone();
+                self.note_nixl_transfer_mode(&params);
+                Some(params)
+            }
         }
     }
 
@@ -1152,6 +1162,393 @@ impl VllmPDRouter {
         .await
     }
 
+    /// Record the NIXL transfer mode ("pull"/"push") advertised in a prefill
+    /// response's kv_transfer_params. Concurrent dispatch relies on the
+    /// decode worker pulling KV from the prefill worker, so it only activates
+    /// once pull mode is confirmed; the first request always runs serially.
+    fn note_nixl_transfer_mode(&self, kv_transfer_params: &Value) {
+        let Some(mode) = kv_transfer_params
+            .get("transfer_mode")
+            .and_then(|v| v.as_str())
+        else {
+            return;
+        };
+        if self.nixl_transfer_mode.set(mode.to_string()).is_ok() {
+            info!(
+                "Learned NIXL transfer mode '{}' from prefill response{}",
+                mode,
+                if self.pd_concurrent_dispatch && mode == "pull" {
+                    "; concurrent P/D dispatch active for subsequent requests"
+                } else {
+                    ""
+                }
+            );
+        }
+    }
+
+    /// Concurrent P/D dispatch gate: opt-in via config, NIXL pull mode only.
+    fn concurrent_dispatch_enabled(&self) -> bool {
+        self.pd_concurrent_dispatch
+            && matches!(self.kv_connector, KvConnector::Nixl)
+            && self.nixl_transfer_mode.get().map(String::as_str) == Some("pull")
+    }
+
+    /// Concurrent P/D dispatch (NIXL only): both legs are dispatched at
+    /// once; the decode leg parks in the scheduler until the router
+    /// forwards the prefill's kv_transfer_params via POST /v1/pd_kv_ready.
+    /// On any failure the decode leg is aborted; a ready notification lost
+    /// after a 2xx is covered by the decode-side park timeout.
+    async fn process_vllm_concurrent_request(
+        &self,
+        original_request: Value,
+        prefill_worker: Arc<dyn Worker>,
+        decode_worker: Arc<dyn Worker>,
+        path: &str,
+        headers: Option<&HeaderMap>,
+    ) -> Result<Response, PDRouterError> {
+        let start_time = Instant::now();
+
+        let prefill_zmq_addr =
+            self.get_zmq_address(prefill_worker.base_url(), ServiceType::Prefill);
+        let decode_zmq_addr = self.get_zmq_address(decode_worker.base_url(), ServiceType::Decode);
+        let request_id = Self::generate_vllm_request_id(&prefill_zmq_addr, &decode_zmq_addr);
+
+        info!(
+            "pd_concurrent_dispatch request_id={} prefill={} decode={}",
+            request_id,
+            prefill_worker.url(),
+            decode_worker.url()
+        );
+
+        // Prefill request: same shape as the serial path.
+        let mut prefill_request = Self::prepare_prefill_request(original_request.clone(), path);
+        let decode_base_url = decode_worker.base_url().to_string();
+        prefill_request["kv_transfer_params"] = self
+            .build_prefill_kv_transfer_params(None, Some(&decode_base_url), decode_worker.dp_rank())
+            .map_err(|reason| PDRouterError::InvalidConfiguration { reason })?;
+
+        // Decode prepare request: marks the request for scheduler parking.
+        let mut decode_request = original_request.clone();
+        decode_request["kv_transfer_params"] = json!({
+            "do_remote_decode": false,
+            "do_remote_prefill": true,
+            "remote_ready": false
+        });
+
+        let prefill_base_url = prefill_worker.base_url().to_string();
+        let decode_base_http = decode_base_url.clone();
+        let prefill_url = prefill_worker.endpoint_url(path);
+        let decode_url = decode_worker.endpoint_url(path);
+
+        prefill_worker.increment_load();
+        decode_worker.increment_load();
+
+        // Dispatch the decode leg in the background: send() only resolves on
+        // completion for non-streaming requests, so a join would deadlock on
+        // the ready notification we have not sent yet.
+        let mut decode_request_builder = self
+            .pd_router
+            .client
+            .post(&decode_url)
+            .header("Content-Type", "application/json")
+            .header(
+                "Authorization",
+                format!(
+                    "Bearer {}",
+                    std::env::var("OPENAI_API_KEY").unwrap_or_default()
+                ),
+            )
+            .header("X-Request-Id", &request_id);
+        decode_request_builder =
+            header_utils::propagate_trace_headers(decode_request_builder, headers);
+        decode_request_builder =
+            dp_utils::add_dp_rank_header(decode_request_builder, decode_worker.dp_rank());
+        let decode_handle =
+            tokio::spawn(async move { decode_request_builder.json(&decode_request).send().await });
+        // Abort the detached decode task if this handler future is dropped
+        // (client disconnect); no-op once the task finished.
+        struct AbortOnDrop(tokio::task::AbortHandle);
+        impl Drop for AbortOnDrop {
+            fn drop(&mut self) {
+                self.0.abort();
+            }
+        }
+        let _decode_abort_guard = AbortOnDrop(decode_handle.abort_handle());
+
+        let mut prefill_request_builder = self
+            .pd_router
+            .client
+            .post(&prefill_url)
+            .header("Content-Type", "application/json")
+            .header(
+                "Authorization",
+                format!(
+                    "Bearer {}",
+                    std::env::var("OPENAI_API_KEY").unwrap_or_default()
+                ),
+            )
+            .header("X-Request-Id", &request_id);
+        prefill_request_builder =
+            dp_utils::add_dp_rank_header(prefill_request_builder, prefill_worker.dp_rank());
+
+        type DecodeHandle = tokio::task::JoinHandle<Result<reqwest::Response, reqwest::Error>>;
+        let fail = |message: String, is_prefill_error: bool, decode_handle: &DecodeHandle| {
+            decode_handle.abort();
+            prefill_worker.decrement_load();
+            decode_worker.decrement_load();
+            let duration = start_time.elapsed();
+            if is_prefill_error {
+                RouterMetrics::record_pd_prefill_error(&prefill_base_url);
+            } else {
+                RouterMetrics::record_pd_decode_error(&decode_base_http);
+            }
+            RouterMetrics::record_pd_request(path);
+            RouterMetrics::record_pd_request_duration(path, duration);
+            PDRouterError::NetworkError { message }
+        };
+
+        let prefill_response = match otel_http::send_client_request(
+            prefill_request_builder.json(&prefill_request),
+            headers,
+            ClientRequestOptions {
+                method: "POST",
+                url: &prefill_url,
+                route: Some(path),
+                request_phase: Some("prefill"),
+            },
+        )
+        .await
+        {
+            Ok(resp) => resp,
+            Err(e) => {
+                return Err(fail(
+                    format!(
+                        "Prefill request failed to {}: {}",
+                        prefill_url,
+                        error_chain(&e)
+                    ),
+                    true,
+                    &decode_handle,
+                ));
+            }
+        };
+
+        let prefill_status = prefill_response.status();
+        let prefill_bytes = match prefill_response.bytes().await {
+            Ok(bytes) => bytes,
+            Err(e) => {
+                return Err(fail(
+                    format!(
+                        "Failed to read prefill response from {}: {}",
+                        prefill_url,
+                        error_chain(&e)
+                    ),
+                    true,
+                    &decode_handle,
+                ));
+            }
+        };
+        if !prefill_status.is_success() {
+            return Err(fail(
+                format!(
+                    "Prefill server error {}: {}",
+                    prefill_status,
+                    String::from_utf8_lossy(&prefill_bytes)
+                ),
+                true,
+                &decode_handle,
+            ));
+        }
+
+        let prefill_response_json: Value = match serde_json::from_slice(&prefill_bytes) {
+            Ok(json) => json,
+            Err(e) => {
+                return Err(fail(
+                    format!("Failed to parse prefill response as JSON: {}", e),
+                    true,
+                    &decode_handle,
+                ));
+            }
+        };
+
+        let kv_transfer_params = match prefill_response_json.get("kv_transfer_params") {
+            Some(params) if params.is_object() => params.clone(),
+            _ => {
+                return Err(fail(
+                    "Prefill response has no kv_transfer_params; cannot resume \
+                     the concurrently dispatched decode request"
+                        .to_string(),
+                    true,
+                    &decode_handle,
+                ));
+            }
+        };
+
+        // Forward the ready notification to the decode worker, with retries.
+        let ready_url = decode_worker.endpoint_url("/v1/pd_kv_ready");
+        let ready_payload = json!({
+            "request_id": request_id,
+            "kv_transfer_params": kv_transfer_params,
+        });
+        let mut ready_ok = false;
+        for attempt in 0..3 {
+            // Match the decode leg's headers: auth plus the DP-rank header,
+            // since endpoint_url() drops the @rank suffix.
+            let mut ready_request_builder = self
+                .pd_router
+                .client
+                .post(&ready_url)
+                .header("Content-Type", "application/json")
+                .header(
+                    "Authorization",
+                    format!(
+                        "Bearer {}",
+                        std::env::var("OPENAI_API_KEY").unwrap_or_default()
+                    ),
+                )
+                .header("X-Request-Id", &request_id);
+            ready_request_builder =
+                dp_utils::add_dp_rank_header(ready_request_builder, decode_worker.dp_rank());
+            match ready_request_builder.json(&ready_payload).send().await {
+                Ok(resp) if resp.status().is_success() => {
+                    ready_ok = true;
+                    break;
+                }
+                Ok(resp) => {
+                    warn!(
+                        "pd_kv_ready POST attempt {} to {} returned {}",
+                        attempt + 1,
+                        ready_url,
+                        resp.status()
+                    );
+                }
+                Err(e) => {
+                    warn!(
+                        "pd_kv_ready POST attempt {} to {} failed: {}",
+                        attempt + 1,
+                        ready_url,
+                        error_chain(&e)
+                    );
+                }
+            }
+            tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+        }
+        if !ready_ok {
+            return Err(fail(
+                format!("Failed to deliver pd_kv_ready to {}", ready_url),
+                false,
+                &decode_handle,
+            ));
+        }
+        debug!(
+            "pd_kv_ready forwarded request_id={} decode={}",
+            request_id, decode_base_http
+        );
+        prefill_worker.decrement_load();
+
+        // Wait for the decode response.
+        let decode_response = match decode_handle.await {
+            Ok(Ok(resp)) => resp,
+            Ok(Err(e)) => {
+                decode_worker.decrement_load();
+                let duration = start_time.elapsed();
+                RouterMetrics::record_pd_decode_error(&decode_base_http);
+                RouterMetrics::record_pd_request(path);
+                RouterMetrics::record_pd_request_duration(path, duration);
+                RouterMetrics::record_pd_prefill_request(&prefill_base_url);
+                return Err(PDRouterError::NetworkError {
+                    message: format!(
+                        "Decode request failed to {}: {}",
+                        decode_url,
+                        error_chain(&e)
+                    ),
+                });
+            }
+            Err(e) => {
+                decode_worker.decrement_load();
+                let duration = start_time.elapsed();
+                RouterMetrics::record_pd_decode_error(&decode_base_http);
+                RouterMetrics::record_pd_request(path);
+                RouterMetrics::record_pd_request_duration(path, duration);
+                RouterMetrics::record_pd_prefill_request(&prefill_base_url);
+                return Err(PDRouterError::NetworkError {
+                    message: format!("Decode request task failed: {}", e),
+                });
+            }
+        };
+
+        decode_worker.decrement_load();
+
+        let status = decode_response.status();
+        let response_headers = decode_response.headers().clone();
+
+        let duration = start_time.elapsed();
+        RouterMetrics::record_pd_request(path);
+        RouterMetrics::record_pd_request_duration(path, duration);
+        RouterMetrics::record_pd_prefill_request(&prefill_base_url);
+        RouterMetrics::record_pd_decode_request(&decode_base_http);
+        if !status.is_success() {
+            RouterMetrics::record_pd_decode_error(&decode_base_http);
+        }
+
+        // Same response handling as the serial path.
+        let needs_logprobs = original_request.get("logprobs").is_some()
+            || original_request
+                .get("echo")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+        let is_streaming = original_request
+            .get("stream")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+
+        if needs_logprobs && !is_streaming {
+            let decode_body =
+                decode_response
+                    .bytes()
+                    .await
+                    .map_err(|e| PDRouterError::NetworkError {
+                        message: format!(
+                            "Failed to read decode response from {}: {}",
+                            decode_url, e
+                        ),
+                    })?;
+            let mut decode_json: Value =
+                serde_json::from_slice(&decode_body).map_err(|e| PDRouterError::NetworkError {
+                    message: format!("Failed to parse decode response as JSON: {}", e),
+                })?;
+            logprobs_merge::merge_logprobs_in_json(&prefill_response_json, &mut decode_json);
+            let merged_body =
+                serde_json::to_vec(&decode_json).map_err(|e| PDRouterError::NetworkError {
+                    message: format!("Failed to serialize merged response: {}", e),
+                })?;
+            let mut response_builder = Response::builder().status(status);
+            for (key, value) in response_headers.iter() {
+                if key != "transfer-encoding" && key != "content-length" {
+                    response_builder = response_builder.header(key, value);
+                }
+            }
+            response_builder.body(Body::from(merged_body)).map_err(|e| {
+                PDRouterError::NetworkError {
+                    message: format!("Failed to build response from {}: {}", decode_url, e),
+                }
+            })
+        } else {
+            let mut response_builder = Response::builder().status(status);
+            for (key, value) in response_headers.iter() {
+                if key != "transfer-encoding" && key != "content-length" {
+                    response_builder = response_builder.header(key, value);
+                }
+            }
+            let body = Body::from_stream(decode_response.bytes_stream());
+            response_builder
+                .body(body)
+                .map_err(|e| PDRouterError::NetworkError {
+                    message: format!("Failed to build response from {}: {}", decode_url, e),
+                })
+        }
+    }
+
     /// Two-stage request processing for vLLM disaggregated mode
     ///
     /// This function handles fine-grained load tracking: the prefill worker's load is only
@@ -1165,6 +1562,17 @@ impl VllmPDRouter {
         path: &str,
         headers: Option<&HeaderMap>,
     ) -> Result<Response, PDRouterError> {
+        if self.concurrent_dispatch_enabled() {
+            return self
+                .process_vllm_concurrent_request(
+                    original_request,
+                    prefill_worker,
+                    decode_worker,
+                    path,
+                    headers,
+                )
+                .await;
+        }
         debug!("ENTERED process_vllm_two_stage_request method");
         let start_time = Instant::now();
         debug!(
@@ -1620,6 +2028,8 @@ impl VllmPDRouter {
                 prefill_dp_round_robin: Arc::new(AtomicUsize::new(0)),
                 kv_connector,
                 mooncake_prefill_info: Arc::new(Mutex::new(HashMap::new())),
+                pd_concurrent_dispatch: ctx.router_config.pd_concurrent_dispatch,
+                nixl_transfer_mode: Arc::new(OnceLock::new()),
             })
         } else {
             // Direct URL mode (same as PdRouterBase)
@@ -1709,6 +2119,8 @@ impl VllmPDRouter {
                 prefill_dp_round_robin: Arc::new(AtomicUsize::new(0)),
                 kv_connector,
                 mooncake_prefill_info,
+                pd_concurrent_dispatch: ctx.router_config.pd_concurrent_dispatch,
+                nixl_transfer_mode: Arc::new(OnceLock::new()),
             })
         }
     }

--- a/tests/api_endpoints_test.rs
+++ b/tests/api_endpoints_test.rs
@@ -61,6 +61,7 @@ impl TestContext {
             enable_profiling: false,
             profile_timeout_secs: 30,
             kv_connector: vllm_router_rs::config::KvConnector::Nixl,
+            pd_concurrent_dispatch: false,
         };
 
         Self::new_with_config(config, worker_configs).await
@@ -1393,6 +1394,7 @@ mod error_tests {
             enable_profiling: false,
             profile_timeout_secs: 30,
             kv_connector: vllm_router_rs::config::KvConnector::Nixl,
+            pd_concurrent_dispatch: false,
         };
 
         let ctx = TestContext::new_with_config(
@@ -1755,6 +1757,7 @@ mod pd_mode_tests {
             enable_profiling: false,
             profile_timeout_secs: 30,
             kv_connector: vllm_router_rs::config::KvConnector::Nixl,
+            pd_concurrent_dispatch: false,
         };
 
         // Create app context
@@ -1920,6 +1923,7 @@ mod request_id_tests {
             enable_profiling: false,
             profile_timeout_secs: 30,
             kv_connector: vllm_router_rs::config::KvConnector::Nixl,
+            pd_concurrent_dispatch: false,
         };
 
         let ctx = TestContext::new_with_config(

--- a/tests/test_dp_routing.rs
+++ b/tests/test_dp_routing.rs
@@ -279,6 +279,7 @@ mod dp_e2e_tests {
             enable_profiling: false,
             profile_timeout_secs: 30,
             kv_connector: vllm_router_rs::config::KvConnector::Nixl,
+            pd_concurrent_dispatch: false,
         }
     }
 
@@ -327,6 +328,7 @@ mod dp_e2e_tests {
             enable_profiling: false,
             profile_timeout_secs: 30,
             kv_connector: vllm_router_rs::config::KvConnector::Nixl,
+            pd_concurrent_dispatch: false,
         }
     }
 

--- a/tests/test_pd_routing.rs
+++ b/tests/test_pd_routing.rs
@@ -130,6 +130,7 @@ mod test_pd_routing {
                 enable_profiling: false,
                 profile_timeout_secs: 30,
                 kv_connector: vllm_router_rs::config::KvConnector::Nixl,
+                pd_concurrent_dispatch: false,
             };
 
             // Router creation will fail due to health checks, but config should be valid


### PR DESCRIPTION
Companion of the vLLM PR https://github.com/vllm-project/vllm/pull/51919 (requires its
`/v1/pd_kv_ready` + prepare-parking support).

### Motivation

The two-stage vLLM PD flow is strictly serial: the decode worker receives the
request only after the prefill has responded, so decode-side HTTP parsing,
tokenization and scheduler admission (~32ms p50 on our 3P1D setup) sit on the
TTFT critical path.

### Changes

With `VLLM_PD_CONCURRENT_DISPATCH=1` (opt-in; NIXL connector only), the router
dispatches both legs at once:

- The decode leg is spawned first with `kv_transfer_params=
  {"do_remote_decode": false, "do_remote_prefill": true, "remote_ready": false}`;
  the decode instance tokenizes, enqueues and parks the request while the
  prefill computes.
- When the prefill responds, the router forwards its `kv_transfer_params`
  (including seeded `first_token_ids`, when enabled) to the decode worker via
  `POST /v1/pd_kv_ready`, retried 3 times.
- Failures (prefill error, missing `kv_transfer_params`, undeliverable ready
  POST) abort the spawned decode leg and return an error; an abort-on-drop
  guard covers client disconnects; a notification lost after a 2xx is covered
  by the decode-side park timeout (local prefill fallback).
- Response handling (logprobs merge / streaming passthrough) and PD metrics
  mirror the serial path. Default off; the serial flow is unchanged.

### Testing

- 3P1D deployment with the vLLM PR; flag on/off A/B runs (1000 requests) and
  fault injection (dropped ready POST, prefill failure, client disconnect).
- Result: decode front-end fully overlapped with prefill; handover
  63ms → 52/36ms p50, mean/median TTFT −23% vs. stock at default settings.

### Changes in the 8/26 update (addressing review comments) (re-tested)
- **Env var → config option.** Removed the `VLLM_PD_CONCURRENT_DISPATCH` env var
  (previously read on every request). Concurrent dispatch is now enabled via a proper
  router option: `--pd-concurrent-dispatch` CLI flag / `RouterConfig.pd_concurrent_dispatch`
  (default: off), parsed once at startup.
- **Gated on NIXL pull mode via `transfer_mode`.** The router now learns the connector's
  `transfer_mode` from the first prefill response's `kv_transfer_params` (exposed by
  vllm-project/vllm#50620) and caches it. Concurrent dispatch only activates once
  `"pull"` mode is confirmed; until then (and always for `"push"`), requests take the
  existing serial path. This keeps this PR strictly scoped to pull mode and orthogonal
  to the push-mode concurrent dispatch in #187 — push deployments are never affected.
- **Fixed `/v1/pd_kv_ready` request headers.** The ready notification now carries the
  same headers as the decode leg: `Authorization`, `X-Request-Id`, `Content-Type`, and
  the data-parallel-rank header (`endpoint_url()` strips the `@rank` suffix, so the DP
  rank must travel in the header). Previously the ready POST could be rejected by
  auth-enabled workers or land on the wrong DP rank.

No changes to the vLLM-side protocol; the fallback behavior (decode-side park timeout
covering a lost ready notification) is unchanged.