### PR TITLE
fix: report end-to-end PD usage accounting

### DIFF
--- a/src/routers/http/mod.rs
+++ b/src/routers/http/mod.rs
@@ -6,5 +6,6 @@ pub mod openai_router;
 pub mod pd_router;
 pub mod pd_types;
 pub mod router;
+pub mod usage_merge;
 pub mod vllm_pd_router;
 pub mod vllm_service_discovery;

--- a/src/routers/http/usage_merge.rs
+++ b/src/routers/http/usage_merge.rs
@@ -1,0 +1,406 @@
+//! Usage merging utilities for prefill/decode disaggregation.
+//!
+//! A decode worker reports KV transferred from the prefill worker as cached
+//! tokens. That is correct from the decode worker's point of view, but it makes
+//! a cold end-to-end PD request look like a 100% prefix-cache hit. The router
+//! has both responses, so it must take input/cache accounting from prefill and
+//! output accounting from decode.
+
+use bytes::Bytes;
+use futures_util::{stream, Stream, StreamExt};
+use serde_json::{Map, Value};
+use std::pin::Pin;
+
+type UpstreamByteStream =
+    Pin<Box<dyn Stream<Item = Result<Bytes, reqwest::Error>> + Send + 'static>>;
+
+struct SseRewriteState {
+    upstream: UpstreamByteStream,
+    buffer: Vec<u8>,
+    prefill_response: Option<Value>,
+    finished: bool,
+}
+
+fn usage_object(value: &Value) -> Option<&Map<String, Value>> {
+    value.get("usage").and_then(Value::as_object).or_else(|| {
+        value
+            .get("response")
+            .and_then(|response| response.get("usage"))
+            .and_then(Value::as_object)
+    })
+}
+
+fn usage_object_mut(value: &mut Value) -> Option<&mut Map<String, Value>> {
+    if value.get("usage").and_then(Value::as_object).is_some() {
+        return value.get_mut("usage").and_then(Value::as_object_mut);
+    }
+
+    value
+        .get_mut("response")
+        .and_then(|response| response.get_mut("usage"))
+        .and_then(Value::as_object_mut)
+}
+
+fn merge_pd_usage_inner(
+    prefill_response: &Value,
+    decode_response: &mut Value,
+    copy_details: bool,
+) -> bool {
+    let Some(prefill_usage) = usage_object(prefill_response) else {
+        return false;
+    };
+    let Some(decode_usage) = usage_object_mut(decode_response) else {
+        return false;
+    };
+
+    let (input_key, details_key, output_key) = if prefill_usage.contains_key("prompt_tokens") {
+        (
+            "prompt_tokens",
+            "prompt_tokens_details",
+            "completion_tokens",
+        )
+    } else if prefill_usage.contains_key("input_tokens") {
+        ("input_tokens", "input_tokens_details", "output_tokens")
+    } else {
+        return false;
+    };
+
+    let Some(input_tokens) = prefill_usage.get(input_key).cloned() else {
+        return false;
+    };
+    decode_usage.insert(input_key.to_string(), input_tokens.clone());
+
+    if copy_details {
+        if let Some(details) = prefill_usage.get(details_key) {
+            decode_usage.insert(details_key.to_string(), details.clone());
+        } else {
+            // Never leave decode-side external KV transfer masquerading as an
+            // end-to-end prefix-cache hit when prefill did not report details.
+            decode_usage.remove(details_key);
+        }
+    }
+
+    if let (Some(input), Some(output)) = (
+        input_tokens.as_u64(),
+        decode_usage.get(output_key).and_then(Value::as_u64),
+    ) {
+        if let Some(total) = input.checked_add(output) {
+            decode_usage.insert("total_tokens".to_string(), Value::from(total));
+        }
+    }
+
+    true
+}
+
+/// Merge end-to-end PD usage into a non-streaming decode response.
+///
+/// Input counts and cache details come from prefill. Output counts stay on the
+/// decode response, so the prefill worker's forced one-token output is never
+/// exposed or billed.
+pub fn merge_pd_usage(prefill_response: &Value, decode_response: &mut Value) -> bool {
+    merge_pd_usage_inner(prefill_response, decode_response, true)
+}
+
+/// Keep only the small usage portion of a prefill response for the lifetime of
+/// a decode stream. In particular, do not retain large KV-transfer block lists.
+pub fn usage_snapshot(prefill_response: &Value) -> Option<Value> {
+    usage_object(prefill_response).cloned().map(|usage| {
+        Value::Object(Map::from_iter([(
+            "usage".to_string(),
+            Value::Object(usage),
+        )]))
+    })
+}
+
+fn is_final_usage_event(value: &Value) -> bool {
+    // Chat/Completions emits a final usage-only chunk with an empty choices
+    // array. Responses API carries the final usage under `response.usage`.
+    value
+        .get("choices")
+        .and_then(Value::as_array)
+        .is_some_and(Vec::is_empty)
+        || value.get("response").is_some()
+        || usage_object(value).is_some_and(|usage| {
+            usage.contains_key("prompt_tokens_details")
+                || usage.contains_key("input_tokens_details")
+        })
+}
+
+fn find_sse_event_end(buffer: &[u8]) -> Option<usize> {
+    let lf = buffer
+        .windows(2)
+        .position(|window| window == b"\n\n")
+        .map(|index| index + 2);
+    let crlf = buffer
+        .windows(4)
+        .position(|window| window == b"\r\n\r\n")
+        .map(|index| index + 4);
+
+    match (lf, crlf) {
+        (Some(a), Some(b)) => Some(a.min(b)),
+        (Some(a), None) => Some(a),
+        (None, Some(b)) => Some(b),
+        (None, None) => None,
+    }
+}
+
+fn rewrite_sse_event(event: &[u8], prefill_response: &Value) -> Vec<u8> {
+    let mut line_start = 0;
+
+    while line_start < event.len() {
+        let line_end = event[line_start..]
+            .iter()
+            .position(|byte| *byte == b'\n')
+            .map(|offset| line_start + offset)
+            .unwrap_or(event.len());
+        let content_end = if line_end > line_start && event[line_end - 1] == b'\r' {
+            line_end - 1
+        } else {
+            line_end
+        };
+        let line = &event[line_start..content_end];
+
+        if let Some(payload) = line.strip_prefix(b"data:") {
+            let leading_spaces = payload.iter().take_while(|byte| **byte == b' ').count();
+            let json_start = line_start + b"data:".len() + leading_spaces;
+            let json_bytes = &event[json_start..content_end];
+
+            if json_bytes != b"[DONE]" {
+                if let Ok(mut decode_json) = serde_json::from_slice::<Value>(json_bytes) {
+                    let copy_details = is_final_usage_event(&decode_json);
+                    if merge_pd_usage_inner(prefill_response, &mut decode_json, copy_details) {
+                        let mut rewritten = Vec::with_capacity(event.len() + 64);
+                        rewritten.extend_from_slice(&event[..json_start]);
+                        if serde_json::to_writer(&mut rewritten, &decode_json).is_ok() {
+                            rewritten.extend_from_slice(&event[content_end..]);
+                            return rewritten;
+                        }
+                    }
+                }
+            }
+        }
+
+        if line_end == event.len() {
+            break;
+        }
+        line_start = line_end + 1;
+    }
+
+    event.to_vec()
+}
+
+/// Rewrite usage in an SSE byte stream while preserving streaming behavior.
+///
+/// Network chunks are not guaranteed to align with SSE events, so this keeps a
+/// small buffer until a complete blank-line-delimited event is available.
+pub fn rewrite_sse_usage_stream<S>(
+    upstream: S,
+    prefill_response: Option<Value>,
+) -> impl Stream<Item = Result<Bytes, reqwest::Error>>
+where
+    S: Stream<Item = Result<Bytes, reqwest::Error>> + Send + 'static,
+{
+    let state = SseRewriteState {
+        upstream: Box::pin(upstream),
+        buffer: Vec::new(),
+        prefill_response,
+        finished: false,
+    };
+
+    stream::unfold(state, |mut state| async move {
+        loop {
+            if let Some(event_end) = find_sse_event_end(&state.buffer) {
+                let event: Vec<u8> = state.buffer.drain(..event_end).collect();
+                let event = state
+                    .prefill_response
+                    .as_ref()
+                    .map(|prefill| rewrite_sse_event(&event, prefill))
+                    .unwrap_or(event);
+                return Some((Ok(Bytes::from(event)), state));
+            }
+
+            if state.finished {
+                if state.buffer.is_empty() {
+                    return None;
+                }
+                let tail = std::mem::take(&mut state.buffer);
+                let tail = state
+                    .prefill_response
+                    .as_ref()
+                    .map(|prefill| rewrite_sse_event(&tail, prefill))
+                    .unwrap_or(tail);
+                return Some((Ok(Bytes::from(tail)), state));
+            }
+
+            match state.upstream.next().await {
+                Some(Ok(chunk)) => state.buffer.extend_from_slice(&chunk),
+                Some(Err(error)) => {
+                    state.finished = true;
+                    state.buffer.clear();
+                    return Some((Err(error), state));
+                }
+                None => state.finished = true,
+            }
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures_util::stream;
+    use serde_json::json;
+
+    #[test]
+    fn merges_chat_and_completions_usage_from_prefill_and_decode() {
+        let prefill = json!({
+            "usage": {
+                "prompt_tokens": 186,
+                "completion_tokens": 1,
+                "total_tokens": 187,
+                "prompt_tokens_details": {"cached_tokens": 64}
+            }
+        });
+        let mut decode = json!({
+            "usage": {
+                "prompt_tokens": 999,
+                "completion_tokens": 8,
+                "total_tokens": 1007,
+                "prompt_tokens_details": {"cached_tokens": 999}
+            }
+        });
+
+        assert!(merge_pd_usage(&prefill, &mut decode));
+        assert_eq!(decode["usage"]["prompt_tokens"], 186);
+        assert_eq!(decode["usage"]["completion_tokens"], 8);
+        assert_eq!(decode["usage"]["total_tokens"], 194);
+        assert_eq!(
+            decode["usage"]["prompt_tokens_details"]["cached_tokens"],
+            64
+        );
+    }
+
+    #[test]
+    fn merges_responses_api_usage() {
+        let prefill = json!({
+            "usage": {
+                "input_tokens": 98,
+                "output_tokens": 1,
+                "total_tokens": 99,
+                "input_tokens_details": {"cached_tokens": 32}
+            }
+        });
+        let mut decode = json!({
+            "usage": {
+                "input_tokens": 98,
+                "output_tokens": 8,
+                "total_tokens": 106,
+                "input_tokens_details": {"cached_tokens": 98},
+                "output_tokens_details": {"reasoning_tokens": 3}
+            }
+        });
+
+        assert!(merge_pd_usage(&prefill, &mut decode));
+        assert_eq!(decode["usage"]["input_tokens"], 98);
+        assert_eq!(decode["usage"]["output_tokens"], 8);
+        assert_eq!(decode["usage"]["total_tokens"], 106);
+        assert_eq!(decode["usage"]["input_tokens_details"]["cached_tokens"], 32);
+        assert_eq!(
+            decode["usage"]["output_tokens_details"]["reasoning_tokens"],
+            3
+        );
+    }
+
+    #[test]
+    fn removes_decode_cache_details_when_prefill_did_not_report_them() {
+        let prefill = json!({
+            "usage": {"prompt_tokens": 10, "completion_tokens": 1, "total_tokens": 11}
+        });
+        let mut decode = json!({
+            "usage": {
+                "prompt_tokens": 10,
+                "completion_tokens": 2,
+                "total_tokens": 12,
+                "prompt_tokens_details": {"cached_tokens": 10}
+            }
+        });
+
+        assert!(merge_pd_usage(&prefill, &mut decode));
+        assert!(decode["usage"].get("prompt_tokens_details").is_none());
+    }
+
+    #[tokio::test]
+    async fn rewrites_split_chat_or_completions_streaming_usage_event() {
+        let prefill = json!({
+            "usage": {
+                "prompt_tokens": 127,
+                "completion_tokens": 1,
+                "total_tokens": 128,
+                "prompt_tokens_details": {"cached_tokens": 0}
+            }
+        });
+        let upstream = stream::iter(vec![
+            Ok::<Bytes, reqwest::Error>(Bytes::from_static(
+                b"data: {\"choices\":[{\"index\":0}],\"usage\":{\"prompt_tokens\":999,\"completion_tokens\":1,\"total_tokens\":1000}}\n\ndata: {\"choices\":[],\"usage\":{\"prompt_tokens\":999,",
+            )),
+            Ok::<Bytes, reqwest::Error>(Bytes::from_static(
+                b"\"completion_tokens\":8,\"total_tokens\":135,\"prompt_tokens_details\":{\"cached_tokens\":127}}}\n\ndata: [DONE]\n\n",
+            )),
+        ]);
+
+        let output = rewrite_sse_usage_stream(upstream, Some(prefill))
+            .collect::<Vec<_>>()
+            .await
+            .into_iter()
+            .map(Result::unwrap)
+            .fold(Vec::new(), |mut output, chunk| {
+                output.extend_from_slice(&chunk);
+                output
+            });
+        let output = String::from_utf8(output).unwrap();
+
+        assert!(output.contains("\"completion_tokens\":8"));
+        assert!(output.contains("\"prompt_tokens\":127"));
+        assert!(output.contains("\"total_tokens\":135"));
+        assert!(output.contains("\"cached_tokens\":0"));
+        assert!(!output.contains("\"cached_tokens\":127"));
+        assert!(!output.contains("\"prompt_tokens\":999"));
+        assert!(output.ends_with("data: [DONE]\n\n"));
+    }
+
+    #[test]
+    fn rewrites_nested_responses_api_streaming_event() {
+        let prefill = json!({
+            "usage": {
+                "input_tokens": 50,
+                "output_tokens": 1,
+                "total_tokens": 51,
+                "input_tokens_details": {"cached_tokens": 16}
+            }
+        });
+        let event = b"event: response.completed\r\ndata: {\"type\":\"response.completed\",\"response\":{\"usage\":{\"input_tokens\":999,\"output_tokens\":7,\"total_tokens\":1006,\"input_tokens_details\":{\"cached_tokens\":999},\"output_tokens_details\":{\"reasoning_tokens\":2}}}}\r\n\r\n";
+
+        let rewritten = rewrite_sse_event(event, &prefill);
+        let rewritten = String::from_utf8(rewritten).unwrap();
+
+        assert!(rewritten.contains("\"cached_tokens\":16"));
+        assert!(rewritten.contains("\"input_tokens\":50"));
+        assert!(rewritten.contains("\"output_tokens\":7"));
+        assert!(rewritten.contains("\"total_tokens\":57"));
+        assert!(rewritten.contains("\"reasoning_tokens\":2"));
+        assert!(!rewritten.contains("\"input_tokens\":999"));
+        assert!(rewritten.ends_with("\r\n\r\n"));
+    }
+
+    #[test]
+    fn usage_snapshot_drops_kv_transfer_metadata() {
+        let prefill = json!({
+            "usage": {"prompt_tokens": 10, "completion_tokens": 1},
+            "kv_transfer_params": {"remote_block_ids": [1, 2, 3]}
+        });
+
+        let snapshot = usage_snapshot(&prefill).unwrap();
+        assert_eq!(snapshot["usage"]["prompt_tokens"], 10);
+        assert!(snapshot.get("kv_transfer_params").is_none());
+    }
+}

--- a/src/routers/http/vllm_pd_router.rs
+++ b/src/routers/http/vllm_pd_router.rs
@@ -4,6 +4,7 @@ use super::dp_utils;
 use super::logprobs_merge;
 use super::pd_router::PdRouterBase;
 use super::pd_types::{error_chain, PDRouterError};
+use super::usage_merge;
 use super::vllm_service_discovery::{MoriIOTransferMode, ServiceRegistry, ServiceType};
 use crate::config::KvConnector;
 use crate::core::{BasicWorker, Worker, WorkerType};
@@ -694,45 +695,6 @@ impl VllmPDRouter {
             RouterMetrics::record_pd_decode_error(decode_http);
         }
 
-        if needs_logprobs && !is_streaming {
-            debug!("Logprobs requested and non-streaming - merging prefill and decode logprobs");
-
-            let status = decode_response.status();
-            let resp_headers = decode_response.headers().clone();
-            let decode_body = decode_response
-                .bytes()
-                .await
-                .map_err(|e| format!("Failed to read decode response: {}", e))?;
-
-            let mut decode_json: Value = serde_json::from_slice(&decode_body)
-                .map_err(|e| format!("Failed to parse decode response as JSON: {}", e))?;
-
-            let empty_json = Value::Null;
-            let prefill_json_ref = prefill_response_json.unwrap_or(&empty_json);
-            let merged = logprobs_merge::merge_logprobs_in_json(prefill_json_ref, &mut decode_json);
-            if merged {
-                debug!("Successfully merged logprobs from prefill and decode responses");
-            } else {
-                warn!("No logprobs were merged (might be expected if logprobs not in response)");
-            }
-
-            let merged_body = serde_json::to_vec(&decode_json)
-                .map_err(|e| format!("Failed to serialize merged response: {}", e))?;
-
-            let mut response_builder = axum::http::Response::builder().status(status);
-            for (name, value) in resp_headers.iter() {
-                response_builder = response_builder.header(name, value);
-            }
-            return response_builder
-                .body(axum::body::Body::from(merged_body))
-                .map_err(|e| format!("Failed to build response: {}", e));
-        }
-
-        debug!(
-            "No logprobs merging needed (streaming={}, needs_logprobs={})",
-            is_streaming, needs_logprobs
-        );
-
         let status = decode_response.status();
 
         if is_streaming {
@@ -743,7 +705,11 @@ impl VllmPDRouter {
             for (name, value) in decode_headers.iter() {
                 response_builder = response_builder.header(name, value);
             }
-            let body = axum::body::Body::from_stream(decode_response.bytes_stream());
+            let prefill_usage = prefill_response_json.and_then(usage_merge::usage_snapshot);
+            let body = axum::body::Body::from_stream(usage_merge::rewrite_sse_usage_stream(
+                decode_response.bytes_stream(),
+                prefill_usage,
+            ));
             return response_builder.body(body).map_err(|e| {
                 format!(
                     "Failed to build streaming response from {}: {}",
@@ -752,18 +718,63 @@ impl VllmPDRouter {
             });
         }
 
-        // Non-streaming, no logprobs: read entire body
-        let decode_headers = decode_response.headers().clone();
-        let body = decode_response
+        // Non-streaming: merge prefill-side input/cache usage with the
+        // decode-side output usage. The original body is retained if it is not
+        // JSON or does not carry usage (for example, an upstream error body).
+        let mut decode_headers = header_utils::preserve_response_headers(decode_response.headers());
+        let decode_body = decode_response
             .bytes()
             .await
             .map_err(|e| format!("Failed to read decode response: {}", e))?;
+        let response_body = match serde_json::from_slice::<Value>(&decode_body) {
+            Ok(mut decode_json) => {
+                let mut changed = false;
+
+                if needs_logprobs {
+                    debug!("Logprobs requested and non-streaming - merging prefill and decode logprobs");
+                    let empty_json = Value::Null;
+                    let prefill_json_ref = prefill_response_json.unwrap_or(&empty_json);
+                    let merged =
+                        logprobs_merge::merge_logprobs_in_json(prefill_json_ref, &mut decode_json);
+                    changed |= merged;
+                    if merged {
+                        debug!("Successfully merged logprobs from prefill and decode responses");
+                    } else {
+                        warn!("No logprobs were merged (might be expected if logprobs not in response)");
+                    }
+                }
+
+                if let Some(prefill_json) = prefill_response_json {
+                    changed |= usage_merge::merge_pd_usage(prefill_json, &mut decode_json);
+                }
+
+                if changed {
+                    // `Value` owns its strings, so the upstream byte buffer can
+                    // be released before allocating the rewritten response.
+                    drop(decode_body);
+                    let merged_body = serde_json::to_vec(&decode_json)
+                        .map_err(|e| format!("Failed to serialize merged response: {}", e))?;
+                    decode_headers.remove(axum::http::header::CONTENT_LENGTH);
+                    axum::body::Body::from(merged_body)
+                } else {
+                    axum::body::Body::from(decode_body)
+                }
+            }
+            Err(error) if needs_logprobs => {
+                return Err(format!(
+                    "Failed to parse decode response as JSON for logprobs merge: {}",
+                    error
+                ));
+            }
+            Err(_) => axum::body::Body::from(decode_body),
+        };
+
         let mut response_builder = axum::http::Response::builder().status(status);
         for (name, value) in decode_headers.iter() {
             response_builder = response_builder.header(name, value);
         }
         response_builder
-            .body(axum::body::Body::from(body))
+            .body(response_body)
             .map_err(|e| format!("Failed to build response: {}", e))
     }
 
@@ -1498,11 +1509,31 @@ impl VllmPDRouter {
             .and_then(|v| v.as_bool())
             .unwrap_or(false);
 
-        // If logprobs requested and non-streaming, merge prefill and decode logprobs
-        if needs_logprobs && !is_streaming {
-            debug!("Logprobs requested and non-streaming - merging prefill and decode logprobs");
+        if is_streaming {
+            debug!(
+                "No logprobs merging needed (streaming={}, needs_logprobs={})",
+                is_streaming, needs_logprobs
+            );
 
-            // Read decode response body
+            let mut response_headers = header_utils::preserve_response_headers(&headers);
+            response_headers.remove(axum::http::header::CONTENT_LENGTH);
+            let mut response_builder = Response::builder().status(status);
+            for (key, value) in response_headers.iter() {
+                response_builder = response_builder.header(key, value);
+            }
+
+            let prefill_usage = usage_merge::usage_snapshot(&prefill_response_json);
+            let body = Body::from_stream(usage_merge::rewrite_sse_usage_stream(
+                decode_response.bytes_stream(),
+                prefill_usage,
+            ));
+            response_builder
+                .body(body)
+                .map_err(|e| PDRouterError::NetworkError {
+                    message: format!("Failed to build response from {}: {}", decode_url, e),
+                })
+        } else {
+            let mut response_headers = header_utils::preserve_response_headers(&headers);
             let decode_body =
                 decode_response
                     .bytes()
@@ -1513,57 +1544,61 @@ impl VllmPDRouter {
                             decode_url, e
                         ),
                     })?;
+            let response_body = match serde_json::from_slice::<Value>(&decode_body) {
+                Ok(mut decode_json) => {
+                    let mut changed = false;
 
-            // Parse decode response as JSON
-            let mut decode_json: Value =
-                serde_json::from_slice(&decode_body).map_err(|e| PDRouterError::NetworkError {
-                    message: format!("Failed to parse decode response as JSON: {}", e),
-                })?;
+                    if needs_logprobs {
+                        debug!("Logprobs requested and non-streaming - merging prefill and decode logprobs");
+                        let merged = logprobs_merge::merge_logprobs_in_json(
+                            &prefill_response_json,
+                            &mut decode_json,
+                        );
+                        changed |= merged;
+                        if merged {
+                            debug!(
+                                "Successfully merged logprobs from prefill and decode responses"
+                            );
+                        } else {
+                            warn!("No logprobs were merged (might be expected if logprobs not in response)");
+                        }
+                    }
 
-            // Merge logprobs from prefill into decode response
-            let merged =
-                logprobs_merge::merge_logprobs_in_json(&prefill_response_json, &mut decode_json);
-            if merged {
-                debug!("Successfully merged logprobs from prefill and decode responses");
-            } else {
-                warn!("No logprobs were merged (might be expected if logprobs not in response)");
-            }
+                    changed |=
+                        usage_merge::merge_pd_usage(&prefill_response_json, &mut decode_json);
 
-            // Serialize merged response
-            let merged_body =
-                serde_json::to_vec(&decode_json).map_err(|e| PDRouterError::NetworkError {
-                    message: format!("Failed to serialize merged response: {}", e),
-                })?;
+                    if changed {
+                        // Avoid retaining a second full copy of the upstream
+                        // response while serializing the corrected JSON.
+                        drop(decode_body);
+                        let merged_body = serde_json::to_vec(&decode_json).map_err(|e| {
+                            PDRouterError::NetworkError {
+                                message: format!("Failed to serialize merged response: {}", e),
+                            }
+                        })?;
+                        response_headers.remove(axum::http::header::CONTENT_LENGTH);
+                        Body::from(merged_body)
+                    } else {
+                        Body::from(decode_body)
+                    }
+                }
+                Err(error) if needs_logprobs => {
+                    return Err(PDRouterError::NetworkError {
+                        message: format!(
+                            "Failed to parse decode response as JSON for logprobs merge: {}",
+                            error
+                        ),
+                    });
+                }
+                Err(_) => Body::from(decode_body),
+            };
 
             let mut response_builder = Response::builder().status(status);
-            for (key, value) in headers.iter() {
-                if key != "transfer-encoding" && key != "content-length" {
-                    response_builder = response_builder.header(key, value);
-                }
+            for (key, value) in response_headers.iter() {
+                response_builder = response_builder.header(key, value);
             }
-
-            response_builder.body(Body::from(merged_body)).map_err(|e| {
-                PDRouterError::NetworkError {
-                    message: format!("Failed to build response from {}: {}", decode_url, e),
-                }
-            })
-        } else {
-            // No logprobs merging needed - return decode response as-is (streaming or no logprobs)
-            debug!(
-                "No logprobs merging needed (streaming={}, needs_logprobs={})",
-                is_streaming, needs_logprobs
-            );
-
-            let mut response_builder = Response::builder().status(status);
-            for (key, value) in headers.iter() {
-                if key != "transfer-encoding" && key != "content-length" {
-                    response_builder = response_builder.header(key, value);
-                }
-            }
-
-            let body = Body::from_stream(decode_response.bytes_stream());
             response_builder
-                .body(body)
+                .body(response_body)
                 .map_err(|e| PDRouterError::NetworkError {
                     message: format!("Failed to build response from {}: {}", decode_url, e),
                 })


### PR DESCRIPTION
## Purpose

Fixes #193.

In P/D disaggregation, the decode worker counts KV blocks transferred from the
prefill worker as cached tokens. Returning the decode response unchanged therefore
makes a cold end-to-end request look like a 100% prefix-cache hit.

This PR reports end-to-end usage by combining the two stages:

- prompt/input token counts and cache details come from prefill;
- completion/output token counts and output details remain from decode;
- total tokens are recomputed as prefill input plus decode output, excluding the
  one token forced during the prefill leg;
- the same accounting is applied to non-streaming JSON and streaming SSE responses
  for Chat Completions, Completions, and Responses API payloads.

Streaming remains incremental: the router buffers only the current SSE event and
retains a usage-only prefill snapshot rather than the potentially large KV-transfer
metadata. Non-streaming responses reuse the upstream `Bytes` when no rewrite is
needed and release them before serializing a corrected response.

Both direct-URL and service-discovery response paths are covered, and the existing
non-streaming logprobs merge behavior is preserved.

## Test Plan

```bash
cargo fmt --all -- --check
cargo test --lib
cargo clippy --lib --tests
```

Manual NIXL P/D end-to-end checks:

- non-streaming Chat Completions, cold and repeated long-prefix requests;
- streaming Chat Completions with `stream_options.include_usage`;
- non-streaming Responses API.

## Test Result

- `cargo test --lib`: 490 passed, 0 failed.
- Added six focused tests covering Chat/Completions and Responses usage, cold/partial
  cache accounting, split network chunks in SSE, nested Responses events, missing
  prefill cache details, and dropping KV-transfer metadata from stream state.
- Cold Chat request: prompt 88, cached 0, completion 12, total 100.
- Streaming Chat final usage: prompt 70, cached 0, completion 10, total 80.
- Responses request: input 65, cached 0, output 10, total 75.
- Repeated 1,378-token prefix: first request cached 0; second request cached 1,024;
  input and total remained 1,378 and 1,379 respectively.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, including the issue it resolves.
- [x] The test plan, including commands and end-to-end scenarios.
- [x] The test results, including unit and before/after end-to-end results.

</details>
