### PR TITLE
[Bugfix][CI] Fix Trivy CVEs by removing pip from router image

### DIFF
--- a/Dockerfile.router
+++ b/Dockerfile.router
@@ -42,8 +42,11 @@ COPY py_src ./py_src
 COPY pyproject.toml ./
 COPY README.md ./
 
-# Install Python dependencies if using Python launcher
-RUN pip install setuptools-rust wheel build requests
+# Install Python dependencies if using Python launcher. 
+# Remove pip after installation to reduce image size and avoid CVE issues with 
+# bundled deps.
+RUN pip install setuptools-rust wheel build requests \
+    && pip uninstall -y pip
 
 # Expose default router port
 EXPOSE 8080


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

CI fails on main, see e.g. https://github.com/vllm-project/router/actions/runs/31799701358/job/94764526735?pr=211.

The msgpack and setuptools CVEs Trivy flags come from pip's vendored copies (pip/_vendor), not real dependencies. Since pip isn't used at container runtime, this uninstalls it after the build-time installs, clearing both findings and shrinking the image.

## Test Plan

Trivy passes

## Test Result

OK: https://github.com/vllm-project/router/actions/runs/31803340600/job/94776254331?pr=212


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
