### PR TITLE
[Bugfix] Route chat completions on the conversation, not the session id

### DIFF
--- a/src/protocols/spec.rs
+++ b/src/protocols/spec.rs
@@ -543,19 +543,41 @@ impl GenerationRequest for ChatCompletionRequest {
     }
 
     fn extract_text_for_routing(&self) -> String {
-        // Use session_id from session_params for session-based routing
-        if let Some(ref session_params) = self.session_params {
-            if let Some(session_id) = session_params.get("session_id") {
-                if let Some(session_id_str) = session_id.as_str() {
-                    if !session_id_str.trim().is_empty() {
-                        return session_id_str.to_string();
-                    }
-                }
+        // The conversation text, like the Completion and Responses impls: cache_aware
+        // matches on it with a radix tree, so returning a session id (or the empty
+        // string when there is none) collapses every request onto one prefix and the
+        // policy silently degrades to min-load. Session affinity is a separate
+        // concern, resolved from headers and the body by `hash_key::extract_hash_key`.
+        let mut buffer = String::new();
+        for message in &self.messages {
+            let text = match message {
+                ChatMessage::System { content, .. } => content.clone(),
+                ChatMessage::User { content, .. } => match content {
+                    UserMessageContent::Text(text) => text.clone(),
+                    UserMessageContent::Parts(parts) => parts
+                        .iter()
+                        .filter_map(|part| match part {
+                            ContentPart::Text { text } => Some(text.as_str()),
+                            ContentPart::ImageUrl { .. } => None,
+                        })
+                        .collect::<Vec<_>>()
+                        .join(" "),
+                },
+                ChatMessage::Assistant { content, .. } => match content {
+                    Some(text) => text.clone(),
+                    None => continue,
+                },
+                _ => continue,
+            };
+            if text.is_empty() {
+                continue;
             }
+            if !buffer.is_empty() {
+                buffer.push('\n');
+            }
+            buffer.push_str(&text);
         }
-
-        // Return empty string if no session_id - let routing policy handle this case
-        String::new()
+        buffer
     }
 }
 
@@ -3232,6 +3254,41 @@ mod tests {
         let request: ChatCompletionRequest = serde_json::from_str(json).unwrap();
         assert!(request.model.is_none());
         assert_eq!(request.get_model(), None);
+    }
+
+    #[test]
+    fn test_chat_completion_routing_text_is_the_conversation() {
+        // cache_aware matches routing text with a radix tree, so a continued
+        // conversation must extend the text of the turn before it.
+        let first: ChatCompletionRequest = serde_json::from_str(
+            r#"{"messages": [{"role": "system", "content": "be brief"},
+                             {"role": "user", "content": "hello"}]}"#,
+        )
+        .unwrap();
+        let second: ChatCompletionRequest = serde_json::from_str(
+            r#"{"messages": [{"role": "system", "content": "be brief"},
+                             {"role": "user", "content": "hello"},
+                             {"role": "assistant", "content": "hi"},
+                             {"role": "user", "content": "again"}]}"#,
+        )
+        .unwrap();
+
+        let first_text = first.extract_text_for_routing();
+        assert_eq!(first_text, "be brief\nhello");
+        assert!(second.extract_text_for_routing().starts_with(&first_text));
+    }
+
+    #[test]
+    fn test_chat_completion_routing_text_ignores_session_params() {
+        // session_params used to be returned instead of the conversation, which
+        // left cache_aware matching on an empty string for every request.
+        let request: ChatCompletionRequest = serde_json::from_str(
+            r#"{"messages": [{"role": "user", "content": "hello"}],
+                "session_params": {"session_id": "abc"}}"#,
+        )
+        .unwrap();
+
+        assert_eq!(request.extract_text_for_routing(), "hello");
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`ChatCompletionRequest::extract_text_for_routing` returns `session_params.session_id`, or an empty string when the request carries none:

https://github.com/vllm-project/router/blob/main/src/protocols/spec.rs#L544-L558

`cache_aware` feeds that value into its radix tree. With an empty string every chat request looks identical to every other one, so the tree never matches a prefix, `match_rate` stays at 0, and selection falls through to the minimum-load branch. Chat completions is the most used endpoint here, so `cache_aware` is effectively plain load balancing on it.

The sibling implementations of the same trait method already return real content — `CompletionRequest` returns the prompt, `ResponsesRequest` walks the input items. Chat is the odd one out.

## Fix

Return the conversation text: system, user (including text parts of multimodal content), and assistant messages joined in order.

Session affinity is unaffected. Hash policies resolve their key through `hash_key::extract_hash_key`, which checks `x-session-id` and the other session headers first.

## Behaviour change

A caller that sends `session_params.session_id` in the body **and** no session header previously got a stable routing key, because the session id happened to be the routing text and fell through to the `request:{text}` fallback. That key now becomes a hash of the conversation, which grows every turn, so such a caller loses session affinity until it sends a session header. Callers using headers — the documented path — are unaffected.

## Testing

`cargo test --lib` — 485 passed, 0 failed. Two tests added alongside the existing `GenerationRequest` trait tests: one asserts a continued conversation extends the previous turn's routing text, one asserts `session_params` no longer displaces the conversation.

End to end on 3 nodes, replaying recorded Codex agent traces (128 sessions, 5280 requests, contexts to ~100K tokens) against 4 vLLM replicas with `--policy cache_aware`. The router's own debug counters for consecutive turns of one session:

| turn | before | after |
|------|--------|-------|
| 1 | `matched_chars=0 input_chars=0` | `matched_chars=0 input_chars=5100` |
| 2 | `matched_chars=0 input_chars=0` | `matched_chars=5100 input_chars=6702` |
| 3 | `matched_chars=0 input_chars=0` | `matched_chars=6702 input_chars=8304` |

Each turn now matches the entirety of the turn before it, which is the prefix reuse `cache_aware` exists to exploit. A 20-session `consistent_hash` run over the same workload kept every session pinned to one worker, unchanged by this patch.

## Duplicate check

`gh pr list --search cache_aware` and an issue search for the routing-text behaviour found nothing covering this. The open cache-aware PRs are #211 (load double-decrement), #176 (PD stream load tracking) and #130 (KV-event routing), all unrelated.

AI assistance was used for this change; the diff and the test results above were reviewed and reproduced by the submitter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)