### PR TITLE
[Bugfix]: preserve array-formatted system message content (#201)

### DIFF
--- a/benches/request_processing.rs
+++ b/benches/request_processing.rs
@@ -151,7 +151,7 @@ fn create_sample_chat_completion_request() -> ChatCompletionRequest {
         messages: vec![
             ChatMessage::System {
                 role: "system".to_string(),
-                content: "You are a helpful assistant".to_string(),
+                content: UserMessageContent::Text("You are a helpful assistant".to_string()),
                 name: None,
             },
             ChatMessage::User {
@@ -192,7 +192,9 @@ fn create_sample_completion_request() -> CompletionRequest {
 fn create_large_chat_completion_request() -> ChatCompletionRequest {
     let mut messages = vec![ChatMessage::System {
         role: "system".to_string(),
-        content: "You are a helpful assistant with extensive knowledge.".to_string(),
+        content: UserMessageContent::Text(
+            "You are a helpful assistant with extensive knowledge.".to_string(),
+        ),
         name: None,
     }];
 

--- a/benches/request_processing.rs
+++ b/benches/request_processing.rs
@@ -4,7 +4,7 @@ use std::time::Instant;
 
 use vllm_router_rs::protocols::spec::{
     ChatCompletionRequest, ChatMessage, CompletionRequest, GenerateParameters, GenerateRequest,
-    PromptInput, SamplingParams, UserMessageContent,
+    PromptInput, SamplingParams, SystemMessageContent, UserMessageContent,
 };
 
 /// Create a default GenerateRequest for benchmarks with minimal fields set
@@ -151,7 +151,7 @@ fn create_sample_chat_completion_request() -> ChatCompletionRequest {
         messages: vec![
             ChatMessage::System {
                 role: "system".to_string(),
-                content: UserMessageContent::Text("You are a helpful assistant".to_string()),
+                content: SystemMessageContent::Text("You are a helpful assistant".to_string()),
                 name: None,
             },
             ChatMessage::User {
@@ -192,7 +192,7 @@ fn create_sample_completion_request() -> CompletionRequest {
 fn create_large_chat_completion_request() -> ChatCompletionRequest {
     let mut messages = vec![ChatMessage::System {
         role: "system".to_string(),
-        content: UserMessageContent::Text(
+        content: SystemMessageContent::Text(
             "You are a helpful assistant with extensive knowledge.".to_string(),
         ),
         name: None,

--- a/src/protocols/spec.rs
+++ b/src/protocols/spec.rs
@@ -294,7 +294,14 @@ pub enum SystemMessageContent {
 #[serde(tag = "type")]
 pub enum SystemContentPart {
     #[serde(rename = "text")]
-    Text { text: String },
+    Text {
+        text: String,
+        // Unknown extension fields (e.g. prompt_cache_breakpoint) are
+        // preserved for transparent forwarding instead of being silently
+        // dropped by the typed parse/reserialize round-trip.
+        #[serde(flatten)]
+        extra: serde_json::Map<String, Value>,
+    },
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -3736,7 +3743,9 @@ mod tests {
                 SystemMessageContent::Parts(parts) => {
                     assert_eq!(parts.len(), 1);
                     match &parts[0] {
-                        SystemContentPart::Text { text } => assert_eq!(text, "You are GLM-5.2."),
+                        SystemContentPart::Text { text, .. } => {
+                            assert_eq!(text, "You are GLM-5.2.");
+                        }
                     }
                 }
                 other => panic!("Expected Parts content, got: {:?}", other),
@@ -3804,6 +3813,40 @@ mod tests {
                 _ => panic!("Expected System message"),
             }
         }
+    }
+
+    #[test]
+    fn test_chat_message_system_text_part_preserves_extension_fields() {
+        // PR review P2: valid extra fields on text parts (e.g.
+        // prompt_cache_breakpoint) must survive the parse/reserialize
+        // forwarding round-trip instead of being silently dropped.
+        let json = r#"{
+            "role": "system",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "Be helpful",
+                    "prompt_cache_breakpoint": {"mode": "explicit"}
+                }
+            ]
+        }"#;
+
+        let message: ChatMessage = serde_json::from_str(json).unwrap();
+        let serialized = serde_json::to_value(&message).unwrap();
+
+        assert_eq!(
+            serialized,
+            serde_json::json!({
+                "role": "system",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "Be helpful",
+                        "prompt_cache_breakpoint": {"mode": "explicit"}
+                    }
+                ]
+            }),
+        );
     }
 
     #[test]

--- a/src/protocols/spec.rs
+++ b/src/protocols/spec.rs
@@ -64,7 +64,7 @@ use std::collections::HashMap;
 pub enum ChatMessage {
     System {
         role: String,
-        content: UserMessageContent,
+        content: SystemMessageContent,
         #[serde(skip_serializing_if = "Option::is_none")]
         name: Option<String>,
     },
@@ -157,13 +157,19 @@ impl<'de> Deserialize<'de> for ChatMessage {
             }),
             "system" => Ok(ChatMessage::System {
                 role: role.to_string(),
-                content: value
-                    .get("content")
-                    .map(|c| {
-                        serde_json::from_value(c.clone())
-                            .unwrap_or(UserMessageContent::Text(String::new()))
-                    })
-                    .unwrap_or(UserMessageContent::Text(String::new())),
+                // Strict OpenAI compatibility: array-formatted content may only
+                // contain text parts. A present but unparseable content (e.g.
+                // image_url parts) is a hard error (400) instead of silently
+                // degrading to an empty string; missing/null still defaults to
+                // empty text for backward compatibility.
+                content: match value.get("content") {
+                    None | Some(Value::Null) => SystemMessageContent::Text(String::new()),
+                    Some(c) => serde_json::from_value(c.clone()).map_err(|e| {
+                        D::Error::custom(format!(
+                            "system message content must be a string or an array of text parts: {e}"
+                        ))
+                    })?,
+                },
                 name: value.get("name").and_then(|n| {
                     if n.is_null() {
                         None
@@ -270,6 +276,24 @@ pub struct StructuredOutputsParams {
 pub enum UserMessageContent {
     Text(String),
     Parts(Vec<ContentPart>),
+}
+
+// System messages are strictly OpenAI-compatible: array-formatted content may
+// only contain text parts. Unlike User messages, non-text parts (e.g.
+// image_url) are rejected at deserialization time and surface as a 400 instead
+// of being silently dropped or forwarded.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum SystemMessageContent {
+    Text(String),
+    Parts(Vec<SystemContentPart>),
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(tag = "type")]
+pub enum SystemContentPart {
+    #[serde(rename = "text")]
+    Text { text: String },
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -3686,7 +3710,7 @@ mod tests {
 
         match message {
             ChatMessage::System { content, .. } => match content {
-                UserMessageContent::Text(text) => {
+                SystemMessageContent::Text(text) => {
                     assert_eq!(text, "You are a helpful assistant.");
                 }
                 _ => panic!("Expected Text content"),
@@ -3708,11 +3732,10 @@ mod tests {
 
         match &message {
             ChatMessage::System { content, .. } => match content {
-                UserMessageContent::Parts(parts) => {
+                SystemMessageContent::Parts(parts) => {
                     assert_eq!(parts.len(), 1);
                     match &parts[0] {
-                        ContentPart::Text { text } => assert_eq!(text, "You are GLM-5.2."),
-                        _ => panic!("Expected text part"),
+                        SystemContentPart::Text { text } => assert_eq!(text, "You are GLM-5.2."),
                     }
                 }
                 other => panic!("Expected Parts content, got: {:?}", other),
@@ -3730,10 +3753,55 @@ mod tests {
         let reparsed: ChatMessage = serde_json::from_value(serialized).unwrap();
         match reparsed {
             ChatMessage::System { content, .. } => match content {
-                UserMessageContent::Parts(parts) => assert_eq!(parts.len(), 1),
+                SystemMessageContent::Parts(parts) => assert_eq!(parts.len(), 1),
                 other => panic!("Expected Parts content, got: {:?}", other),
             },
             _ => panic!("Expected System message"),
+        }
+    }
+
+    #[test]
+    fn test_chat_message_system_rejects_non_text_parts() {
+        // Strict OpenAI compatibility: system arrays may only contain text
+        // parts. image_url (and any other non-text part) must be rejected with
+        // a deserialization error instead of being silently dropped or
+        // forwarded.
+        let cases = [
+            r#"{
+                "role": "system",
+                "content": [{"type": "image_url", "image_url": {"url": "https://example.com/x.png"}}]
+            }"#,
+            r#"{
+                "role": "system",
+                "content": [{"type": "text", "text": "ok"}, {"type": "image_url", "image_url": {"url": "x"}}]
+            }"#,
+            r#"{
+                "role": "system",
+                "content": [{"type": "text"}]
+            }"#,
+        ];
+
+        for json in cases {
+            let result: Result<ChatMessage, _> = serde_json::from_str(json);
+            assert!(
+                result.is_err(),
+                "expected deserialization error for: {json}"
+            );
+        }
+
+        // Missing or null content still defaults to empty text.
+        for json in [
+            r#"{"role": "system"}"#,
+            r#"{"role": "system", "content": null}"#,
+        ] {
+            let message: ChatMessage = serde_json::from_str(json).unwrap();
+            match message {
+                ChatMessage::System { content, .. } => match content {
+                    SystemMessageContent::Text(text) => assert_eq!(text, ""),
+                    other => panic!("Expected Text content, got: {:?}", other),
+                },
+                _ => panic!("Expected System message"),
+            }
         }
     }
 

--- a/src/protocols/spec.rs
+++ b/src/protocols/spec.rs
@@ -64,7 +64,7 @@ use std::collections::HashMap;
 pub enum ChatMessage {
     System {
         role: String,
-        content: String,
+        content: UserMessageContent,
         #[serde(skip_serializing_if = "Option::is_none")]
         name: Option<String>,
     },
@@ -159,9 +159,11 @@ impl<'de> Deserialize<'de> for ChatMessage {
                 role: role.to_string(),
                 content: value
                     .get("content")
-                    .and_then(|c| c.as_str())
-                    .unwrap_or("")
-                    .to_string(),
+                    .map(|c| {
+                        serde_json::from_value(c.clone())
+                            .unwrap_or(UserMessageContent::Text(String::new()))
+                    })
+                    .unwrap_or(UserMessageContent::Text(String::new())),
                 name: value.get("name").and_then(|n| {
                     if n.is_null() {
                         None
@@ -3683,9 +3685,54 @@ mod tests {
         let message: ChatMessage = serde_json::from_str(json).unwrap();
 
         match message {
-            ChatMessage::System { content, .. } => {
-                assert_eq!(content, "You are a helpful assistant.");
-            }
+            ChatMessage::System { content, .. } => match content {
+                UserMessageContent::Text(text) => {
+                    assert_eq!(text, "You are a helpful assistant.");
+                }
+                _ => panic!("Expected Text content"),
+            },
+            _ => panic!("Expected System message"),
+        }
+    }
+
+    #[test]
+    fn test_chat_message_system_array_content_roundtrip() {
+        // Regression (issue #201): array-formatted system content must survive
+        // deserialization and re-serialization instead of being dropped to "".
+        let json = r#"{
+            "role": "system",
+            "content": [{"type": "text", "text": "You are GLM-5.2."}]
+        }"#;
+
+        let message: ChatMessage = serde_json::from_str(json).unwrap();
+
+        match &message {
+            ChatMessage::System { content, .. } => match content {
+                UserMessageContent::Parts(parts) => {
+                    assert_eq!(parts.len(), 1);
+                    match &parts[0] {
+                        ContentPart::Text { text } => assert_eq!(text, "You are GLM-5.2."),
+                        _ => panic!("Expected text part"),
+                    }
+                }
+                other => panic!("Expected Parts content, got: {:?}", other),
+            },
+            _ => panic!("Expected System message"),
+        }
+
+        // Re-serialization must preserve the array form for forwarding.
+        let serialized = serde_json::to_value(&message).unwrap();
+        assert_eq!(
+            serialized.get("content"),
+            Some(&serde_json::json!([{"type": "text", "text": "You are GLM-5.2."}])),
+        );
+
+        let reparsed: ChatMessage = serde_json::from_value(serialized).unwrap();
+        match reparsed {
+            ChatMessage::System { content, .. } => match content {
+                UserMessageContent::Parts(parts) => assert_eq!(parts.len(), 1),
+                other => panic!("Expected Parts content, got: {:?}", other),
+            },
             _ => panic!("Expected System message"),
         }
     }

--- a/src/protocols/spec.rs
+++ b/src/protocols/spec.rs
@@ -159,9 +159,10 @@ impl<'de> Deserialize<'de> for ChatMessage {
                 role: role.to_string(),
                 // Strict OpenAI compatibility: array-formatted content may only
                 // contain text parts. A present but unparseable content (e.g.
-                // image_url parts) is a hard error (400) instead of silently
-                // degrading to an empty string; missing/null still defaults to
-                // empty text for backward compatibility.
+                // image_url parts) is a hard error (4xx, 422 via axum's Json
+                // extractor) instead of silently degrading to an empty string;
+                // missing/null still defaults to empty text for backward
+                // compatibility.
                 content: match value.get("content") {
                     None | Some(Value::Null) => SystemMessageContent::Text(String::new()),
                     Some(c) => serde_json::from_value(c.clone()).map_err(|e| {
@@ -280,8 +281,8 @@ pub enum UserMessageContent {
 
 // System messages are strictly OpenAI-compatible: array-formatted content may
 // only contain text parts. Unlike User messages, non-text parts (e.g.
-// image_url) are rejected at deserialization time and surface as a 400 instead
-// of being silently dropped or forwarded.
+// image_url) are rejected at deserialization time and surface as a 4xx (422
+// via axum's Json extractor) instead of being silently dropped or forwarded.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum SystemMessageContent {


### PR DESCRIPTION
## Purpose

Fixes #201: system messages with OpenAI-style array-formatted content (e.g. `[{"type":"text","text":"..."}]`) were silently forwarded to upstream vLLM as an empty string `""`, so the system prompt was completely lost. String-format system content and array-format user content both worked correctly.

Root cause: `ChatMessage`'s custom `Deserialize` "system" branch coerced the content field with `Value::as_str()`, which returns `None` for arrays, falling back to `""`.

Fix: model `ChatMessage::System.content` with a role-specific `SystemMessageContent` (untagged `Text | Parts`) whose parts are text-only (`SystemContentPart`), and deserialize it via `serde_json::from_value`, so both content forms round-trip through the router's parse-and-reserialize forwarding path. Serialization of the untagged enum already handles string vs array.

Strict OpenAI compatibility: system message arrays may only contain text parts. A present but unparseable system content (e.g. `image_url` parts) is rejected at deserialization time and surfaces as a 4xx (422 via axum's `Json` extractor) instead of silently degrading to an empty string; missing/null content still defaults to empty text for backward compatibility. User messages remain permissive (`UserMessageContent` with `image_url` support).

## Test Plan

```bash
cargo fmt --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --lib --bins
cargo test --test '*'
```

Added unit tests in `src/protocols/spec.rs`:
- `test_chat_message_system_array_content_roundtrip` — deserialize → re-serialize → reparse of array-formatted system content
- `test_chat_message_system_rejects_non_text_parts` — `image_url` (and other non-text) parts are rejected with a deserialization error; missing/null content still defaults to empty text

End-to-end verification: router built with this change, mock upstream worker echoing the received body, `POST /v1/chat/completions`.

## Test Result

Rust unit/integration tests and CI-grade clippy all pass (only pre-existing failure: `test_openai_router_health` returns 503 on macOS, also fails on pristine `main`).

End-to-end forwarded content, before → after:

| Message content | Before | After |
|---|---|---|
| system array (text parts) | `""` | `[{"type":"text","text":"You are GLM-5.2."}]` |
| system string | `"You are GLM-5.2."` | `"You are GLM-5.2."` |
| system array (image_url part) | `""` | HTTP 422, rejected |
| user array | `[{"type":"text","text":"hello array user"}]` | `[{"type":"text","text":"hello array user"}]` |
| user array (image_url part) | forwarded | forwarded (unchanged, permissive) |
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results