### PR TITLE
fix: make worker load tracking cancellation-safe with an RAII guard

### DIFF
--- a/src/core/worker_registry.rs
+++ b/src/core/worker_registry.rs
@@ -388,12 +388,24 @@ impl WorkerRegistry {
                     let _ = worker.check_health_async().await; // Use async version directly
                 }
 
-                // Reset loads periodically
+                // Periodically reset load counters to clear drift, but only
+                // when all workers appear idle: an unconditional reset wipes
+                // real in-flight load for long-running requests, permanently
+                // disabling load-based routing decisions (e.g. cache_aware's
+                // min-load balance fallback). Mirrors the guarded variant in
+                // worker.rs::start_health_checker.
                 check_count += 1;
                 if check_count.is_multiple_of(LOAD_RESET_INTERVAL) {
-                    tracing::debug!("Resetting worker loads (cycle {})", check_count);
-                    for worker in &workers {
-                        worker.reset_load();
+                    let max_load = workers.iter().map(|w| w.load()).max().unwrap_or(0);
+                    if max_load <= 2 {
+                        tracing::debug!(
+                            "Resetting worker loads to clear drift (cycle {}, max_load {})",
+                            check_count,
+                            max_load
+                        );
+                        for worker in &workers {
+                            worker.reset_load();
+                        }
                     }
                 }
             }

--- a/src/routers/http/router.rs
+++ b/src/routers/http/router.rs
@@ -922,25 +922,38 @@ impl Router {
             tokio::spawn(async move {
                 let mut stream = stream;
                 let mut guard = Some(guard);
-                while let Some(chunk) = stream.next().await {
-                    match chunk {
-                        Ok(bytes) => {
-                            // Release the load count as soon as generation
-                            // finishes rather than when the connection closes
-                            if bytes
-                                .as_ref()
-                                .windows(12)
-                                .any(|window| window == b"data: [DONE]")
-                            {
-                                guard.take();
-                            }
-                            if tx.send(Ok(bytes)).is_err() {
-                                break;
-                            }
-                        }
-                        Err(e) => {
-                            let _ = tx.send(Err(format!("Stream error: {}", e)));
+                loop {
+                    tokio::select! {
+                        // Client went away: drop the upstream stream (which
+                        // cancels the request to the worker) and release the
+                        // guard now, instead of waiting for the worker's next
+                        // chunk — a stalled worker would otherwise pin the
+                        // load count until the request timeout.
+                        _ = tx.closed() => {
                             break;
+                        }
+                        chunk = stream.next() => {
+                            match chunk {
+                                Some(Ok(bytes)) => {
+                                    // Release the load count as soon as generation
+                                    // finishes rather than when the connection closes
+                                    if bytes
+                                        .as_ref()
+                                        .windows(12)
+                                        .any(|window| window == b"data: [DONE]")
+                                    {
+                                        guard.take();
+                                    }
+                                    if tx.send(Ok(bytes)).is_err() {
+                                        break;
+                                    }
+                                }
+                                Some(Err(e)) => {
+                                    let _ = tx.send(Err(format!("Stream error: {}", e)));
+                                    break;
+                                }
+                                None => break,
+                            }
                         }
                     }
                 }
@@ -968,16 +981,27 @@ impl Router {
             // Spawn task to forward stream
             tokio::spawn(async move {
                 let mut stream = stream;
-                while let Some(chunk) = stream.next().await {
-                    match chunk {
-                        Ok(bytes) => {
-                            if tx.send(Ok(bytes)).is_err() {
-                                break;
-                            }
-                        }
-                        Err(e) => {
-                            let _ = tx.send(Err(format!("Stream error: {}", e)));
+                loop {
+                    tokio::select! {
+                        // Client went away: drop the upstream stream so the
+                        // worker request is cancelled promptly instead of on
+                        // the next chunk
+                        _ = tx.closed() => {
                             break;
+                        }
+                        chunk = stream.next() => {
+                            match chunk {
+                                Some(Ok(bytes)) => {
+                                    if tx.send(Ok(bytes)).is_err() {
+                                        break;
+                                    }
+                                }
+                                Some(Err(e)) => {
+                                    let _ = tx.send(Err(format!("Stream error: {}", e)));
+                                    break;
+                                }
+                                None => break,
+                            }
                         }
                     }
                 }

--- a/src/routers/http/router.rs
+++ b/src/routers/http/router.rs
@@ -31,6 +31,37 @@ use std::time::{Duration, Instant};
 use tokio_stream::wrappers::UnboundedReceiverStream;
 use tracing::{debug, error, info, warn};
 
+/// RAII guard for a worker's load counter: increments on creation, decrements
+/// exactly once on drop.
+///
+/// Load tracking previously paired increment_load() with manually-placed
+/// decrement_load() calls on every exit path. That leaked one count per
+/// cancelled request: when a client disconnects mid-request, axum drops the
+/// handler future at its current await point, so straight-line decrement code
+/// after the await never runs. Under cache_aware routing the leaked counts
+/// accumulate (they also survive as drift the periodic reset can no longer
+/// safely clear) and skew the min-load balance fallback. Tying the decrement
+/// to Drop covers early returns, retries, panics, and future cancellation
+/// alike.
+struct WorkerLoadGuard {
+    worker: Arc<dyn Worker>,
+}
+
+impl WorkerLoadGuard {
+    fn new(worker: Arc<dyn Worker>) -> Self {
+        worker.increment_load();
+        RouterMetrics::set_running_requests(worker.url(), worker.load());
+        Self { worker }
+    }
+}
+
+impl Drop for WorkerLoadGuard {
+    fn drop(&mut self) {
+        self.worker.decrement_load();
+        RouterMetrics::set_running_requests(self.worker.url(), self.worker.load());
+    }
+}
+
 /// Regular router that uses injected load balancing policies
 #[derive(Debug)]
 pub struct Router {
@@ -571,17 +602,12 @@ impl Router {
                     None => self.policy_registry.get_default_policy(),
                 };
 
-                let load_incremented = if policy.name() == "cache_aware" {
-                    worker.increment_load();
-                    RouterMetrics::set_running_requests(worker.url(), worker.load());
-                    true
-                } else {
-                    false
-                };
-
-                // Keep a clone for potential cleanup on retry
-                let worker_for_cleanup = if load_incremented {
-                    Some(worker.clone())
+                // RAII load tracking: the guard decrements on drop, so every
+                // exit path — success, retryable failure, panic, and crucially
+                // cancellation (axum drops this future when the client
+                // disconnects) — releases the load exactly once.
+                let load_guard = if policy.name() == "cache_aware" {
+                    Some(WorkerLoadGuard::new(worker.clone()))
                 } else {
                     None
                 };
@@ -593,7 +619,7 @@ impl Router {
                         route,
                         worker.url(),
                         is_stream,
-                        load_incremented,
+                        load_guard,
                     )
                     .await;
 
@@ -601,18 +627,6 @@ impl Router {
                 // should count against the circuit breaker.
                 let status = response.status();
                 worker.record_outcome(status.is_success() || status.is_client_error());
-
-                // For retryable failures, we need to decrement load since send_typed_request
-                // won't have done it (it only decrements on success or non-retryable failures)
-                if is_retryable_status(response.status()) && load_incremented {
-                    if let Some(cleanup_worker) = worker_for_cleanup {
-                        cleanup_worker.decrement_load();
-                        RouterMetrics::set_running_requests(
-                            cleanup_worker.url(),
-                            cleanup_worker.load(),
-                        );
-                    }
-                }
 
                 response
             },
@@ -771,7 +785,12 @@ impl Router {
         route: &str,
         worker_url: &str,
         is_stream: bool,
-        load_incremented: bool, // Whether load was incremented for this request
+        // Load guard for cache-aware routing; None when the policy does not
+        // track load. Dropping it decrements the worker's load counter: for
+        // non-streaming requests that happens when this function returns (or
+        // is cancelled), for streaming requests ownership moves into the
+        // stream-forwarding task.
+        load_guard: Option<WorkerLoadGuard>,
     ) -> Response {
         let (mut request_builder, extracted_dp_rank, request_url) =
             if self.intra_node_data_parallel_size > 1 {
@@ -856,13 +875,7 @@ impl Router {
                     worker_url, route, e
                 );
 
-                // Decrement load on error if it was incremented
-                if load_incremented {
-                    if let Some(worker) = self.worker_registry.get_by_url(worker_url) {
-                        worker.decrement_load();
-                        RouterMetrics::set_running_requests(worker_url, worker.load());
-                    }
-                }
+                // load_guard (if any) drops here and releases the load count
 
                 return (
                     StatusCode::INTERNAL_SERVER_ERROR,
@@ -879,7 +892,9 @@ impl Router {
             // For non-streaming requests, preserve headers
             let response_headers = header_utils::preserve_response_headers(res.headers());
 
-            let response = match res.bytes().await {
+            // load_guard drops when this function returns (or is cancelled),
+            // releasing the load count on every path below.
+            match res.bytes().await {
                 Ok(body) => {
                     let mut response = Response::new(axum::body::Body::from(body));
                     *response.status_mut() = status;
@@ -887,33 +902,14 @@ impl Router {
                     response
                 }
                 Err(e) => {
-                    // IMPORTANT: Decrement load on error before returning
-                    if load_incremented {
-                        if let Some(worker) = self.worker_registry.get_by_url(worker_url) {
-                            worker.decrement_load();
-                            RouterMetrics::set_running_requests(worker_url, worker.load());
-                        }
-                    }
-
                     let error_msg = format!("Failed to get response body: {}", e);
                     (StatusCode::INTERNAL_SERVER_ERROR, error_msg).into_response()
                 }
-            };
-
-            // Decrement load counter for non-streaming requests if it was incremented
-            if load_incremented {
-                if let Some(worker) = self.worker_registry.get_by_url(worker_url) {
-                    worker.decrement_load();
-                    RouterMetrics::set_running_requests(worker_url, worker.load());
-                }
             }
-
-            response
-        } else if load_incremented {
-            // For streaming with load tracking, we need to manually decrement when done
-            let registry = Arc::clone(&self.worker_registry);
-            let worker_url = worker_url.to_string();
-
+        } else if let Some(guard) = load_guard {
+            // For streaming with load tracking, ownership of the guard moves
+            // into the forwarding task so the load count survives exactly as
+            // long as the upstream stream is live
             // Preserve headers for streaming response
             let mut response_headers = header_utils::preserve_response_headers(res.headers());
             // Ensure we set the correct content-type for SSE
@@ -925,21 +921,18 @@ impl Router {
             // Spawn task to forward stream and detect completion
             tokio::spawn(async move {
                 let mut stream = stream;
-                let mut decremented = false;
+                let mut guard = Some(guard);
                 while let Some(chunk) = stream.next().await {
                     match chunk {
                         Ok(bytes) => {
-                            // Check for stream end marker
+                            // Release the load count as soon as generation
+                            // finishes rather than when the connection closes
                             if bytes
                                 .as_ref()
                                 .windows(12)
                                 .any(|window| window == b"data: [DONE]")
                             {
-                                if let Some(worker) = registry.get_by_url(&worker_url) {
-                                    worker.decrement_load();
-                                    RouterMetrics::set_running_requests(&worker_url, worker.load());
-                                    decremented = true;
-                                }
+                                guard.take();
                             }
                             if tx.send(Ok(bytes)).is_err() {
                                 break;
@@ -951,12 +944,8 @@ impl Router {
                         }
                     }
                 }
-                if !decremented {
-                    if let Some(worker) = registry.get_by_url(&worker_url) {
-                        worker.decrement_load();
-                        RouterMetrics::set_running_requests(&worker_url, worker.load());
-                    }
-                }
+                // If still held (client disconnect, upstream error, or a
+                // stream that ended without [DONE]), the guard drops here
             });
 
             let stream = UnboundedReceiverStream::new(rx);


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Fix a load-counter leak in worker load tracking that eventually breaks
`cache_aware` routing.

Load tracking pairs `increment_load()` with manually-placed
`decrement_load()` calls on every exit path of
`route_typed_request`/`send_typed_request`. This is not
cancellation-safe: when a client disconnects mid-request, axum drops the
handler future at whatever await point it is parked on (typically while
awaiting response headers from the worker), so the decrement code after
that await never runs. Every aborted request leaks exactly one load
count, permanently.

On agent-style workloads where clients routinely abort requests
(timeouts, tool-loop cancellations) we measured ~400 leaked counts per
worker per day on a production 10-node vLLM 0.27.1 cluster. The leak
breaks routing, not just metrics, through `cache_aware`'s min-load
balance fallback:

- while the leak is uniform across workers, phantom counts dominate and
  the fallback never sees real imbalance;
- as soon as one worker's counter diverges — e.g. a worker restarts and
  rejoins with an honest counter of 0 while its peers carry ~395 phantom
  counts — the fallback decides the fleet is massively imbalanced and
  funnels **every** new-prefix request to that single worker. We hit
  exactly this in production: one node pinned at `--max-num-seqs` while
  nine idled, ~10x throughput loss until counters were manually reset.

This PR replaces the manual pairing with a `WorkerLoadGuard` that
increments on creation and decrements exactly once on `Drop`. Rust runs
`Drop` when a future is dropped, so cancellation, early returns, retries
and panics all release the count. For streaming responses the guard
moves into the stream-forwarding task and is released on `data: [DONE]`
(same timing as before), with drop-at-task-end as backstop for client
disconnect / upstream error / streams that end without `[DONE]`.

The RAII guard also fixes two adjacent bugs the manual pairing caused:

- **double decrement** for streaming responses with a retryable status
  (the forwarding task decremented when the short error stream ended
  *and* the retry path in `route_typed_request` decremented again);
- **lost decrement after worker removal**: decrements went through
  `worker_registry.get_by_url(worker_url)` and silently no-op'd if the
  worker had been removed (e.g. via `/remove_worker`) while a request
  was in flight. The guard holds the worker `Arc` directly.

Additionally, the periodic load reset in the registry health checker
(`worker_registry.rs`) now only fires when all workers are near-idle
(`max_load <= 2`), mirroring the already-guarded variant in
`worker.rs::start_health_checker`. The unconditional reset wiped real
in-flight load for long-running requests every 10 check cycles, which on
its own disables the balance fallback for agent workloads (requests
running for minutes never survive to be counted). With the RAII guard
the reset is a drift backstop only, so the idle guard is the correct
semantics.

No public API changes; `send_typed_request` is private and its
`load_incremented: bool` parameter becomes
`load_guard: Option<WorkerLoadGuard>`.

## Test Plan

`cargo check` on the branch, plus a live reproduction against a real
vLLM backend. Start the router with `--policy cache_aware` in front of
one worker, then:

```bash
R=http://127.0.0.1:9155
load() { curl -s $R/workers | python3 -c "import json,sys; print(json.load(sys.stdin)['workers'][0]['load'])"; }

# 1) a completed request must return load to 0
curl -s $R/v1/chat/completions -H 'Content-Type: application/json' \
  -d '{"model":"m","messages":[{"role":"user","content":"say OK"}],"max_tokens":5}' >/dev/null
load

# 2) three aborted requests: client disconnects ~1s in while generation
#    is still running (the cancellation path)
for i in 1 2 3; do
  curl -s --max-time 1 $R/v1/chat/completions -H 'Content-Type: application/json' \
    -d '{"model":"m","messages":[{"role":"user","content":"Count slowly from 1 to 1000, one number per line."}],"max_tokens":800}' >/dev/null
  load
done

# 3) settle 30s (backend finishes/aborts orphaned generations), re-check
sleep 30; load
```

## Test Result

Before (current main / 0.1.15), each abort leaks exactly +1 and the
counter never recovers:

```
after 1 completed request: 0   (correct)
after abort #1: 1
after abort #2: 2
after abort #3: 3
final load after 30s settle: 3
```

After (this PR), same sequence:

```
after 1 completed request: 0
after abort #1: 0
after abort #2: 0
after abort #3: 0
final load after 30s settle: 0
```

Also running in production on a 10-node vLLM 0.27.1 cluster under an
agent eval workload with frequent client aborts.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
</details>
