### PR TITLE
[Bugfix]: Fix health checker to preserve worker load during checks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,7 @@ portpicker = "0.1"
 tempfile = "3.8"
 lazy_static = "1.4"
 opentelemetry_sdk = { version = "0.27", features = ["testing"] }
+tokio = { version = "1.42.0", features = ["full", "test-util"] }
 
 [[bench]]
 name = "request_processing"

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -20,7 +20,7 @@ pub use circuit_breaker::{
 pub use error::{WorkerError, WorkerResult};
 pub use retry::{is_retryable_status, BackoffCalculator, RetryError, RetryExecutor};
 pub use worker::{
-    start_health_checker, BasicWorker, ConnectionMode, DPAwareWorker, HealthChecker, HealthConfig,
-    Worker, WorkerCollection, WorkerFactory, WorkerLoadGuard, WorkerType,
+    BasicWorker, ConnectionMode, DPAwareWorker, HealthChecker, HealthConfig, Worker,
+    WorkerCollection, WorkerFactory, WorkerLoadGuard, WorkerType,
 };
 pub use worker_registry::{WorkerId, WorkerRegistry, WorkerRegistryStats};

--- a/src/core/worker.rs
+++ b/src/core/worker.rs
@@ -57,9 +57,10 @@ pub trait Worker: Send + Sync + fmt::Debug {
     /// Decrement the load counter
     fn decrement_load(&self);
 
-    /// Reset the load counter to 0. Recovery-only: called exclusively when a
-    /// worker transitions back to healthy, never periodically. Health checks
-    /// must not discard active request accounting.
+    /// Reset the load counter to 0. Administrative operation: only safe when
+    /// the caller has independently established that no requests are in
+    /// flight for this worker. The runtime never calls this automatically;
+    /// health checks and routing must not discard active request accounting.
     fn reset_load(&self) {
         // Default implementation - does nothing
         // Workers that track load should override this
@@ -468,10 +469,9 @@ impl Worker for BasicWorker {
         RouterMetrics::set_worker_load(self.url(), self.load());
     }
 
-    /// Recovery-only: clears the load counter after the worker transitions
-    /// back to healthy. While unhealthy no new requests are routed to this
-    /// worker, so any remaining load is drift from the down period. Never
-    /// called periodically.
+    /// Administrative operation: resets the load counter to 0. Only safe when
+    /// the caller has independently established that no requests are in
+    /// flight for this worker; the runtime never calls this automatically.
     fn reset_load(&self) {
         self.load_counter.store(0, Ordering::Relaxed);
         RouterMetrics::set_worker_load(self.url(), 0);

--- a/src/core/worker.rs
+++ b/src/core/worker.rs
@@ -1,7 +1,6 @@
 use super::{CircuitBreaker, CircuitBreakerConfig, WorkerError, WorkerResult};
 use crate::metrics::RouterMetrics;
 use async_trait::async_trait;
-use futures;
 use serde_json;
 use std::fmt;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
@@ -58,7 +57,9 @@ pub trait Worker: Send + Sync + fmt::Debug {
     /// Decrement the load counter
     fn decrement_load(&self);
 
-    /// Reset the load counter to 0 (for sync/recovery)
+    /// Reset the load counter to 0. Recovery-only: called exclusively when a
+    /// worker transitions back to healthy, never periodically. Health checks
+    /// must not discard active request accounting.
     fn reset_load(&self) {
         // Default implementation - does nothing
         // Workers that track load should override this
@@ -448,18 +449,32 @@ impl Worker for BasicWorker {
 
     fn increment_load(&self) {
         self.load_counter.fetch_add(1, Ordering::Relaxed);
+        RouterMetrics::set_worker_load(self.url(), self.load());
     }
 
     fn decrement_load(&self) {
-        self.load_counter
+        if self
+            .load_counter
             .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
                 current.checked_sub(1)
             })
-            .ok();
+            .is_err()
+        {
+            tracing::warn!(
+                worker_url = %self.metadata.url,
+                "Attempted to decrement load counter that is already at 0"
+            );
+        }
+        RouterMetrics::set_worker_load(self.url(), self.load());
     }
 
+    /// Recovery-only: clears the load counter after the worker transitions
+    /// back to healthy. While unhealthy no new requests are routed to this
+    /// worker, so any remaining load is drift from the down period. Never
+    /// called periodically.
     fn reset_load(&self) {
         self.load_counter.store(0, Ordering::Relaxed);
+        RouterMetrics::set_worker_load(self.url(), 0);
     }
 
     fn processed_requests(&self) -> usize {
@@ -812,36 +827,73 @@ pub fn workers_to_urls(workers: &[Box<dyn Worker>]) -> Vec<String> {
     workers.iter().map(|w| w.url().to_string()).collect()
 }
 
-/// RAII guard for worker load management
-pub struct WorkerLoadGuard<'a> {
-    workers: Vec<&'a dyn Worker>,
+/// RAII guard for worker load management.
+///
+/// Increments the load counter of the tracked worker(s) on creation and
+/// decrements exactly once when released (explicitly or on drop). Handles can
+/// be shared via [`WorkerLoadGuard::share`] so that a streaming forward task
+/// can own the guard while the routing task releases it early on retryable
+/// failures; only the first release decrements.
+pub struct WorkerLoadGuard {
+    inner: Arc<WorkerLoadGuardInner>,
 }
 
-impl<'a> WorkerLoadGuard<'a> {
+struct WorkerLoadGuardInner {
+    workers: Vec<Arc<dyn Worker>>,
+    released: AtomicBool,
+}
+
+impl WorkerLoadGuard {
     /// Create a new load guard for a single worker
-    pub fn new(worker: &'a dyn Worker) -> Self {
+    pub fn new(worker: Arc<dyn Worker>) -> Self {
         worker.increment_load();
+        RouterMetrics::set_running_requests(worker.url(), worker.load());
         Self {
-            workers: vec![worker],
+            inner: Arc::new(WorkerLoadGuardInner {
+                workers: vec![worker],
+                released: AtomicBool::new(false),
+            }),
         }
     }
 
     /// Create a new load guard for multiple workers
-    pub fn new_multi(workers: Vec<&'a dyn Worker>) -> Self {
+    pub fn new_multi(workers: Vec<Arc<dyn Worker>>) -> Self {
         // Increment load counters for all workers
         for worker in &workers {
             worker.increment_load();
+            RouterMetrics::set_running_requests(worker.url(), worker.load());
         }
-        Self { workers }
+        Self {
+            inner: Arc::new(WorkerLoadGuardInner {
+                workers,
+                released: AtomicBool::new(false),
+            }),
+        }
+    }
+
+    /// Share the guard without touching load counters. All shared handles
+    /// refer to the same release state: only the first release decrements.
+    pub fn share(&self) -> Self {
+        Self {
+            inner: Arc::clone(&self.inner),
+        }
+    }
+
+    /// Decrement the tracked workers' load counters exactly once. Safe to
+    /// call multiple times; subsequent calls are no-ops.
+    pub fn release(&self) {
+        if !self.inner.released.swap(true, Ordering::AcqRel) {
+            for worker in &self.inner.workers {
+                worker.decrement_load();
+                RouterMetrics::set_running_requests(worker.url(), worker.load());
+            }
+        }
     }
 }
 
-impl<'a> Drop for WorkerLoadGuard<'a> {
+impl Drop for WorkerLoadGuard {
     fn drop(&mut self) {
-        // Decrement load counters for all workers
-        for worker in &self.workers {
-            worker.decrement_load();
-        }
+        self.release();
     }
 }
 
@@ -872,95 +924,90 @@ impl HealthChecker {
     }
 }
 
-/// Start an async background health checker for a collection of workers
-pub fn start_health_checker(
-    workers: std::sync::Arc<std::sync::RwLock<Vec<std::sync::Arc<dyn Worker>>>>,
-    check_interval_secs: u64,
-) -> HealthChecker {
-    let shutdown = Arc::new(AtomicBool::new(false));
-    let shutdown_clone = shutdown.clone();
-
-    let handle = tokio::spawn(async move {
-        let mut interval =
-            tokio::time::interval(tokio::time::Duration::from_secs(check_interval_secs));
-
-        // Counter for periodic load reset (every 10 health check cycles)
-        let mut check_count = 0u64;
-        const LOAD_RESET_INTERVAL: u64 = 10;
-
-        loop {
-            interval.tick().await;
-
-            // Check for shutdown signal
-            if shutdown_clone.load(Ordering::Acquire) {
-                tracing::debug!("Health checker shutting down");
-                break;
-            }
-
-            check_count += 1;
-
-            // Check health of all workers
-            let workers_to_check = match workers.read() {
-                Ok(guard) => guard.clone(),
-                Err(poisoned) => {
-                    tracing::error!("Worker lock poisoned: {}", poisoned);
-                    continue;
-                }
-            };
-
-            // Periodically reset load counters to prevent drift
-            // Only do this when we believe all workers should be idle
-            if check_count.is_multiple_of(LOAD_RESET_INTERVAL) {
-                let max_load = workers_to_check.iter().map(|w| w.load()).max().unwrap_or(0);
-                // Only reset if load appears to be very low (likely drift)
-                if max_load <= 2 {
-                    tracing::debug!(
-                        "Resetting load counters to prevent drift (max_load: {})",
-                        max_load
-                    );
-                    for worker in &workers_to_check {
-                        worker.reset_load();
-                    }
-                }
-            }
-
-            // Perform health checks concurrently
-            let health_checks = workers_to_check.iter().map(|worker| {
-                let worker_url = worker.url().to_string();
-                let was_healthy = worker.is_healthy();
-
-                async move {
-                    match worker.check_health_async().await {
-                        Ok(_) => {
-                            if !was_healthy {
-                                tracing::info!("Worker {} is now healthy", worker_url);
-                            }
-                        }
-                        Err(e) => {
-                            if was_healthy {
-                                tracing::warn!("Worker {} health check failed: {}", worker_url, e);
-                            } else {
-                                // Worker was already unhealthy, log at debug level
-                                tracing::debug!("Worker {} remains unhealthy: {}", worker_url, e);
-                            }
-                        }
-                    }
-                }
-            });
-
-            // Execute all health checks concurrently
-            futures::future::join_all(health_checks).await;
-        }
-    });
-
-    HealthChecker { handle, shutdown }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::thread;
     use std::time::Duration;
+
+    fn test_worker() -> Arc<dyn Worker> {
+        Arc::new(BasicWorker::new(
+            "http://test:8080".to_string(),
+            WorkerType::Regular,
+        ))
+    }
+
+    #[test]
+    fn test_worker_load_guard_drop_decrements() {
+        let worker = test_worker();
+        {
+            let _guard = WorkerLoadGuard::new(worker.clone());
+            assert_eq!(worker.load(), 1);
+        }
+        assert_eq!(worker.load(), 0);
+    }
+
+    #[test]
+    fn test_worker_load_guard_release_is_idempotent() {
+        let worker = test_worker();
+        let guard = WorkerLoadGuard::new(worker.clone());
+        assert_eq!(worker.load(), 1);
+        guard.release();
+        assert_eq!(worker.load(), 0);
+        guard.release();
+        assert_eq!(worker.load(), 0);
+        drop(guard);
+        assert_eq!(worker.load(), 0);
+    }
+
+    #[test]
+    fn test_worker_load_guard_shared_handle_decrements_once() {
+        let worker = test_worker();
+        let guard = WorkerLoadGuard::new(worker.clone());
+        let shared = guard.share();
+        assert_eq!(worker.load(), 1);
+        // First release wins regardless of which handle triggers it.
+        drop(shared);
+        assert_eq!(worker.load(), 0);
+        drop(guard);
+        assert_eq!(worker.load(), 0, "second release must be a no-op");
+    }
+
+    #[test]
+    fn test_worker_load_guard_release_then_shared_drop_is_noop() {
+        // Streaming retryable path: release immediately, then hand a shared
+        // handle to the forward task; its drop must not decrement again.
+        let worker = test_worker();
+        let guard = WorkerLoadGuard::new(worker.clone());
+        guard.release();
+        assert_eq!(worker.load(), 0);
+        let shared = guard.share();
+        drop(shared);
+        drop(guard);
+        assert_eq!(worker.load(), 0);
+    }
+
+    #[test]
+    fn test_worker_load_guard_multi() {
+        let worker1 = test_worker();
+        let worker2 = Arc::new(BasicWorker::new(
+            "http://test:8081".to_string(),
+            WorkerType::Regular,
+        )) as Arc<dyn Worker>;
+        let guard = WorkerLoadGuard::new_multi(vec![worker1.clone(), worker2.clone()]);
+        assert_eq!(worker1.load(), 1);
+        assert_eq!(worker2.load(), 1);
+        guard.release();
+        assert_eq!(worker1.load(), 0);
+        assert_eq!(worker2.load(), 0);
+    }
+
+    #[test]
+    fn test_decrement_at_zero_clamps() {
+        let worker = test_worker();
+        worker.decrement_load();
+        assert_eq!(worker.load(), 0);
+    }
 
     // Test WorkerType
     #[test]
@@ -1398,11 +1445,14 @@ mod tests {
     // Test WorkerLoadGuard
     #[test]
     fn test_load_guard_single_worker() {
-        let worker = BasicWorker::new("http://test:8080".to_string(), WorkerType::Regular);
+        let worker: Arc<dyn Worker> = Arc::new(BasicWorker::new(
+            "http://test:8080".to_string(),
+            WorkerType::Regular,
+        ));
         assert_eq!(worker.load(), 0);
 
         {
-            let _guard = WorkerLoadGuard::new(&worker);
+            let _guard = WorkerLoadGuard::new(worker.clone());
             assert_eq!(worker.load(), 1);
         }
 
@@ -1412,16 +1462,23 @@ mod tests {
 
     #[test]
     fn test_load_guard_multiple_workers() {
-        let workers: Vec<Box<dyn Worker>> = vec![
-            WorkerFactory::create_regular("http://w1:8080".to_string()),
-            WorkerFactory::create_regular("http://w2:8080".to_string()),
-            WorkerFactory::create_regular("http://w3:8080".to_string()),
+        let workers: Vec<Arc<dyn Worker>> = vec![
+            Arc::new(BasicWorker::new(
+                "http://w1:8080".to_string(),
+                WorkerType::Regular,
+            )),
+            Arc::new(BasicWorker::new(
+                "http://w2:8080".to_string(),
+                WorkerType::Regular,
+            )),
+            Arc::new(BasicWorker::new(
+                "http://w3:8080".to_string(),
+                WorkerType::Regular,
+            )),
         ];
 
-        let worker_refs: Vec<&dyn Worker> = workers.iter().map(|w| w.as_ref()).collect();
-
         {
-            let _guard = WorkerLoadGuard::new_multi(worker_refs);
+            let _guard = WorkerLoadGuard::new_multi(workers.clone());
             // All loads incremented
             assert_eq!(workers[0].load(), 1);
             assert_eq!(workers[1].load(), 1);
@@ -1436,14 +1493,11 @@ mod tests {
 
     #[test]
     fn test_load_guard_panic_safety() {
-        let worker = Arc::new(BasicWorker::new(
+        let worker: Arc<dyn Worker> = Arc::new(BasicWorker::new(
             "http://test:8080".to_string(),
             WorkerType::Regular,
         ));
         assert_eq!(worker.load(), 0);
-
-        // Clone for use inside catch_unwind
-        let worker_clone = Arc::clone(&worker);
 
         // Use AssertUnwindSafe wrapper for the test
         // This is safe because we're only testing the load counter behavior.
@@ -1451,8 +1505,8 @@ mod tests {
 
         // This will panic, but the guard should still clean up
         let result = std::panic::catch_unwind(AssertUnwindSafe(|| {
-            let _guard = WorkerLoadGuard::new(worker_clone.as_ref());
-            assert_eq!(worker_clone.load(), 1);
+            let _guard = WorkerLoadGuard::new(worker.clone());
+            assert_eq!(worker.load(), 1);
             panic!("Test panic");
         }));
 

--- a/src/core/worker_registry.rs
+++ b/src/core/worker_registry.rs
@@ -381,24 +381,20 @@ impl WorkerRegistry {
                     .collect();
 
                 // Perform health checks in parallel. Health checking must not
-                // mutate load accounting: the only reset happens when a worker
-                // transitions from unhealthy back to healthy, because any load
-                // it still reports is drift accumulated while it was down
-                // (no new requests are routed to unhealthy workers).
+                // mutate load accounting: a failed /health probe does not
+                // cancel in-flight requests, so a worker marked unhealthy can
+                // still hold valid load when it recovers. Reset on recovery
+                // would erase that load (or erase a newly routed request's
+                // increment racing the reset), recreating the undercount that
+                // this checker previously caused. WorkerLoadGuard keeps
+                // increments and decrements paired on every request path, so
+                // no reset is needed.
                 let health_futures: Vec<_> = workers
                     .iter()
                     .map(|worker| {
                         let worker = worker.clone();
-                        let was_healthy = worker.is_healthy();
                         async move {
                             let _ = worker.check_health_async().await;
-                            if !was_healthy && worker.is_healthy() {
-                                tracing::info!(
-                                    "Worker {} recovered; resetting stale load counter",
-                                    worker.url()
-                                );
-                                worker.reset_load();
-                            }
                         }
                     })
                     .collect();
@@ -431,8 +427,75 @@ pub struct WorkerRegistryStats {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::error::WorkerResult;
+    use crate::core::worker::WorkerMetadata;
     use crate::core::{BasicWorker, CircuitBreakerConfig, HealthConfig, WorkerFactory};
+    use async_trait::async_trait;
     use std::collections::HashMap;
+
+    /// Test worker that skips real HTTP health checks so the health-checker
+    /// loop can be driven deterministically under paused Tokio time (no I/O).
+    #[derive(Debug)]
+    struct NoopHealthWorker(Arc<BasicWorker>);
+
+    #[async_trait]
+    impl Worker for NoopHealthWorker {
+        fn url(&self) -> &str {
+            self.0.url()
+        }
+
+        fn worker_type(&self) -> WorkerType {
+            self.0.worker_type()
+        }
+
+        fn connection_mode(&self) -> ConnectionMode {
+            self.0.connection_mode()
+        }
+
+        fn is_healthy(&self) -> bool {
+            self.0.is_healthy()
+        }
+
+        fn set_healthy(&self, healthy: bool) {
+            self.0.set_healthy(healthy);
+        }
+
+        async fn check_health_async(&self) -> WorkerResult<()> {
+            Ok(())
+        }
+
+        fn load(&self) -> usize {
+            self.0.load()
+        }
+
+        fn increment_load(&self) {
+            self.0.increment_load();
+        }
+
+        fn decrement_load(&self) {
+            self.0.decrement_load();
+        }
+
+        fn reset_load(&self) {
+            self.0.reset_load();
+        }
+
+        fn processed_requests(&self) -> usize {
+            self.0.processed_requests()
+        }
+
+        fn increment_processed(&self) {
+            self.0.increment_processed();
+        }
+
+        fn metadata(&self) -> &WorkerMetadata {
+            self.0.metadata()
+        }
+
+        fn circuit_breaker(&self) -> &crate::core::CircuitBreaker {
+            self.0.circuit_breaker()
+        }
+    }
 
     #[test]
     fn test_worker_registry() {
@@ -542,7 +605,6 @@ mod tests {
         let handle = tokio::spawn(async move {
             axum::serve(listener, app).await.unwrap();
         });
-        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
         (format!("http://{}", addr), handle)
     }
 
@@ -562,11 +624,18 @@ mod tests {
 
     /// Regression test for issue #197: health checks must not reset the load
     /// counters of workers with requests in flight.
-    #[tokio::test]
+    ///
+    /// Uses paused Tokio time and a no-I/O health check to advance through
+    /// well over 10 health-check cycles, the cadence at which the previous
+    /// implementation reset load counters. This test fails against that
+    /// implementation and passes with the fix.
+    #[tokio::test(start_paused = true)]
     async fn test_health_checker_preserves_inflight_load() {
-        let (url, _server) = start_healthy_mock_server().await;
         let registry = WorkerRegistry::new();
-        let worker = registry_worker(&url);
+        let worker: Arc<dyn Worker> = Arc::new(NoopHealthWorker(Arc::new(BasicWorker::new(
+            "http://worker:8080".to_string(),
+            WorkerType::Regular,
+        ))));
         registry.register(worker.clone());
 
         // Simulate 5 requests in flight.
@@ -575,29 +644,38 @@ mod tests {
         }
         assert_eq!(worker.load(), 5);
 
-        // Run several health-check cycles while the "requests" are still
-        // in flight. The old implementation reset the counters every 10
-        // cycles; ensure no reset happens at all.
+        // Advance through 12 health-check cycles (the first tick fires
+        // immediately, so this covers check counts well past the old
+        // 10-cycle reset interval).
         let checker = registry.start_health_checker(1);
-        tokio::time::sleep(std::time::Duration::from_millis(2500)).await;
-        checker.shutdown().await;
+        for _ in 0..12 {
+            tokio::time::advance(std::time::Duration::from_secs(1)).await;
+            tokio::task::yield_now().await;
+        }
 
         assert_eq!(
             worker.load(),
             5,
             "health checker must not reset the load counter of a worker with in-flight requests"
         );
+
+        // Under paused time the checker task cannot observe a shutdown flag
+        // until the next tick fires, so drop the handle instead of awaiting
+        // shutdown; the test runtime aborts the task.
+        drop(checker);
     }
 
-    /// Load counters are only reset when a worker recovers from an unhealthy
-    /// state: any remaining load is drift from the down period.
+    /// Load must survive an unhealthy->healthy recovery transition: a failed
+    /// /health probe does not cancel in-flight requests, so the load a worker
+    /// reports at recovery time may be real work, not drift.
     #[tokio::test]
-    async fn test_health_checker_resets_load_on_recovery_only() {
+    async fn test_health_checker_preserves_load_across_recovery() {
         let (url, _server) = start_healthy_mock_server().await;
         let registry = WorkerRegistry::new();
         let worker = registry_worker(&url);
         worker.set_healthy(false);
-        // Stale load accumulated while the worker was down.
+        // Load accumulated while the worker was down. Some of it may still
+        // be in flight when the worker recovers.
         for _ in 0..3 {
             worker.increment_load();
         }
@@ -610,8 +688,8 @@ mod tests {
         assert!(worker.is_healthy(), "worker should have recovered");
         assert_eq!(
             worker.load(),
-            0,
-            "stale load must be reset on the unhealthy->healthy transition"
+            3,
+            "load must be preserved across the unhealthy->healthy transition"
         );
     }
 }

--- a/src/core/worker_registry.rs
+++ b/src/core/worker_registry.rs
@@ -4,7 +4,6 @@
 
 use crate::core::{ConnectionMode, Worker, WorkerType};
 use dashmap::DashMap;
-use futures;
 use std::sync::{Arc, RwLock};
 use uuid::Uuid;
 

--- a/src/core/worker_registry.rs
+++ b/src/core/worker_registry.rs
@@ -4,6 +4,7 @@
 
 use crate::core::{ConnectionMode, Worker, WorkerType};
 use dashmap::DashMap;
+use futures;
 use std::sync::{Arc, RwLock};
 use uuid::Uuid;
 
@@ -364,10 +365,6 @@ impl WorkerRegistry {
             let mut interval =
                 tokio::time::interval(tokio::time::Duration::from_secs(check_interval_secs));
 
-            // Counter for periodic load reset (every 10 health check cycles)
-            let mut check_count = 0u64;
-            const LOAD_RESET_INTERVAL: u64 = 10;
-
             loop {
                 interval.tick().await;
 
@@ -383,19 +380,29 @@ impl WorkerRegistry {
                     .map(|entry| entry.value().clone())
                     .collect();
 
-                // Perform health checks
-                for worker in &workers {
-                    let _ = worker.check_health_async().await; // Use async version directly
-                }
-
-                // Reset loads periodically
-                check_count += 1;
-                if check_count.is_multiple_of(LOAD_RESET_INTERVAL) {
-                    tracing::debug!("Resetting worker loads (cycle {})", check_count);
-                    for worker in &workers {
-                        worker.reset_load();
-                    }
-                }
+                // Perform health checks in parallel. Health checking must not
+                // mutate load accounting: the only reset happens when a worker
+                // transitions from unhealthy back to healthy, because any load
+                // it still reports is drift accumulated while it was down
+                // (no new requests are routed to unhealthy workers).
+                let health_futures: Vec<_> = workers
+                    .iter()
+                    .map(|worker| {
+                        let worker = worker.clone();
+                        let was_healthy = worker.is_healthy();
+                        async move {
+                            let _ = worker.check_health_async().await;
+                            if !was_healthy && worker.is_healthy() {
+                                tracing::info!(
+                                    "Worker {} recovered; resetting stale load counter",
+                                    worker.url()
+                                );
+                                worker.reset_load();
+                            }
+                        }
+                    })
+                    .collect();
+                futures::future::join_all(health_futures).await;
             }
         });
 
@@ -424,7 +431,7 @@ pub struct WorkerRegistryStats {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::{CircuitBreakerConfig, WorkerFactory};
+    use crate::core::{BasicWorker, CircuitBreakerConfig, HealthConfig, WorkerFactory};
     use std::collections::HashMap;
 
     #[test]
@@ -522,5 +529,89 @@ mod tests {
         let llama_workers_after = registry.get_by_model_fast("llama-3");
         assert_eq!(llama_workers_after.len(), 1);
         assert_eq!(llama_workers_after[0].url(), "http://worker2:8080");
+    }
+
+    /// Start a mock HTTP server whose /health endpoint always returns 200.
+    async fn start_healthy_mock_server() -> (String, tokio::task::JoinHandle<()>) {
+        use axum::{http::StatusCode, routing::get, Router as AxumRouter};
+        use tokio::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let app = AxumRouter::new().route("/health", get(|| async { StatusCode::OK }));
+        let handle = tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        (format!("http://{}", addr), handle)
+    }
+
+    fn registry_worker(url: &str) -> Arc<dyn Worker> {
+        Arc::new(
+            BasicWorker::new(url.to_string(), WorkerType::Regular).with_health_config(
+                HealthConfig {
+                    timeout_secs: 2,
+                    check_interval_secs: 1,
+                    endpoint: "/health".to_string(),
+                    failure_threshold: 3,
+                    success_threshold: 1,
+                },
+            ),
+        )
+    }
+
+    /// Regression test for issue #197: health checks must not reset the load
+    /// counters of workers with requests in flight.
+    #[tokio::test]
+    async fn test_health_checker_preserves_inflight_load() {
+        let (url, _server) = start_healthy_mock_server().await;
+        let registry = WorkerRegistry::new();
+        let worker = registry_worker(&url);
+        registry.register(worker.clone());
+
+        // Simulate 5 requests in flight.
+        for _ in 0..5 {
+            worker.increment_load();
+        }
+        assert_eq!(worker.load(), 5);
+
+        // Run several health-check cycles while the "requests" are still
+        // in flight. The old implementation reset the counters every 10
+        // cycles; ensure no reset happens at all.
+        let checker = registry.start_health_checker(1);
+        tokio::time::sleep(std::time::Duration::from_millis(2500)).await;
+        checker.shutdown().await;
+
+        assert_eq!(
+            worker.load(),
+            5,
+            "health checker must not reset the load counter of a worker with in-flight requests"
+        );
+    }
+
+    /// Load counters are only reset when a worker recovers from an unhealthy
+    /// state: any remaining load is drift from the down period.
+    #[tokio::test]
+    async fn test_health_checker_resets_load_on_recovery_only() {
+        let (url, _server) = start_healthy_mock_server().await;
+        let registry = WorkerRegistry::new();
+        let worker = registry_worker(&url);
+        worker.set_healthy(false);
+        // Stale load accumulated while the worker was down.
+        for _ in 0..3 {
+            worker.increment_load();
+        }
+        registry.register(worker.clone());
+
+        let checker = registry.start_health_checker(1);
+        tokio::time::sleep(std::time::Duration::from_millis(2500)).await;
+        checker.shutdown().await;
+
+        assert!(worker.is_healthy(), "worker should have recovered");
+        assert_eq!(
+            worker.load(),
+            0,
+            "stale load must be reset on the unhealthy->healthy transition"
+        );
     }
 }

--- a/src/routers/http/router.rs
+++ b/src/routers/http/router.rs
@@ -1,7 +1,7 @@
 use crate::config::types::RetryConfig;
 use crate::core::{
     is_retryable_status, BasicWorker, CircuitBreakerConfig, DPAwareWorker, HealthConfig,
-    RetryExecutor, Worker, WorkerRegistry, WorkerType,
+    RetryExecutor, Worker, WorkerLoadGuard, WorkerRegistry, WorkerType,
 };
 use crate::metrics::RouterMetrics;
 use crate::otel_http::{self, ClientRequestOptions};
@@ -571,17 +571,11 @@ impl Router {
                     None => self.policy_registry.get_default_policy(),
                 };
 
-                let load_incremented = if policy.name() == "cache_aware" {
-                    worker.increment_load();
-                    RouterMetrics::set_running_requests(worker.url(), worker.load());
-                    true
-                } else {
-                    false
-                };
-
-                // Keep a clone for potential cleanup on retry
-                let worker_for_cleanup = if load_incremented {
-                    Some(worker.clone())
+                // The load guard owns the load accounting for this attempt:
+                // it increments on creation and decrements exactly once on
+                // release (drop, retry transfer, or stream completion).
+                let load_guard = if policy.name() == "cache_aware" {
+                    Some(WorkerLoadGuard::new(worker.clone()))
                 } else {
                     None
                 };
@@ -593,7 +587,7 @@ impl Router {
                         route,
                         worker.url(),
                         is_stream,
-                        load_incremented,
+                        load_guard,
                     )
                     .await;
 
@@ -601,18 +595,6 @@ impl Router {
                 // should count against the circuit breaker.
                 let status = response.status();
                 worker.record_outcome(status.is_success() || status.is_client_error());
-
-                // For retryable failures, we need to decrement load since send_typed_request
-                // won't have done it (it only decrements on success or non-retryable failures)
-                if is_retryable_status(response.status()) && load_incremented {
-                    if let Some(cleanup_worker) = worker_for_cleanup {
-                        cleanup_worker.decrement_load();
-                        RouterMetrics::set_running_requests(
-                            cleanup_worker.url(),
-                            cleanup_worker.load(),
-                        );
-                    }
-                }
 
                 response
             },
@@ -771,7 +753,7 @@ impl Router {
         route: &str,
         worker_url: &str,
         is_stream: bool,
-        load_incremented: bool, // Whether load was incremented for this request
+        load_guard: Option<WorkerLoadGuard>, // Load guard for cache-aware policy
     ) -> Response {
         let (mut request_builder, extracted_dp_rank, request_url) =
             if self.intra_node_data_parallel_size > 1 {
@@ -856,14 +838,7 @@ impl Router {
                     worker_url, route, e
                 );
 
-                // Decrement load on error if it was incremented
-                if load_incremented {
-                    if let Some(worker) = self.worker_registry.get_by_url(worker_url) {
-                        worker.decrement_load();
-                        RouterMetrics::set_running_requests(worker_url, worker.load());
-                    }
-                }
-
+                // The load guard is dropped on return, decrementing load.
                 return (
                     StatusCode::INTERNAL_SERVER_ERROR,
                     format!("Request failed: {}", e),
@@ -887,32 +862,29 @@ impl Router {
                     response
                 }
                 Err(e) => {
-                    // IMPORTANT: Decrement load on error before returning
-                    if load_incremented {
-                        if let Some(worker) = self.worker_registry.get_by_url(worker_url) {
-                            worker.decrement_load();
-                            RouterMetrics::set_running_requests(worker_url, worker.load());
-                        }
-                    }
-
+                    // The load guard is dropped on return, decrementing load.
                     let error_msg = format!("Failed to get response body: {}", e);
                     (StatusCode::INTERNAL_SERVER_ERROR, error_msg).into_response()
                 }
             };
 
-            // Decrement load counter for non-streaming requests if it was incremented
-            if load_incremented {
-                if let Some(worker) = self.worker_registry.get_by_url(worker_url) {
-                    worker.decrement_load();
-                    RouterMetrics::set_running_requests(worker_url, worker.load());
-                }
-            }
+            // The load guard is dropped when this function returns, after the
+            // response body has been fully buffered, decrementing load once.
 
             response
-        } else if load_incremented {
-            // For streaming with load tracking, we need to manually decrement when done
-            let registry = Arc::clone(&self.worker_registry);
-            let worker_url = worker_url.to_string();
+        } else if let Some(guard) = load_guard {
+            // Streaming with load tracking: the guard moves into the forward
+            // task and is released when the stream ends (completion, error,
+            // or client disconnect). For retryable statuses the load is
+            // released immediately, before the retry executor selects the
+            // next worker.
+            let status_is_retryable = is_retryable_status(status);
+            let task_guard = if status_is_retryable {
+                guard.release();
+                guard.share()
+            } else {
+                guard
+            };
 
             // Preserve headers for streaming response
             let mut response_headers = header_utils::preserve_response_headers(res.headers());
@@ -922,25 +894,14 @@ impl Router {
             let stream = res.bytes_stream();
             let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
 
-            // Spawn task to forward stream and detect completion
+            // Spawn task to forward stream; the guard is released on drop
+            // when the task finishes.
             tokio::spawn(async move {
+                let _guard = task_guard;
                 let mut stream = stream;
-                let mut decremented = false;
                 while let Some(chunk) = stream.next().await {
                     match chunk {
                         Ok(bytes) => {
-                            // Check for stream end marker
-                            if bytes
-                                .as_ref()
-                                .windows(12)
-                                .any(|window| window == b"data: [DONE]")
-                            {
-                                if let Some(worker) = registry.get_by_url(&worker_url) {
-                                    worker.decrement_load();
-                                    RouterMetrics::set_running_requests(&worker_url, worker.load());
-                                    decremented = true;
-                                }
-                            }
                             if tx.send(Ok(bytes)).is_err() {
                                 break;
                             }
@@ -949,12 +910,6 @@ impl Router {
                             let _ = tx.send(Err(format!("Stream error: {}", e)));
                             break;
                         }
-                    }
-                }
-                if !decremented {
-                    if let Some(worker) = registry.get_by_url(&worker_url) {
-                        worker.decrement_load();
-                        RouterMetrics::set_running_requests(&worker_url, worker.load());
                     }
                 }
             });

--- a/src/routers/http/vllm_pd_router.rs
+++ b/src/routers/http/vllm_pd_router.rs
@@ -6,7 +6,7 @@ use super::pd_router::PdRouterBase;
 use super::pd_types::{error_chain, PDRouterError};
 use super::vllm_service_discovery::{MoriIOTransferMode, ServiceRegistry, ServiceType};
 use crate::config::KvConnector;
-use crate::core::{BasicWorker, Worker, WorkerType};
+use crate::core::{BasicWorker, Worker, WorkerLoadGuard, WorkerType};
 use crate::metrics::RouterMetrics;
 use crate::otel_http::{self, ClientRequestOptions};
 use crate::policies::PolicyRegistry;
@@ -1174,8 +1174,11 @@ impl VllmPDRouter {
             path
         );
 
-        // Increment prefill load at the start of the prefill phase
-        prefill_worker.increment_load();
+        // Increment prefill load at the start of the prefill phase. The guard
+        // releases the load on every exit path, including task cancellation
+        // (e.g. client disconnect dropping the handler future), which the
+        // previous manual decrements leaked.
+        let prefill_guard = WorkerLoadGuard::new(prefill_worker.clone());
 
         let prefill_zmq_addr =
             self.get_zmq_address(prefill_worker.base_url(), ServiceType::Prefill);
@@ -1270,7 +1273,6 @@ impl VllmPDRouter {
         {
             Ok(resp) => resp,
             Err(e) => {
-                prefill_worker.decrement_load();
                 let full_error = error_chain(&e);
                 let duration = start_time.elapsed();
                 RouterMetrics::record_pd_prefill_error(&prefill_base_url);
@@ -1292,7 +1294,6 @@ impl VllmPDRouter {
         let prefill_bytes = match prefill_response.bytes().await {
             Ok(bytes) => bytes,
             Err(e) => {
-                prefill_worker.decrement_load();
                 let full_error = error_chain(&e);
                 let duration = start_time.elapsed();
                 RouterMetrics::record_pd_prefill_error(&prefill_base_url);
@@ -1322,7 +1323,6 @@ impl VllmPDRouter {
         let prefill_response_json: Value = match serde_json::from_slice(&prefill_bytes) {
             Ok(json) => json,
             Err(e) => {
-                prefill_worker.decrement_load();
                 let duration = start_time.elapsed();
                 RouterMetrics::record_pd_prefill_error(&prefill_base_url);
                 RouterMetrics::record_pd_request(path);
@@ -1348,9 +1348,10 @@ impl VllmPDRouter {
         // Stop profiling on prefill server after its work is done
         self.stop_profiling(&prefill_base_url).await;
 
-        // Prefill phase complete: decrement prefill load, increment decode load
-        prefill_worker.decrement_load();
-        decode_worker.increment_load();
+        // Prefill phase complete: release prefill load, track decode load.
+        // The decode guard releases on every exit path, including cancellation.
+        prefill_guard.release();
+        let decode_guard = WorkerLoadGuard::new(decode_worker.clone());
 
         debug!("✅ vLLM Stage 1 completed, starting Stage 2 - Decode");
 
@@ -1451,7 +1452,6 @@ impl VllmPDRouter {
         {
             Ok(resp) => resp,
             Err(e) => {
-                decode_worker.decrement_load();
                 let full_error = error_chain(&e);
                 let duration = start_time.elapsed();
                 RouterMetrics::record_pd_decode_error(&decode_base_url);
@@ -1467,8 +1467,8 @@ impl VllmPDRouter {
         // Stop profiling on decode server after response received
         self.stop_profiling(&decode_base_url).await;
 
-        // Decode phase complete: decrement decode load
-        decode_worker.decrement_load();
+        // Decode phase complete: release decode load
+        decode_guard.release();
 
         let status = decode_response.status();
         let headers = decode_response.headers().clone();
@@ -2418,6 +2418,7 @@ impl WorkerManagement for VllmPDRouter {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use axum::extract::Json;
     use serde_json::json;
 
     #[test]
@@ -2688,5 +2689,222 @@ mod tests {
     fn test_moriio_write_decode_params_includes_remote_dp_rank_when_dp_size_gt_1() {
         let params = moriio_write_decode_params(Some("tx-abc"), 4, Some(2));
         assert_eq!(params["remote_dp_rank"], 2);
+    }
+
+    // --- Load-accounting cancellation tests (regression for #197 review P1) ---
+
+    /// Build a VllmPDRouter without AppContext for focused tests.
+    fn test_vllm_pd_router() -> VllmPDRouter {
+        let worker_registry = Arc::new(crate::core::WorkerRegistry::new());
+        let policy_registry =
+            Arc::new(PolicyRegistry::new(crate::config::PolicyConfig::RoundRobin));
+        let pd_router = PdRouterBase {
+            worker_registry,
+            policy_registry: policy_registry.clone(),
+            worker_startup_timeout_secs: 5,
+            worker_startup_check_interval_secs: 1,
+            worker_loads: Arc::new(tokio::sync::watch::channel(HashMap::new()).1),
+            load_monitor_handle: None,
+            client: reqwest::Client::new(),
+            circuit_breaker_config: crate::core::CircuitBreakerConfig::default(),
+            dp_size: 1,
+        };
+        VllmPDRouter {
+            pd_router,
+            service_registry: Arc::new(ServiceRegistry::new()),
+            http_client: reqwest::Client::new(),
+            policy_registry,
+            use_discovery: false,
+            enable_profiling: false,
+            profile_timeout_secs: 0,
+            profiling_tasks: Arc::new(Mutex::new(HashMap::new())),
+            intra_node_data_parallel_size: 1,
+            prefill_dp_round_robin: Arc::new(AtomicUsize::new(0)),
+            kv_connector: KvConnector::Nixl,
+            mooncake_prefill_info: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    /// Mock server whose POST /v1/chat/completions handler signals `entered`
+    /// and then waits for `release` before responding.
+    async fn start_pending_mock_server() -> (
+        String,
+        Arc<tokio::sync::Notify>,
+        Arc<tokio::sync::Notify>,
+        tokio::task::JoinHandle<()>,
+    ) {
+        use axum::routing::post;
+        use tokio::net::TcpListener;
+
+        let entered = Arc::new(tokio::sync::Notify::new());
+        let release = Arc::new(tokio::sync::Notify::new());
+        let entered_clone = entered.clone();
+        let release_clone = release.clone();
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let app = axum::Router::new().route(
+            "/v1/chat/completions",
+            post(move |Json(_body): Json<serde_json::Value>| {
+                let entered = entered_clone.clone();
+                let release = release_clone.clone();
+                async move {
+                    entered.notify_one();
+                    release.notified().await;
+                    (axum::http::StatusCode::OK, "{}")
+                }
+            }),
+        );
+
+        let handle = tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        (format!("http://{}", addr), entered, release, handle)
+    }
+
+    /// Mock server whose POST /v1/chat/completions responds immediately with a
+    /// JSON body containing kv_transfer_params (prefill stage).
+    async fn start_immediate_prefill_mock_server() -> (String, tokio::task::JoinHandle<()>) {
+        use axum::routing::post;
+        use tokio::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let app = axum::Router::new().route(
+            "/v1/chat/completions",
+            post(|Json(_body): Json<serde_json::Value>| async move {
+                (
+                    axum::http::StatusCode::OK,
+                    "{\"kv_transfer_params\":{\"dummy\":true}}",
+                )
+            }),
+        );
+
+        let handle = tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        (format!("http://{}", addr), handle)
+    }
+
+    async fn wait_for_load(worker: &Arc<dyn Worker>, expected: usize) {
+        for _ in 0..200 {
+            if worker.load() == expected {
+                return;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        panic!(
+            "timed out waiting for worker load to reach {}, got {}",
+            expected,
+            worker.load()
+        );
+    }
+
+    /// Cancelling a two-stage request while the prefill response is pending
+    /// must release the prefill worker's load.
+    #[tokio::test]
+    async fn test_pd_request_cancellation_releases_prefill_load() {
+        let router = test_vllm_pd_router();
+        let (prefill_url, entered, _release, _server) = start_pending_mock_server().await;
+
+        let prefill_worker: Arc<dyn Worker> = Arc::new(BasicWorker::new(
+            prefill_url.clone(),
+            WorkerType::Prefill {
+                bootstrap_port: None,
+            },
+        ));
+        let decode_worker: Arc<dyn Worker> = Arc::new(BasicWorker::new(
+            "http://127.0.0.1:1".to_string(),
+            WorkerType::Decode,
+        ));
+
+        let prefill_task_worker = prefill_worker.clone();
+        let decode_task_worker = decode_worker.clone();
+        let handle = tokio::spawn(async move {
+            let request = json!({
+                "model": "test",
+                "messages": [{"role": "user", "content": "hi"}],
+            });
+            let _ = router
+                .process_vllm_two_stage_request(
+                    request,
+                    prefill_task_worker,
+                    decode_task_worker,
+                    "/v1/chat/completions",
+                    None,
+                )
+                .await;
+        });
+
+        // Wait until the request reached the prefill worker and its load is
+        // counted, then cancel the whole request task.
+        entered.notified().await;
+        wait_for_load(&prefill_worker, 1).await;
+        handle.abort();
+        let _ = handle.await;
+
+        assert_eq!(
+            prefill_worker.load(),
+            0,
+            "cancelling a P/D request must release its prefill load"
+        );
+        assert_eq!(decode_worker.load(), 0);
+    }
+
+    /// Cancelling a two-stage request while the decode response is pending
+    /// must release both the decode and prefill workers' load.
+    #[tokio::test]
+    async fn test_pd_request_cancellation_releases_decode_load() {
+        let router = test_vllm_pd_router();
+        let (prefill_url, _prefill_server) = start_immediate_prefill_mock_server().await;
+        let (decode_url, decode_entered, _release, _decode_server) =
+            start_pending_mock_server().await;
+
+        let prefill_worker: Arc<dyn Worker> = Arc::new(BasicWorker::new(
+            prefill_url.clone(),
+            WorkerType::Prefill {
+                bootstrap_port: None,
+            },
+        ));
+        let decode_worker: Arc<dyn Worker> =
+            Arc::new(BasicWorker::new(decode_url.clone(), WorkerType::Decode));
+
+        let prefill_task_worker = prefill_worker.clone();
+        let decode_task_worker = decode_worker.clone();
+        let handle = tokio::spawn(async move {
+            let request = json!({
+                "model": "test",
+                "messages": [{"role": "user", "content": "hi"}],
+            });
+            let _ = router
+                .process_vllm_two_stage_request(
+                    request,
+                    prefill_task_worker,
+                    decode_task_worker,
+                    "/v1/chat/completions",
+                    None,
+                )
+                .await;
+        });
+
+        // Wait until the prefill stage completed and the request reached the
+        // decode worker, then cancel the whole request task.
+        decode_entered.notified().await;
+        wait_for_load(&decode_worker, 1).await;
+        handle.abort();
+        let _ = handle.await;
+
+        assert_eq!(
+            decode_worker.load(),
+            0,
+            "cancelling a P/D request must release its decode load"
+        );
+        assert_eq!(
+            prefill_worker.load(),
+            0,
+            "the prefill load must have been released at the transition"
+        );
     }
 }


### PR DESCRIPTION
<!-- markdownlint-disable -->
## Purpose

Fixes #197: the runtime health checker unconditionally reset every worker's load counter to zero every 10 health-check cycles, even while requests were in flight. The cache-aware prefix tree was never reset, so the policy saw all workers as balanced and kept routing by prefix affinity to already-saturated workers, creating a positive feedback loop of hot spots.

Changes:

- Remove the periodic load reset from `WorkerRegistry::start_health_checker()`; health checks now run in parallel and never mutate load accounting. Load counters are neither reset periodically nor reset on health transitions: a failed `/health` probe does not cancel in-flight requests, so the load a worker reports at recovery time can still be real work.
- Delete the unused standalone `start_health_checker()` with its conditional low-load reset (zero callers).
- Redesign `WorkerLoadGuard` as an owning RAII guard with `share()`/`release()` and adopt it in the OpenAI router proxy path. This also fixes a pre-existing double-decrement on retryable responses and guarantees paired increment/decrement on every path (success, failure, retry, stream abort, client disconnect).
- Adopt `WorkerLoadGuard` for both phases of the P/D two-stage flow (`process_vllm_two_stage_request`), fixing a permanent load leak when a P/D request task is cancelled (e.g. client disconnect) between the manual increment and a decrement branch. Cancellation now releases the prefill/decode load via guard drop; covered by cancellation tests for both phases.
- Clamp decrement at zero with a warning and wire the `vllm_router_worker_load` gauge on increment/decrement/reset.

## Changes since first review

- Removed the unhealthy-to-healthy `reset_load()` call that the first review round flagged: it could erase real in-flight load (a failed `/health` probe does not cancel requests) and raced with new routing. The health checker now never mutates load accounting; `reset_load` is documented as an administrative operation that is only safe when the caller has established that no requests are in flight.
- Strengthened the #197 regression test: it now runs under paused Tokio time with a no-I/O health check and advances through 12 health-check cycles, so it fails against the pre-fix 10-cycle reset (verified by mutation probe: `left: 0, right: 5`).
- Added P/D cancellation tests for both phases (see Test Plan); verified they fail against the previous manual accounting (`left: 1, right: 0`) and pass with the guard-based fix.

## Test Plan

```bash
cargo fmt --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --lib --bins
cargo test --test '*'
pre-commit run --files src/core/mod.rs src/core/worker.rs src/core/worker_registry.rs \
  src/routers/http/router.rs src/routers/http/vllm_pd_router.rs Cargo.toml
```

New tests:

- `src/core/worker.rs`: `WorkerLoadGuard` unit tests (drop decrements, release idempotence, shared handle decrements once, multi-worker, decrement-at-zero clamps).
- `src/core/worker_registry.rs`: `test_health_checker_preserves_inflight_load` (regression test for #197; runs under paused Tokio time with a no-I/O health check and advances through 12 cycles, so it fails against the pre-fix 10-cycle reset) and `test_health_checker_preserves_load_across_recovery`.
- `src/routers/http/vllm_pd_router.rs`: `test_pd_request_cancellation_releases_prefill_load` and `test_pd_request_cancellation_releases_decode_load` — run the real two-stage flow against mock prefill/decode servers, abort the request while the upstream response is pending, and assert load returns to zero (verified to fail against the previous manual accounting).

## Test Result

All Rust unit/integration tests pass: `cargo test --lib --bins` (494 passed), `cargo test --test '*'` (all suites passed), `cargo fmt --check` and CI-grade clippy clean, all pre-commit hooks pass.

End-to-end verification with 3 mock workers (requests held in flight, 1s health-check interval) comparing router-reported load vs actual in-flight requests:

| Event | Before | After |
|---|---|---|
| 10 requests in flight, 10 health-check cycles elapsed | `Resetting worker loads (cycle 10)`; router view `max_load=0, min_load=0` | No reset lines; `max_load=4, min_load=3` (≈ actual in-flight) |
| Probes while 13-15 requests in flight | Router view `max_load=0..1`, `is_imbalanced=false` -> prefix-affinity routing continues | `max_load=4..5` tracking actual in-flight; balancing decisions see true load |

Mutation probes: restoring the old 10-cycle reset makes the regression test fail (`left: 0, right: 5`); restoring the manual P/D accounting makes both cancellation tests fail (`left: 1, right: 0`).

---

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
</details>
