### PR TITLE
[Feature]: cache-aware chat routing with session-id/full-history fallback

### DIFF
--- a/benches/request_processing.rs
+++ b/benches/request_processing.rs
@@ -4,7 +4,7 @@ use std::time::Instant;
 
 use vllm_router_rs::protocols::spec::{
     ChatCompletionRequest, ChatMessage, CompletionRequest, GenerateParameters, GenerateRequest,
-    PromptInput, SamplingParams, UserMessageContent,
+    PromptInput, SamplingParams, SystemMessageContent, UserMessageContent,
 };
 
 /// Create a default GenerateRequest for benchmarks with minimal fields set
@@ -151,7 +151,7 @@ fn create_sample_chat_completion_request() -> ChatCompletionRequest {
         messages: vec![
             ChatMessage::System {
                 role: "system".to_string(),
-                content: "You are a helpful assistant".to_string(),
+                content: SystemMessageContent::Text("You are a helpful assistant".to_string()),
                 name: None,
             },
             ChatMessage::User {
@@ -192,7 +192,9 @@ fn create_sample_completion_request() -> CompletionRequest {
 fn create_large_chat_completion_request() -> ChatCompletionRequest {
     let mut messages = vec![ChatMessage::System {
         role: "system".to_string(),
-        content: "You are a helpful assistant with extensive knowledge.".to_string(),
+        content: SystemMessageContent::Text(
+            "You are a helpful assistant with extensive knowledge.".to_string(),
+        ),
         name: None,
     }];
 

--- a/docs/load_balancing/README.md
+++ b/docs/load_balancing/README.md
@@ -201,21 +201,23 @@ The `cache_aware` policy optimizes for prefix caching by maintaining an approxim
 
 ```bash
 vllm-router --policy cache_aware \
-  --cache-threshold 0.5 \
-  --balance-abs-threshold 32 \
-  --balance-rel-threshold 1.1 \
-  --worker-urls http://worker1:8000,http://worker2:8000
+  --cache-threshold 0.3 \
+  --balance-abs-threshold 64 \
+  --balance-rel-threshold 1.5 \
+  --worker-urls http://worker1:8000 http://worker2:8000
 ```
+
+Chat routing key is always session id first, then full chat history fallback.
 
 ### Parameters
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
-| `cache_threshold` | 0.5 | Minimum prefix match ratio to use cache-based routing |
-| `balance_abs_threshold` | 32 | Absolute load difference threshold for load balancing |
-| `balance_rel_threshold` | 1.1 | Relative load ratio threshold for load balancing |
-| `eviction_interval_secs` | 30 | Interval for cache eviction |
-| `max_tree_size` | 10000 | Maximum nodes per radix tree |
+| `cache_threshold` | 0.3 | Minimum prefix match ratio to use cache-based routing |
+| `balance_abs_threshold` | 64 | Absolute load difference that allows breaking affinity |
+| `balance_rel_threshold` | 1.5 | Relative load ratio that allows breaking affinity |
+| `eviction_interval_secs` | 120 | Interval for cache eviction |
+| `max_tree_size` | 2^26 | Maximum nodes per radix tree |
 
 ### Behavior
 
@@ -231,6 +233,7 @@ vllm-router --policy cache_aware \
 ### Best For
 
 - Workloads with repeated prompt prefixes (system prompts, few-shot examples)
+- Multi-turn chat / agent sessions when prefix caching is enabled on workers
 - When prefix caching is enabled on vLLM workers
 - Multi-tenant deployments with distinct prompt patterns
 
@@ -260,8 +263,8 @@ vllm-router --policy cache_aware \
                  │                       │       │                       │
                  ▼                       ▼       ▼                       ▼
         ┌────────────────┐     ┌────────────────┐ ┌────────────────┐ ┌────────────────┐
-        │ consistent_hash│     │  cache_aware   │ │  power_of_two  │ │  round_robin   │
-        │                │     │                │ │                │ │  or random     │
+        │ cache_aware    │     │ consistent_hash│ │  power_of_two  │ │  round_robin   │
+        │ (chat default) │     │                │ │                │ │  or random     │
         └────────────────┘     └────────────────┘ └────────────────┘ └────────────────┘
 ```
 
@@ -269,7 +272,8 @@ vllm-router --policy cache_aware \
 
 | Scenario | Recommended Policy |
 |----------|-------------------|
-| Chat applications with conversation history | `consistent_hash` |
+| Chat / multi-turn agent with prefix caching | `cache_aware` (default chat key: session then full history) |
+| Session stickiness without prefix matching | `consistent_hash` |
 | Batch inference with no state | `round_robin` |
 | Variable request complexity | `power_of_two` |
 | Repeated system prompts / few-shot | `cache_aware` |

--- a/examples/simulate_consistent_hash.rs
+++ b/examples/simulate_consistent_hash.rs
@@ -309,7 +309,7 @@ fn analyze_ring_distribution(
     for url in worker_urls {
         vnodes_per_url.insert(url.clone(), 0);
     }
-    for (_, url) in ring.iter() {
+    for url in ring.values() {
         *vnodes_per_url.get_mut(url).unwrap() += 1;
     }
 

--- a/py_src/vllm_router/router.py
+++ b/py_src/vllm_router/router.py
@@ -37,11 +37,11 @@ class Router:
         worker_startup_check_interval: Interval in seconds between checks for worker initialization. Default: 10
         cache_threshold: Cache threshold (0.0-1.0) for cache-aware routing. Routes to cached worker
             if the match rate exceeds threshold, otherwise routes to the worker with the smallest
-            tree. Default: 0.5
+            tree. Default: 0.3
         balance_abs_threshold: Load balancing is triggered when (max_load - min_load) > abs_threshold
-            AND max_load > min_load * rel_threshold. Otherwise, use cache aware. Default: 32
+            AND max_load > min_load * rel_threshold. Otherwise, use cache aware. Default: 64
         balance_rel_threshold: Load balancing is triggered when (max_load - min_load) > abs_threshold
-            AND max_load > min_load * rel_threshold. Otherwise, use cache aware. Default: 1.0001
+            AND max_load > min_load * rel_threshold. Otherwise, use cache aware. Default: 1.5
         eviction_interval_secs: Interval in seconds between cache eviction operations in cache-aware
             routing. Default: 60
         max_payload_size: Maximum payload size in bytes. Default: 256MB

--- a/py_test/integration/load_balancing/test_cache_aware.py
+++ b/py_test/integration/load_balancing/test_cache_aware.py
@@ -34,6 +34,62 @@ def test_cache_aware_affinity(mock_workers, router_manager):
 
 
 @pytest.mark.integration
+def test_cache_aware_chat_affinity_uses_stable_agent_prefix(
+    mock_workers, router_manager
+):
+    # Same system/tools but changing user suffix should stick to one worker.
+    _, urls, ids = mock_workers(n=2)
+    rh = router_manager.start_router(worker_urls=urls, policy="cache_aware")
+
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "read_file",
+                "description": "Read a file",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"path": {"type": "string"}},
+                },
+            },
+        }
+    ]
+
+    counts = collections.Counter()
+    with requests.Session() as s:
+        for i in range(12):
+            r = s.post(
+                f"{rh.url}/v1/chat/completions",
+                json={
+                    "model": "test-model",
+                    "messages": [
+                        {
+                            "role": "system",
+                            "content": "You are a coding agent.",
+                        },
+                        {
+                            "role": "developer",
+                            "content": "Inspect before editing.",
+                        },
+                        {
+                            "role": "user",
+                            "content": f"Fix changing task suffix {i}",
+                        },
+                    ],
+                    "tools": tools,
+                    "max_tokens": 1,
+                    "stream": False,
+                },
+            )
+            assert r.status_code == 200
+            wid = r.headers.get("X-Worker-Id") or r.json().get("worker_id")
+            counts[wid] += 1
+
+    top = max(counts.values())
+    assert top >= 10, counts
+
+
+@pytest.mark.integration
 def test_cache_aware_diverse_prompts_balances(mock_workers, router_manager):
     # Add latency so concurrent requests overlap and influence load-based selection
     _, urls, ids = mock_workers(n=3, args=["--latency-ms", "30"])

--- a/py_test/unit/test_arg_parser.py
+++ b/py_test/unit/test_arg_parser.py
@@ -440,7 +440,7 @@ class TestParseRouterArgs:
         assert router_args.worker_urls == ["http://worker1:8000", "http://worker2:8000"]
         assert router_args.policy == "round_robin"
 
-    def test_parse_pd_args(self):
+    def test_parse_pd_disaggregation_args(self):
         """Test parsing PD disaggregated mode arguments."""
         args = [
             "--vllm-pd-disaggregation",

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -89,6 +89,10 @@ pub fn init_metrics() {
         "vllm_router_load_balancing_events_total",
         "Total load balancing trigger events"
     );
+    describe_counter!(
+        "vllm_router_cache_aware_decisions_total",
+        "Cache-aware routing decisions by decision path"
+    );
     describe_gauge!("vllm_router_max_load", "Maximum worker load");
     describe_gauge!("vllm_router_min_load", "Minimum worker load");
 
@@ -379,6 +383,10 @@ impl RouterMetrics {
 
     pub fn record_load_balancing_event() {
         counter!("vllm_router_load_balancing_events_total").increment(1);
+    }
+
+    pub fn record_cache_aware_decision(decision: &'static str) {
+        counter!("vllm_router_cache_aware_decisions_total", "decision" => decision).increment(1);
     }
 
     pub fn set_load_range(max_load: usize, min_load: usize) {

--- a/src/policies/cache_aware.rs
+++ b/src/policies/cache_aware.rs
@@ -59,7 +59,7 @@
     during the next eviction cycle.
 */
 
-use super::hash_key::extract_hash_key_from_headers;
+use super::hash_key::{extract_hash_key_from_body, extract_hash_key_from_headers};
 use super::{
     get_healthy_worker_indices, CacheAwareConfig, LoadBalancingPolicy, RequestHeaders,
     RoutingSelection,
@@ -359,21 +359,34 @@ impl CacheAwarePolicy {
             );
         }
 
-        // Use explicit routing text first; fall back to session headers for
-        // clients that carry affinity only in HTTP metadata.
+        // Session identity is derived the same way hash policies derive their
+        // key (extract_hash_key priority: HTTP headers, then body fields),
+        // with the explicit routing text winning when present: for chat
+        // requests the routing text already IS the session id extracted from
+        // session_params, and text-like prompts keep their prefix semantics.
         let header_key = headers.and_then(extract_hash_key_from_headers);
-        let primary_text = request_text
-            .filter(|text| !text.trim().is_empty())
+        let body_key = extract_hash_key_from_body(request_text);
+        let request_text_non_empty = request_text.filter(|text| !text.trim().is_empty());
+        let primary_text = request_text_non_empty
             .or(header_key.as_deref())
+            .or(body_key.as_deref())
             .unwrap_or("");
-        // A fallback key marks the chat path: the primary key is a session id
-        // matched by exact string equality against the session map (no prefix
-        // semantics, so session-1 can never collide with session-12). When
-        // there is no extractable history (e.g. an image-only chat), a session
-        // miss falls back to min-load instead of probing an empty history key.
+        // A fallback key marks the chat path. Session-derived keys (HTTP
+        // headers or body fields) use exact-match session semantics even
+        // without a fallback key, so a request carrying only an x-session-id
+        // header still gets sticky session affinity. Plain text keys keep
+        // prefix-tree semantics even when unrelated headers are present.
+        // Session keys are matched by exact string equality against the
+        // session map (no prefix semantics, so session-1 can never collide
+        // with session-12). When there is no extractable history (e.g. an
+        // image-only chat), a session miss falls back to min-load instead of
+        // probing an empty history key.
         let fallback_provided = fallback_text.is_some();
         let fallback_text = fallback_text.filter(|text| !text.trim().is_empty());
-        let session_keyed = fallback_provided && !primary_text.is_empty();
+        let session_keyed = !primary_text.is_empty()
+            && (fallback_provided
+                || (request_text_non_empty.is_none()
+                    && (header_key.is_some() || body_key.is_some())));
         let primary_text = if primary_text.is_empty() {
             fallback_text.unwrap_or("")
         } else {
@@ -807,6 +820,110 @@ mod tests {
             .select_worker_with_headers(&workers, None, Some(&headers))
             .unwrap();
 
+        assert_eq!(idx1, idx2);
+    }
+
+    #[test]
+    fn test_cache_aware_header_session_key_uses_exact_match_without_fallback() {
+        // A session-derived header key (x-session-id) on a request without a
+        // fallback key must use exact-match session semantics: repeated
+        // requests stick to one worker and prefix-related header values do
+        // not collide.
+        let config = CacheAwareConfig {
+            eviction_interval_secs: 0,
+            ..Default::default()
+        };
+        let policy = CacheAwarePolicy::with_config(config);
+        let workers: Vec<Arc<dyn Worker>> = vec![
+            Arc::new(BasicWorker::new(
+                "http://w1:8000".to_string(),
+                WorkerType::Regular,
+            )),
+            Arc::new(BasicWorker::new(
+                "http://w2:8000".to_string(),
+                WorkerType::Regular,
+            )),
+        ];
+        policy.init_workers(&workers);
+
+        let mut headers_a = RequestHeaders::new();
+        headers_a.insert("x-session-id".to_string(), "agent-session-1".to_string());
+
+        let idx1 = policy
+            .select_worker_with_headers(&workers, Some(""), Some(&headers_a))
+            .unwrap();
+
+        // Same header again: exact hit on the session map.
+        let sel2 = policy
+            .select_worker_with_fallback_headers_with_decision(
+                &workers,
+                Some(""),
+                None,
+                Some(&headers_a),
+            )
+            .unwrap();
+        assert_eq!(sel2.index, idx1);
+        assert_eq!(sel2.decision, Some("session_id_match"));
+
+        // A prefix-related header value is a different session under exact
+        // equality: it must not ride on agent-session-1's worker.
+        workers[idx1].increment_load();
+        let mut headers_b = RequestHeaders::new();
+        headers_b.insert("x-session-id".to_string(), "agent-session-12".to_string());
+        let sel3 = policy
+            .select_worker_with_fallback_headers_with_decision(
+                &workers,
+                Some(""),
+                None,
+                Some(&headers_b),
+            )
+            .unwrap();
+        assert_ne!(sel3.index, idx1);
+    }
+
+    #[test]
+    fn test_cache_aware_text_key_keeps_prefix_semantics_with_headers_present() {
+        // Non-chat text keys keep prefix-tree semantics even when a session
+        // header is present: the explicit routing text wins, so prompt
+        // prefix affinity is not replaced by exact matching.
+        let config = CacheAwareConfig {
+            cache_threshold: 0.3,
+            eviction_interval_secs: 0,
+            ..Default::default()
+        };
+        let policy = CacheAwarePolicy::with_config(config);
+        let workers: Vec<Arc<dyn Worker>> = vec![
+            Arc::new(BasicWorker::new(
+                "http://w1:8000".to_string(),
+                WorkerType::Regular,
+            )),
+            Arc::new(BasicWorker::new(
+                "http://w2:8000".to_string(),
+                WorkerType::Regular,
+            )),
+        ];
+        policy.init_workers(&workers);
+
+        let mut headers = RequestHeaders::new();
+        headers.insert("x-session-id".to_string(), "some-session".to_string());
+
+        let shared_prefix = "system:You are a coding agent\ntool:read_file";
+        let idx1 = policy
+            .select_worker_with_headers(&workers, Some(shared_prefix), Some(&headers))
+            .unwrap();
+
+        // Same prefix, different suffix, different header: prefix affinity
+        // still routes to the same worker (prefix-tree semantics, not exact
+        // matching on the full text).
+        let mut headers_b = RequestHeaders::new();
+        headers_b.insert("x-session-id".to_string(), "another-session".to_string());
+        let idx2 = policy
+            .select_worker_with_headers(
+                &workers,
+                Some(&format!("{shared_prefix}\nuser:different suffix")),
+                Some(&headers_b),
+            )
+            .unwrap();
         assert_eq!(idx1, idx2);
     }
 

--- a/src/policies/cache_aware.rs
+++ b/src/policies/cache_aware.rs
@@ -59,7 +59,11 @@
     during the next eviction cycle.
 */
 
-use super::{get_healthy_worker_indices, CacheAwareConfig, LoadBalancingPolicy, RequestHeaders};
+use super::hash_key::extract_hash_key_from_headers;
+use super::{
+    get_healthy_worker_indices, CacheAwareConfig, LoadBalancingPolicy, RequestHeaders,
+    RoutingSelection,
+};
 use crate::core::Worker;
 use crate::metrics::RouterMetrics;
 use crate::policies::normalize_model_key;
@@ -71,6 +75,8 @@ use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
 use tracing::{debug, info};
+
+const FALLBACK_SESSION_CACHE_THRESHOLD: f32 = 0.999;
 
 /// Cache-aware routing policy
 ///
@@ -171,15 +177,17 @@ impl CacheAwarePolicy {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn select_worker_min_load(
         &self,
         workers: &[Arc<dyn Worker>],
         request_text: Option<&str>,
+        fallback_text: Option<&str>,
         healthy_indices: &[usize],
         model_id: &str,
         max_load: usize,
         min_load: usize,
-    ) -> Option<usize> {
+    ) -> Option<RoutingSelection> {
         // Log load balancing trigger (only compute worker loads if debug enabled)
         if tracing::enabled!(tracing::Level::DEBUG) {
             let worker_loads: Vec<(&str, usize)> =
@@ -191,6 +199,7 @@ impl CacheAwarePolicy {
         }
 
         RouterMetrics::record_load_balancing_event();
+        RouterMetrics::record_cache_aware_decision("load_balance");
         RouterMetrics::set_load_range(max_load, min_load);
 
         // Use shortest queue when imbalanced
@@ -199,21 +208,24 @@ impl CacheAwarePolicy {
             .min_by_key(|&&idx| workers[idx].load())
             .copied()?;
 
-        // Even in imbalanced mode, update the tree to maintain cache state
-        if let Some(text) = request_text {
-            // Get the tree reference without locking the entire HashMap
-            // DashMap only locks the specific shard containing this key
-            let tree = self.trees.get(model_id).map(|entry| entry.value().clone());
+        // Even in imbalanced mode, update the tree to maintain cache state.
+        // Teach it the session key and the full chat history: the worker has
+        // just processed and cached the whole prompt, so a later balanced
+        // request sharing the same prefix must be able to discover it.
+        let tree = self.trees.get(model_id).map(|entry| entry.value().clone());
 
-            if let Some(tree) = tree {
-                let worker_url = workers[min_load_idx].url();
-                tree.insert(text, worker_url);
-            } else {
-                debug!(
-                    "Warning: No tree found for model '{}', skipping cache update",
-                    model_id
-                );
+        if let Some(tree) = tree {
+            let worker_url = workers[min_load_idx].url();
+            for text in [request_text, fallback_text].into_iter().flatten() {
+                if !text.is_empty() {
+                    tree.insert(text, worker_url);
+                }
             }
+        } else {
+            debug!(
+                "Warning: No tree found for model '{}', skipping cache update",
+                model_id
+            );
         }
 
         // Increment processed counter
@@ -221,17 +233,19 @@ impl CacheAwarePolicy {
         RouterMetrics::record_processed_request(workers[min_load_idx].url());
         RouterMetrics::record_policy_decision(self.name(), workers[min_load_idx].url());
 
-        Some(min_load_idx)
+        Some(RoutingSelection {
+            index: min_load_idx,
+            decision: Some("load_balance"),
+        })
     }
-}
 
-impl LoadBalancingPolicy for CacheAwarePolicy {
-    fn select_worker_with_headers(
+    fn select_worker_cache_aware_with_decision(
         &self,
         workers: &[Arc<dyn Worker>],
         request_text: Option<&str>,
-        _headers: Option<&RequestHeaders>,
-    ) -> Option<usize> {
+        fallback_text: Option<&str>,
+        headers: Option<&RequestHeaders>,
+    ) -> Option<RoutingSelection> {
         let healthy_indices = get_healthy_worker_indices(workers);
 
         if healthy_indices.is_empty() {
@@ -239,17 +253,17 @@ impl LoadBalancingPolicy for CacheAwarePolicy {
         }
 
         // Determine the model for this set of workers (router pre-filters by model)
-        // All workers should be from the same model
+        // All workers should be from the same model.
         let model_id = normalize_model_key(workers[healthy_indices[0]].model_id());
 
-        // Get current load statistics - compute min/max in single pass without allocation
+        // Get current load statistics - compute min/max in single pass without allocation.
         let (min_load, max_load) = workers.iter().fold((usize::MAX, 0usize), |(min, max), w| {
             let load = w.load();
             (min.min(load), max.max(load))
         });
         let min_load = if min_load == usize::MAX { 0 } else { min_load };
 
-        // Check if load is imbalanced
+        // Check if load is imbalanced.
         let is_imbalanced = max_load.saturating_sub(min_load) > self.config.balance_abs_threshold
             && (max_load as f32) > (min_load as f32 * self.config.balance_rel_threshold);
 
@@ -262,6 +276,7 @@ impl LoadBalancingPolicy for CacheAwarePolicy {
             return self.select_worker_min_load(
                 workers,
                 request_text,
+                fallback_text,
                 &healthy_indices,
                 model_id,
                 max_load,
@@ -269,23 +284,41 @@ impl LoadBalancingPolicy for CacheAwarePolicy {
             );
         }
 
-        // Use cache-aware routing when balanced
-        let text = request_text.unwrap_or("");
+        // Use explicit routing text first; fall back to session headers for
+        // clients that carry affinity only in HTTP metadata.
+        let header_key = headers.and_then(extract_hash_key_from_headers);
+        let primary_text = request_text
+            .filter(|text| !text.trim().is_empty())
+            .or(header_key.as_deref())
+            .unwrap_or("");
+        // A chat request may carry a session key with no extractable history
+        // (e.g. an image-only user message). Keep the two-stage session
+        // semantics in that case: probe the session key at the strict 0.999
+        // threshold and fall back to min-load instead of probing the empty
+        // history at cache_threshold, which would let prefix-related session
+        // ids (session-1\x1f vs session-12\x1f) pass as cache hits.
+        let fallback_provided = fallback_text.is_some();
+        let fallback_text = fallback_text.filter(|text| !text.trim().is_empty());
+        let use_fallback_probe = fallback_provided && !primary_text.is_empty();
+        let primary_text = if primary_text.is_empty() {
+            fallback_text.unwrap_or("")
+        } else {
+            primary_text
+        };
 
-        // Get the tree reference without locking the entire HashMap
-        // DashMap only locks the specific shard containing this key
+        // Get the tree reference without locking the entire HashMap.
+        // DashMap only locks the specific shard containing this key.
         let tree = self.trees.get(model_id).map(|entry| entry.value().clone());
 
         let keys: Vec<_> = self.trees.iter().map(|entry| entry.key().clone()).collect();
         debug!("Available tree keys: {:?}", keys);
 
         let Some(tree) = tree else {
-            // No tree for this model, log warning and use random selection
             debug!(
                 "Warning: No tree found for model '{}', using random worker selection",
                 model_id
             );
-            // Return a random healthy worker
+            RouterMetrics::record_cache_aware_decision("no_tree_random");
             let mut rng = rand::rng();
             let random_idx = rng.random_range(0..healthy_indices.len());
             let selected_idx = healthy_indices[random_idx];
@@ -294,67 +327,200 @@ impl LoadBalancingPolicy for CacheAwarePolicy {
             RouterMetrics::record_processed_request(workers[selected_idx].url());
             RouterMetrics::record_policy_decision(self.name(), workers[selected_idx].url());
 
-            return Some(selected_idx);
+            return Some(RoutingSelection {
+                index: selected_idx,
+                decision: Some("no_tree_random"),
+            });
         };
         debug!("Using cache-aware routing for model '{}'", model_id);
-        // Now we work with the tree without holding the HashMap lock
-        // Use prefix_match_with_counts to avoid redundant chars().count() calls
-        let result = tree.prefix_match_with_counts(text);
-        let match_rate = if result.input_char_count == 0 {
-            0.0
-        } else {
-            result.matched_char_count as f32 / result.input_char_count as f32
+
+        let probe = |text: &str, cache_threshold: f32| {
+            let result = tree.prefix_match_with_counts(text);
+            let match_rate = if result.input_char_count == 0 {
+                0.0
+            } else {
+                result.matched_char_count as f32 / result.input_char_count as f32
+            };
+            let selected_idx = if match_rate > cache_threshold {
+                let tenant_url: &str = &result.tenant;
+                workers
+                    .iter()
+                    .position(|w| w.url() == tenant_url)
+                    .filter(|&idx| workers[idx].is_healthy())
+            } else {
+                healthy_indices
+                    .iter()
+                    .min_by_key(|&&idx| workers[idx].load())
+                    .copied()
+            };
+
+            (selected_idx, match_rate, result.tenant.to_string())
         };
 
-        debug!(
-            "Cache match for model '{}': matched_chars={}, input_chars={}, match_rate={:.2}",
-            model_id, result.matched_char_count, result.input_char_count, match_rate
-        );
-        // Select worker without String allocation
-        let selected_idx = if match_rate > self.config.cache_threshold {
-            // Cache hit path: find worker by URL (compare &str directly, no allocation)
-            let tenant_url: &str = &result.tenant;
-            workers
-                .iter()
-                .position(|w| w.url() == tenant_url)
-                .filter(|&idx| workers[idx].is_healthy())
+        // Probe the full-history fallback at the configured threshold; when no
+        // usable history text exists, select min-load directly so the strict
+        // session semantics (0.999) still apply to the session key itself.
+        let probe_fallback_or_min_load =
+            |fallback_text: Option<&str>| -> (Option<usize>, &'static str, Option<String>, bool) {
+                match fallback_text {
+                    Some(fallback_text) => {
+                        let (fallback_idx, fallback_match_rate, fallback_tenant) =
+                            probe(fallback_text, self.config.cache_threshold);
+                        if fallback_match_rate > self.config.cache_threshold {
+                            if let Some(idx) = fallback_idx {
+                                (Some(idx), "full_history_match", None, true)
+                            } else {
+                                (
+                                    healthy_indices.first().copied(),
+                                    "stale_tenant_fallback",
+                                    Some(fallback_tenant),
+                                    true,
+                                )
+                            }
+                        } else {
+                            (fallback_idx, "full_history_low_match", None, true)
+                        }
+                    }
+                    None => {
+                        let min_load_idx = healthy_indices
+                            .iter()
+                            .min_by_key(|&&idx| workers[idx].load())
+                            .copied();
+                        (min_load_idx, "empty_history_min_load", None, false)
+                    }
+                }
+            };
+
+        let (selected_idx, decision, stale_tenant, used_fallback) = if use_fallback_probe {
+            let (primary_idx, primary_match_rate, primary_tenant) =
+                probe(primary_text, FALLBACK_SESSION_CACHE_THRESHOLD);
+
+            let session_hit = primary_match_rate > FALLBACK_SESSION_CACHE_THRESHOLD;
+            if session_hit {
+                if let Some(idx) = primary_idx {
+                    (Some(idx), "session_id_match", None, false)
+                } else {
+                    // Stale worker for the session key; drop it and probe
+                    // the history.
+                    tree.remove_tenant(&primary_tenant);
+                    debug!("Removed stale worker {} from cache tree", primary_tenant);
+                    RouterMetrics::record_cache_aware_decision("session_id_fallback");
+                    probe_fallback_or_min_load(fallback_text)
+                }
+            } else {
+                RouterMetrics::record_cache_aware_decision("session_id_fallback");
+                probe_fallback_or_min_load(fallback_text)
+            }
         } else {
-            // Low cache match: use worker with minimum load
-            healthy_indices
-                .iter()
-                .min_by_key(|&&idx| workers[idx].load())
-                .copied()
+            let (idx, match_rate, tenant) = probe(primary_text, self.config.cache_threshold);
+            let decision = if match_rate > self.config.cache_threshold {
+                "cache_affinity"
+            } else {
+                "low_match_min_load"
+            };
+            let stale_tenant = if idx.is_none() && match_rate > self.config.cache_threshold {
+                Some(tenant)
+            } else {
+                None
+            };
+
+            (idx, decision, stale_tenant, false)
         };
+
+        let selected_text = if used_fallback {
+            fallback_text.unwrap_or(primary_text)
+        } else {
+            primary_text
+        };
+
+        if let Some(tenant) = stale_tenant {
+            tree.remove_tenant(&tenant);
+            debug!("Removed stale worker {} from cache tree", tenant);
+        }
 
         if let Some(idx) = selected_idx {
-            // Update the tree with this request (use worker URL directly, no allocation)
-            tree.insert(text, workers[idx].url());
+            RouterMetrics::record_cache_aware_decision(decision);
 
-            // Increment processed counter
+            let worker_url = workers[idx].url();
+            tree.insert(selected_text, worker_url);
+
+            if used_fallback && !primary_text.is_empty() && primary_text != selected_text {
+                tree.insert(primary_text, worker_url);
+            }
+
             workers[idx].increment_processed();
             RouterMetrics::record_processed_request(workers[idx].url());
             RouterMetrics::record_policy_decision(self.name(), workers[idx].url());
 
-            return Some(idx);
+            return Some(RoutingSelection {
+                index: idx,
+                decision: Some(decision),
+            });
         }
 
-        // Selected worker no longer exists or unhealthy, remove stale tenant from tree
-        if match_rate > self.config.cache_threshold {
-            let tenant_url: &str = &result.tenant;
-            tree.remove_tenant(tenant_url);
-            debug!("Removed stale worker {} from cache tree", tenant_url);
+        if decision == "stale_tenant_fallback" {
+            RouterMetrics::record_cache_aware_decision("stale_tenant_fallback");
+        } else {
+            RouterMetrics::record_cache_aware_decision("first_healthy_fallback");
         }
-
-        // Fallback to first healthy worker
         if let Some(idx) = healthy_indices.first().copied() {
             workers[idx].increment_processed();
             RouterMetrics::record_processed_request(workers[idx].url());
             RouterMetrics::record_policy_decision(self.name(), workers[idx].url());
 
-            Some(idx)
+            Some(RoutingSelection {
+                index: idx,
+                decision: Some(if decision == "stale_tenant_fallback" {
+                    "stale_tenant_fallback"
+                } else {
+                    "first_healthy_fallback"
+                }),
+            })
         } else {
             None
         }
+    }
+
+    fn select_worker_cache_aware(
+        &self,
+        workers: &[Arc<dyn Worker>],
+        request_text: Option<&str>,
+        fallback_text: Option<&str>,
+        headers: Option<&RequestHeaders>,
+    ) -> Option<usize> {
+        self.select_worker_cache_aware_with_decision(workers, request_text, fallback_text, headers)
+            .map(|selection| selection.index)
+    }
+}
+
+impl LoadBalancingPolicy for CacheAwarePolicy {
+    fn select_worker_with_headers(
+        &self,
+        workers: &[Arc<dyn Worker>],
+        request_text: Option<&str>,
+        headers: Option<&RequestHeaders>,
+    ) -> Option<usize> {
+        self.select_worker_cache_aware(workers, request_text, None, headers)
+    }
+
+    fn select_worker_with_fallback_headers(
+        &self,
+        workers: &[Arc<dyn Worker>],
+        request_text: Option<&str>,
+        fallback_text: Option<&str>,
+        headers: Option<&RequestHeaders>,
+    ) -> Option<usize> {
+        self.select_worker_cache_aware(workers, request_text, fallback_text, headers)
+    }
+
+    fn select_worker_with_fallback_headers_with_decision(
+        &self,
+        workers: &[Arc<dyn Worker>],
+        request_text: Option<&str>,
+        fallback_text: Option<&str>,
+        headers: Option<&RequestHeaders>,
+    ) -> Option<RoutingSelection> {
+        self.select_worker_cache_aware_with_decision(workers, request_text, fallback_text, headers)
     }
 
     fn name(&self) -> &'static str {
@@ -511,6 +677,273 @@ mod tests {
         // Similar request should also go to same worker
         let idx3 = policy.select_worker(&workers, Some("hello")).unwrap();
         assert_eq!(idx1, idx3);
+    }
+
+    #[test]
+    fn test_cache_aware_falls_back_to_session_header_when_text_empty() {
+        let config = CacheAwareConfig {
+            eviction_interval_secs: 0,
+            ..Default::default()
+        };
+        let policy = CacheAwarePolicy::with_config(config);
+        let workers: Vec<Arc<dyn Worker>> = vec![
+            Arc::new(BasicWorker::new(
+                "http://w1:8000".to_string(),
+                WorkerType::Regular,
+            )),
+            Arc::new(BasicWorker::new(
+                "http://w2:8000".to_string(),
+                WorkerType::Regular,
+            )),
+        ];
+        policy.init_workers(&workers);
+
+        let mut headers = RequestHeaders::new();
+        headers.insert("x-session-id".to_string(), "agent-session-1".to_string());
+
+        let idx1 = policy
+            .select_worker_with_headers(&workers, Some(""), Some(&headers))
+            .unwrap();
+        let idx2 = policy
+            .select_worker_with_headers(&workers, None, Some(&headers))
+            .unwrap();
+
+        assert_eq!(idx1, idx2);
+    }
+
+    #[test]
+    fn test_cache_aware_stable_text_precedes_session_header() {
+        let config = CacheAwareConfig {
+            eviction_interval_secs: 0,
+            ..Default::default()
+        };
+        let policy = CacheAwarePolicy::with_config(config);
+        let workers: Vec<Arc<dyn Worker>> = vec![
+            Arc::new(BasicWorker::new(
+                "http://w1:8000".to_string(),
+                WorkerType::Regular,
+            )),
+            Arc::new(BasicWorker::new(
+                "http://w2:8000".to_string(),
+                WorkerType::Regular,
+            )),
+        ];
+        policy.init_workers(&workers);
+
+        let mut headers_a = RequestHeaders::new();
+        headers_a.insert("x-session-id".to_string(), "session-a".to_string());
+        let mut headers_b = RequestHeaders::new();
+        headers_b.insert("x-session-id".to_string(), "session-b".to_string());
+
+        let stable_agent_prefix = "system:You are a coding agent\ntool:read_file";
+        let idx1 = policy
+            .select_worker_with_headers(&workers, Some(stable_agent_prefix), Some(&headers_a))
+            .unwrap();
+        let idx2 = policy
+            .select_worker_with_headers(&workers, Some(stable_agent_prefix), Some(&headers_b))
+            .unwrap();
+
+        assert_eq!(idx1, idx2);
+    }
+
+    #[test]
+    fn test_cache_aware_session_id_falls_back_to_full_history() {
+        let config = CacheAwareConfig {
+            cache_threshold: 0.3,
+            eviction_interval_secs: 0,
+            ..Default::default()
+        };
+        let policy = CacheAwarePolicy::with_config(config);
+        let workers: Vec<Arc<dyn Worker>> = vec![
+            Arc::new(BasicWorker::new(
+                "http://w1:8000".to_string(),
+                WorkerType::Regular,
+            )),
+            Arc::new(BasicWorker::new(
+                "http://w2:8000".to_string(),
+                WorkerType::Regular,
+            )),
+        ];
+        policy.init_workers(&workers);
+
+        let shared_history = "system:bench\nuser:shared long prefix";
+        let idx1 = policy
+            .select_worker_with_fallback_headers(
+                &workers,
+                Some("session-a"),
+                Some(shared_history),
+                None,
+            )
+            .unwrap();
+
+        let idx2 = policy
+            .select_worker_with_fallback_headers(
+                &workers,
+                Some("session-b"),
+                Some(shared_history),
+                None,
+            )
+            .unwrap();
+        assert_eq!(idx1, idx2);
+
+        let idx3 = policy
+            .select_worker_with_fallback_headers(
+                &workers,
+                Some("session-a"),
+                Some("system:bench\nuser:different prefix"),
+                None,
+            )
+            .unwrap();
+        assert_eq!(idx1, idx3);
+    }
+
+    #[test]
+    fn test_cache_aware_fallback_uses_strict_session_threshold() {
+        let config = CacheAwareConfig {
+            cache_threshold: 0.3,
+            eviction_interval_secs: 0,
+            ..Default::default()
+        };
+        let policy = CacheAwarePolicy::with_config(config);
+        let workers: Vec<Arc<dyn Worker>> = vec![
+            Arc::new(BasicWorker::new(
+                "http://w1:8000".to_string(),
+                WorkerType::Regular,
+            )),
+            Arc::new(BasicWorker::new(
+                "http://w2:8000".to_string(),
+                WorkerType::Regular,
+            )),
+        ];
+        policy.init_workers(&workers);
+
+        let idx1 = policy
+            .select_worker_with_fallback_headers(
+                &workers,
+                Some("session-1\x1f"),
+                Some("system:first unrelated prefix"),
+                None,
+            )
+            .unwrap();
+        assert_eq!(idx1, 0);
+
+        workers[0].increment_load();
+
+        let idx2 = policy
+            .select_worker_with_fallback_headers(
+                &workers,
+                Some("session-12\x1f"),
+                Some("system:second unrelated prefix"),
+                None,
+            )
+            .unwrap();
+
+        assert_eq!(idx2, 1);
+    }
+
+    #[test]
+    fn test_cache_aware_empty_history_keeps_strict_session_threshold() {
+        // A session key with no extractable history (e.g. image-only chat)
+        // must still be probed at the strict 0.999 threshold. session-1\x1f
+        // and session-12\x1f share 80% of their chars, which would pass the
+        // configured 0.3 threshold and falsely count as a session hit.
+        let config = CacheAwareConfig {
+            cache_threshold: 0.3,
+            eviction_interval_secs: 0,
+            ..Default::default()
+        };
+        let policy = CacheAwarePolicy::with_config(config);
+        let workers: Vec<Arc<dyn Worker>> = vec![
+            Arc::new(BasicWorker::new(
+                "http://w1:8000".to_string(),
+                WorkerType::Regular,
+            )),
+            Arc::new(BasicWorker::new(
+                "http://w2:8000".to_string(),
+                WorkerType::Regular,
+            )),
+        ];
+        policy.init_workers(&workers);
+
+        let sel1 = policy
+            .select_worker_with_fallback_headers_with_decision(
+                &workers,
+                Some("session-1\x1f"),
+                Some(""),
+                None,
+            )
+            .unwrap();
+        assert_eq!(sel1.index, 0);
+        assert_eq!(sel1.decision, Some("empty_history_min_load"));
+
+        workers[0].increment_load();
+
+        let sel2 = policy
+            .select_worker_with_fallback_headers_with_decision(
+                &workers,
+                Some("session-12\x1f"),
+                Some(""),
+                None,
+            )
+            .unwrap();
+        // Not a session hit (0.8 < 0.999): must fall back to min-load
+        // instead of following the session-1 affinity.
+        assert_eq!(sel2.index, 1);
+        assert_eq!(sel2.decision, Some("empty_history_min_load"));
+    }
+
+    #[test]
+    fn test_cache_aware_imbalanced_path_teaches_full_history() {
+        let config = CacheAwareConfig {
+            cache_threshold: 0.3,
+            balance_abs_threshold: 1,
+            balance_rel_threshold: 1.1,
+            eviction_interval_secs: 0,
+            ..Default::default()
+        };
+        let policy = CacheAwarePolicy::with_config(config);
+        let workers: Vec<Arc<dyn Worker>> = vec![
+            Arc::new(BasicWorker::new(
+                "http://w1:8000".to_string(),
+                WorkerType::Regular,
+            )),
+            Arc::new(BasicWorker::new(
+                "http://w2:8000".to_string(),
+                WorkerType::Regular,
+            )),
+        ];
+        policy.init_workers(&workers);
+
+        // Force an imbalance so the selection takes the min-load path.
+        workers[0].increment_load();
+        workers[0].increment_load();
+
+        let shared_history = "system:bench\nuser:shared long prefix";
+        let idx1 = policy
+            .select_worker_with_fallback_headers(
+                &workers,
+                Some("session-a\x1f"),
+                Some(shared_history),
+                None,
+            )
+            .unwrap();
+        assert_eq!(idx1, 1, "imbalanced selection must pick min-load worker");
+
+        // Rebalance. The full history must have been learned during the
+        // imbalanced request, so a new session with the same prefix is
+        // attracted to the same worker.
+        workers[0].decrement_load();
+        workers[0].decrement_load();
+
+        let idx2 = policy
+            .select_worker_with_fallback_headers(
+                &workers,
+                Some("session-b\x1f"),
+                Some(shared_history),
+                None,
+            )
+            .unwrap();
+        assert_eq!(idx2, idx1, "learned history must attract the new session");
     }
 
     #[test]

--- a/src/policies/cache_aware.rs
+++ b/src/policies/cache_aware.rs
@@ -73,21 +73,58 @@ use rand::Rng;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tracing::{debug, info};
 
-const FALLBACK_SESSION_CACHE_THRESHOLD: f32 = 0.999;
+/// How long an untouched session entry survives before eviction.
+const SESSION_ENTRY_TTL_SECS: u64 = 3600;
+
+/// Value of a session entry: the worker URL and the last-access timestamp.
+pub type SessionEntry = (String, u64);
+/// Per-model session map: session_id -> SessionEntry.
+pub type SessionMap = DashMap<String, SessionEntry>;
 
 /// Cache-aware routing policy
 ///
 /// Routes requests based on cache affinity when load is balanced,
 /// switches to shortest-queue routing when load is imbalanced.
 /// Maintains separate trees per model for multi-model support.
+///
+/// Session keys are matched by exact string equality in a dedicated
+/// per-model map; the prefix tree only holds text-like keys (full chat
+/// history for chat requests, plain prompts otherwise).
 #[derive(Debug)]
 pub struct CacheAwarePolicy {
     config: CacheAwareConfig,
     trees: Arc<DashMap<String, Arc<Tree>>>, // model_id -> Arc<Tree>
+    // model_id -> session_id -> SessionEntry
+    session_keys: Arc<DashMap<String, Arc<SessionMap>>>,
     eviction_handle: Option<thread::JoinHandle<()>>,
+}
+
+/// Current unix time in milliseconds, for session-entry aging.
+fn session_now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// Drop session entries that were not touched for the TTL, then enforce the
+/// per-model capacity by evicting the least recently accessed entries.
+fn evict_session_entries(map: &SessionMap, max_entries: usize) {
+    let cutoff = session_now_ms().saturating_sub(SESSION_ENTRY_TTL_SECS * 1000);
+    map.retain(|_, (_, last_access_ms)| *last_access_ms >= cutoff);
+
+    if map.len() > max_entries {
+        let mut entries: Vec<(String, u64)> =
+            map.iter().map(|e| (e.key().clone(), e.value().1)).collect();
+        entries.sort_by_key(|(_, last_access_ms)| *last_access_ms);
+        let to_remove = entries.len() - max_entries;
+        for (key, _) in entries.into_iter().take(to_remove) {
+            map.remove(&key);
+        }
+    }
 }
 
 impl CacheAwarePolicy {
@@ -97,10 +134,12 @@ impl CacheAwarePolicy {
 
     pub fn with_config(config: CacheAwareConfig) -> Self {
         let trees = Arc::new(DashMap::<String, Arc<Tree>>::new());
+        let session_keys = Arc::new(DashMap::<String, Arc<SessionMap>>::new());
 
         // Start background eviction thread if configured
         let eviction_handle = if config.eviction_interval_secs > 0 {
             let trees_clone = Arc::clone(&trees);
+            let session_keys_clone = Arc::clone(&session_keys);
             let max_tree_size = config.max_tree_size;
             let interval = config.eviction_interval_secs;
 
@@ -117,6 +156,14 @@ impl CacheAwarePolicy {
                         model_id, max_tree_size
                     );
                 }
+
+                // Sweep stale/overflowing session entries
+                for entry in session_keys_clone.iter() {
+                    let model_id = entry.key().clone();
+                    let map = entry.value();
+                    evict_session_entries(map, max_tree_size);
+                    debug!("Session key eviction completed for model {}", model_id);
+                }
             }))
         } else {
             None
@@ -125,6 +172,7 @@ impl CacheAwarePolicy {
         Self {
             config,
             trees,
+            session_keys,
             eviction_handle,
         }
     }
@@ -137,6 +185,9 @@ impl CacheAwarePolicy {
             .entry(tree_key.to_string())
             .or_insert_with(|| Arc::new(Tree::new()));
         tree.insert("", worker.url());
+        self.session_keys
+            .entry(tree_key.to_string())
+            .or_insert_with(|| Arc::new(DashMap::new()));
     }
 
     /// Add a worker by URL and model (for backward compatibility)
@@ -146,6 +197,9 @@ impl CacheAwarePolicy {
             .entry(model_id.to_string())
             .or_insert_with(|| Arc::new(Tree::new()));
         tree.insert("", url);
+        self.session_keys
+            .entry(model_id.to_string())
+            .or_insert_with(|| Arc::new(DashMap::new()));
     }
 
     /// Remove a worker from the tree
@@ -154,6 +208,9 @@ impl CacheAwarePolicy {
         if let Some(tree) = self.trees.get(tree_key) {
             tree.remove_tenant(worker.url());
         }
+        if let Some(map) = self.session_keys.get(tree_key) {
+            map.retain(|_, (url, _)| url != worker.url());
+        }
     }
 
     /// Remove a worker by URL (removes from all model trees for backward compatibility)
@@ -161,6 +218,9 @@ impl CacheAwarePolicy {
         // Remove from all trees since we don't know which model it belongs to
         for tree_ref in self.trees.iter() {
             tree_ref.value().remove_tenant(url);
+        }
+        for map_ref in self.session_keys.iter() {
+            map_ref.value().retain(|_, (entry_url, _)| entry_url != url);
         }
     }
 
@@ -174,6 +234,9 @@ impl CacheAwarePolicy {
                 "Cache eviction for model {}, max_size: {}",
                 model_id, max_size
             );
+        }
+        for map_ref in self.session_keys.iter() {
+            evict_session_entries(map_ref.value(), max_size);
         }
     }
 
@@ -208,24 +271,36 @@ impl CacheAwarePolicy {
             .min_by_key(|&&idx| workers[idx].load())
             .copied()?;
 
-        // Even in imbalanced mode, update the tree to maintain cache state.
-        // Teach it the session key and the full chat history: the worker has
-        // just processed and cached the whole prompt, so a later balanced
-        // request sharing the same prefix must be able to discover it.
-        let tree = self.trees.get(model_id).map(|entry| entry.value().clone());
-
-        if let Some(tree) = tree {
-            let worker_url = workers[min_load_idx].url();
-            for text in [request_text, fallback_text].into_iter().flatten() {
+        // Even in imbalanced mode, maintain cache state: the session map
+        // learns the session key (exact match) and the tree learns the full
+        // chat history, so a later balanced request sharing the same prefix
+        // can discover the worker that already cached it.
+        let worker_url = workers[min_load_idx].url();
+        if fallback_text.is_some() {
+            if let Some(request_text) = request_text {
+                if !request_text.trim().is_empty() {
+                    self.session_keys
+                        .entry(model_id.to_string())
+                        .or_insert_with(|| Arc::new(DashMap::new()))
+                        .insert(
+                            request_text.to_string(),
+                            (worker_url.to_string(), session_now_ms()),
+                        );
+                }
+            }
+            if let Some(tree) = self.trees.get(model_id).map(|entry| entry.value().clone()) {
+                if let Some(text) = fallback_text {
+                    if !text.is_empty() {
+                        tree.insert(text, worker_url);
+                    }
+                }
+            }
+        } else if let Some(tree) = self.trees.get(model_id).map(|entry| entry.value().clone()) {
+            if let Some(text) = request_text {
                 if !text.is_empty() {
                     tree.insert(text, worker_url);
                 }
             }
-        } else {
-            debug!(
-                "Warning: No tree found for model '{}', skipping cache update",
-                model_id
-            );
         }
 
         // Increment processed counter
@@ -291,19 +366,29 @@ impl CacheAwarePolicy {
             .filter(|text| !text.trim().is_empty())
             .or(header_key.as_deref())
             .unwrap_or("");
-        // A chat request may carry a session key with no extractable history
-        // (e.g. an image-only user message). Keep the two-stage session
-        // semantics in that case: probe the session key at the strict 0.999
-        // threshold and fall back to min-load instead of probing the empty
-        // history at cache_threshold, which would let prefix-related session
-        // ids (session-1\x1f vs session-12\x1f) pass as cache hits.
+        // A fallback key marks the chat path: the primary key is a session id
+        // matched by exact string equality against the session map (no prefix
+        // semantics, so session-1 can never collide with session-12). When
+        // there is no extractable history (e.g. an image-only chat), a session
+        // miss falls back to min-load instead of probing an empty history key.
         let fallback_provided = fallback_text.is_some();
         let fallback_text = fallback_text.filter(|text| !text.trim().is_empty());
-        let use_fallback_probe = fallback_provided && !primary_text.is_empty();
+        let session_keyed = fallback_provided && !primary_text.is_empty();
         let primary_text = if primary_text.is_empty() {
             fallback_text.unwrap_or("")
         } else {
             primary_text
+        };
+
+        let session_map = if session_keyed {
+            Some(
+                self.session_keys
+                    .entry(model_id.to_string())
+                    .or_insert_with(|| Arc::new(DashMap::new()))
+                    .clone(),
+            )
+        } else {
+            None
         };
 
         // Get the tree reference without locking the entire HashMap.
@@ -358,27 +443,26 @@ impl CacheAwarePolicy {
         };
 
         // Probe the full-history fallback at the configured threshold; when no
-        // usable history text exists, select min-load directly so the strict
-        // session semantics (0.999) still apply to the session key itself.
+        // usable history text exists, select min-load directly so the session
+        // key still gets exact-match semantics instead of a text probe.
         let probe_fallback_or_min_load =
-            |fallback_text: Option<&str>| -> (Option<usize>, &'static str, Option<String>, bool) {
+            |fallback_text: Option<&str>| -> (Option<usize>, &'static str, Option<String>) {
                 match fallback_text {
                     Some(fallback_text) => {
                         let (fallback_idx, fallback_match_rate, fallback_tenant) =
                             probe(fallback_text, self.config.cache_threshold);
                         if fallback_match_rate > self.config.cache_threshold {
                             if let Some(idx) = fallback_idx {
-                                (Some(idx), "full_history_match", None, true)
+                                (Some(idx), "full_history_match", None)
                             } else {
                                 (
                                     healthy_indices.first().copied(),
                                     "stale_tenant_fallback",
                                     Some(fallback_tenant),
-                                    true,
                                 )
                             }
                         } else {
-                            (fallback_idx, "full_history_low_match", None, true)
+                            (fallback_idx, "full_history_low_match", None)
                         }
                     }
                     None => {
@@ -386,28 +470,38 @@ impl CacheAwarePolicy {
                             .iter()
                             .min_by_key(|&&idx| workers[idx].load())
                             .copied();
-                        (min_load_idx, "empty_history_min_load", None, false)
+                        (min_load_idx, "empty_history_min_load", None)
                     }
                 }
             };
 
-        let (selected_idx, decision, stale_tenant, used_fallback) = if use_fallback_probe {
-            let (primary_idx, primary_match_rate, primary_tenant) =
-                probe(primary_text, FALLBACK_SESSION_CACHE_THRESHOLD);
-
-            let session_hit = primary_match_rate > FALLBACK_SESSION_CACHE_THRESHOLD;
-            if session_hit {
-                if let Some(idx) = primary_idx {
-                    (Some(idx), "session_id_match", None, false)
-                } else {
-                    // Stale worker for the session key; drop it and probe
-                    // the history.
-                    tree.remove_tenant(&primary_tenant);
-                    debug!("Removed stale worker {} from cache tree", primary_tenant);
-                    probe_fallback_or_min_load(fallback_text)
+        let (selected_idx, decision, stale_tenant) = if session_keyed {
+            // Exact-match session lookup: the session key never enters the
+            // prefix tree, so session ids cannot prefix-collide.
+            let session_map = session_map
+                .as_ref()
+                .expect("session map must exist when session_keyed");
+            let cached = session_map
+                .get(primary_text)
+                .map(|entry| entry.value().clone());
+            match cached {
+                Some((worker_url, _last_access)) => {
+                    match workers
+                        .iter()
+                        .position(|w| w.url() == worker_url)
+                        .filter(|&idx| workers[idx].is_healthy())
+                    {
+                        Some(idx) => (Some(idx), "session_id_match", None),
+                        None => {
+                            // Stale worker for this session: drop the entry and
+                            // fall back to the history probe.
+                            session_map.remove(primary_text);
+                            debug!("Removed stale session entry for worker {}", worker_url);
+                            probe_fallback_or_min_load(fallback_text)
+                        }
+                    }
                 }
-            } else {
-                probe_fallback_or_min_load(fallback_text)
+                None => probe_fallback_or_min_load(fallback_text),
             }
         } else {
             let (idx, match_rate, tenant) = probe(primary_text, self.config.cache_threshold);
@@ -422,13 +516,7 @@ impl CacheAwarePolicy {
                 None
             };
 
-            (idx, decision, stale_tenant, false)
-        };
-
-        let selected_text = if used_fallback {
-            fallback_text.unwrap_or(primary_text)
-        } else {
-            primary_text
+            (idx, decision, stale_tenant)
         };
 
         if let Some(tenant) = stale_tenant {
@@ -440,22 +528,22 @@ impl CacheAwarePolicy {
             RouterMetrics::record_cache_aware_decision(decision);
 
             let worker_url = workers[idx].url();
-            tree.insert(selected_text, worker_url);
-
-            // Teach the tree the full history even on a session hit: the
-            // client may later drop or change the session id, and the
-            // history key must reflect the most recent prefix the worker
-            // cached, not the shorter one from an earlier turn.
-            if let Some(history_text) = fallback_text {
-                if history_text != selected_text {
+            if session_keyed {
+                // The session map is authoritative for the session key; the
+                // prefix tree only learns text-like history keys. Teaching the
+                // history on a session hit keeps the grown conversation prefix
+                // available for clients that later drop the session id.
+                session_map
+                    .as_ref()
+                    .expect("session map must exist when session_keyed")
+                    .insert(
+                        primary_text.to_string(),
+                        (worker_url.to_string(), session_now_ms()),
+                    );
+                if let Some(history_text) = fallback_text {
                     tree.insert(history_text, worker_url);
                 }
-            }
-            if used_fallback
-                && !primary_text.is_empty()
-                && primary_text != selected_text
-                && Some(primary_text) != fallback_text
-            {
+            } else {
                 tree.insert(primary_text, worker_url);
             }
 
@@ -809,7 +897,7 @@ mod tests {
     }
 
     #[test]
-    fn test_cache_aware_fallback_uses_strict_session_threshold() {
+    fn test_cache_aware_fallback_uses_exact_session_match() {
         let config = CacheAwareConfig {
             cache_threshold: 0.3,
             eviction_interval_secs: 0,
@@ -831,7 +919,7 @@ mod tests {
         let idx1 = policy
             .select_worker_with_fallback_headers(
                 &workers,
-                Some("session-1\x1f"),
+                Some("session-1"),
                 Some("system:first unrelated prefix"),
                 None,
             )
@@ -840,10 +928,12 @@ mod tests {
 
         workers[0].increment_load();
 
+        // session-12 is a different key under exact equality even though it
+        // shares a long string prefix with session-1.
         let idx2 = policy
             .select_worker_with_fallback_headers(
                 &workers,
-                Some("session-12\x1f"),
+                Some("session-12"),
                 Some("system:second unrelated prefix"),
                 None,
             )
@@ -887,7 +977,7 @@ mod tests {
         let idx1 = policy
             .select_worker_with_fallback_headers(
                 &workers,
-                Some("session-a\x1f"),
+                Some("session-a"),
                 Some(short_history),
                 None,
             )
@@ -897,7 +987,7 @@ mod tests {
         let idx2 = policy
             .select_worker_with_fallback_headers(
                 &workers,
-                Some("session-a\x1f"),
+                Some("session-a"),
                 Some(&long_history),
                 None,
             )
@@ -915,11 +1005,11 @@ mod tests {
     }
 
     #[test]
-    fn test_cache_aware_empty_history_keeps_strict_session_threshold() {
+    fn test_cache_aware_empty_history_uses_exact_session_match() {
         // A session key with no extractable history (e.g. image-only chat)
-        // must still be probed at the strict 0.999 threshold. session-1\x1f
-        // and session-12\x1f share 80% of their chars, which would pass the
-        // configured 0.3 threshold and falsely count as a session hit.
+        // is matched by exact equality against the session map: session-12
+        // never collides with session-1 no matter how long their shared
+        // string prefix is.
         let config = CacheAwareConfig {
             cache_threshold: 0.3,
             eviction_interval_secs: 0,
@@ -941,7 +1031,7 @@ mod tests {
         let sel1 = policy
             .select_worker_with_fallback_headers_with_decision(
                 &workers,
-                Some("session-1\x1f"),
+                Some("session-1"),
                 Some(""),
                 None,
             )
@@ -954,15 +1044,122 @@ mod tests {
         let sel2 = policy
             .select_worker_with_fallback_headers_with_decision(
                 &workers,
-                Some("session-12\x1f"),
+                Some("session-12"),
                 Some(""),
                 None,
             )
             .unwrap();
-        // Not a session hit (0.8 < 0.999): must fall back to min-load
-        // instead of following the session-1 affinity.
+        // Not the session-1 affinity: exact equality says this is a
+        // different session, so fall back to min-load.
         assert_eq!(sel2.index, 1);
         assert_eq!(sel2.decision, Some("empty_history_min_load"));
+    }
+
+    #[test]
+    fn test_cache_aware_session_id_match_is_exact() {
+        let config = CacheAwareConfig {
+            cache_threshold: 0.3,
+            eviction_interval_secs: 0,
+            ..Default::default()
+        };
+        let policy = CacheAwarePolicy::with_config(config);
+        let workers: Vec<Arc<dyn Worker>> = vec![
+            Arc::new(BasicWorker::new(
+                "http://w1:8000".to_string(),
+                WorkerType::Regular,
+            )),
+            Arc::new(BasicWorker::new(
+                "http://w2:8000".to_string(),
+                WorkerType::Regular,
+            )),
+        ];
+        policy.init_workers(&workers);
+
+        let sel1 = policy
+            .select_worker_with_fallback_headers_with_decision(
+                &workers,
+                Some("session-1"),
+                Some("system:first prefix"),
+                None,
+            )
+            .unwrap();
+        workers[0].increment_load();
+
+        // Exact key: session affinity wins over the min-load worker even
+        // though worker 0 is busier (loads are still balanced).
+        let sel2 = policy
+            .select_worker_with_fallback_headers_with_decision(
+                &workers,
+                Some("session-1"),
+                Some("system:first prefix with more text"),
+                None,
+            )
+            .unwrap();
+        assert_eq!(sel2.index, sel1.index);
+        assert_eq!(sel2.decision, Some("session_id_match"));
+    }
+
+    #[test]
+    fn test_cache_aware_removed_worker_clears_session_entries() {
+        // remove_worker must drop the worker's session entries eagerly so a
+        // session can never exact-hit a worker that was removed from the
+        // policy.
+        let config = CacheAwareConfig {
+            cache_threshold: 0.5,
+            eviction_interval_secs: 0,
+            ..Default::default()
+        };
+        let policy = CacheAwarePolicy::with_config(config);
+        let workers: Vec<Arc<dyn Worker>> = vec![
+            Arc::new(BasicWorker::new(
+                "http://w1:8000".to_string(),
+                WorkerType::Regular,
+            )),
+            Arc::new(BasicWorker::new(
+                "http://w2:8000".to_string(),
+                WorkerType::Regular,
+            )),
+        ];
+        policy.init_workers(&workers);
+
+        let history = "system:bench\nuser:hello";
+        let idx1 = policy
+            .select_worker_with_fallback_headers(&workers, Some("session-a"), Some(history), None)
+            .unwrap();
+        assert_eq!(idx1, 0);
+
+        policy.remove_worker(workers[idx1].as_ref());
+        workers[0].increment_load();
+
+        // The session entry for the removed worker must be gone, so
+        // session-a cannot exact-hit it; with the history tenant also
+        // removed, the request lands on min-load (worker 2).
+        let idx2 = policy
+            .select_worker_with_fallback_headers(&workers, Some("session-a"), Some(history), None)
+            .unwrap();
+        assert_ne!(idx2, idx1);
+    }
+
+    #[test]
+    fn test_evict_session_entries_ttl_and_capacity() {
+        let map: SessionMap = DashMap::new();
+        let now = session_now_ms();
+        map.insert("fresh".to_string(), ("w1".to_string(), now));
+        map.insert(
+            "stale".to_string(),
+            ("w1".to_string(), now - (SESSION_ENTRY_TTL_SECS * 1000) - 1),
+        );
+        map.insert("oldest-fresh".to_string(), ("w1".to_string(), now - 1000));
+        map.insert("newest".to_string(), ("w2".to_string(), now));
+
+        evict_session_entries(&map, 2);
+
+        // TTL removes the stale entry; capacity then keeps the two most
+        // recently accessed entries.
+        assert!(map.contains_key("fresh"));
+        assert!(map.contains_key("newest"));
+        assert!(!map.contains_key("stale"));
+        assert!(!map.contains_key("oldest-fresh"));
     }
 
     #[test]
@@ -995,7 +1192,7 @@ mod tests {
         let idx1 = policy
             .select_worker_with_fallback_headers(
                 &workers,
-                Some("session-a\x1f"),
+                Some("session-a"),
                 Some(shared_history),
                 None,
             )
@@ -1011,7 +1208,7 @@ mod tests {
         let idx2 = policy
             .select_worker_with_fallback_headers(
                 &workers,
-                Some("session-b\x1f"),
+                Some("session-b"),
                 Some(shared_history),
                 None,
             )

--- a/src/policies/cache_aware.rs
+++ b/src/policies/cache_aware.rs
@@ -404,11 +404,9 @@ impl CacheAwarePolicy {
                     // the history.
                     tree.remove_tenant(&primary_tenant);
                     debug!("Removed stale worker {} from cache tree", primary_tenant);
-                    RouterMetrics::record_cache_aware_decision("session_id_fallback");
                     probe_fallback_or_min_load(fallback_text)
                 }
             } else {
-                RouterMetrics::record_cache_aware_decision("session_id_fallback");
                 probe_fallback_or_min_load(fallback_text)
             }
         } else {
@@ -444,7 +442,20 @@ impl CacheAwarePolicy {
             let worker_url = workers[idx].url();
             tree.insert(selected_text, worker_url);
 
-            if used_fallback && !primary_text.is_empty() && primary_text != selected_text {
+            // Teach the tree the full history even on a session hit: the
+            // client may later drop or change the session id, and the
+            // history key must reflect the most recent prefix the worker
+            // cached, not the shorter one from an earlier turn.
+            if let Some(history_text) = fallback_text {
+                if history_text != selected_text {
+                    tree.insert(history_text, worker_url);
+                }
+            }
+            if used_fallback
+                && !primary_text.is_empty()
+                && primary_text != selected_text
+                && Some(primary_text) != fallback_text
+            {
                 tree.insert(primary_text, worker_url);
             }
 
@@ -839,6 +850,68 @@ mod tests {
             .unwrap();
 
         assert_eq!(idx2, 1);
+    }
+
+    #[test]
+    fn test_cache_aware_session_hit_records_full_history() {
+        // On a session hit the tree must also learn the current full
+        // history: the client may later drop the session id, and the tree
+        // must know the grown conversation prefix the worker cached, not
+        // the shorter one from an earlier turn.
+        let config = CacheAwareConfig {
+            cache_threshold: 0.5,
+            eviction_interval_secs: 0,
+            ..Default::default()
+        };
+        let policy = CacheAwarePolicy::with_config(config);
+        let workers: Vec<Arc<dyn Worker>> = vec![
+            Arc::new(BasicWorker::new(
+                "http://w1:8000".to_string(),
+                WorkerType::Regular,
+            )),
+            Arc::new(BasicWorker::new(
+                "http://w2:8000".to_string(),
+                WorkerType::Regular,
+            )),
+        ];
+        policy.init_workers(&workers);
+
+        let short_history = "system:bench\nuser:turn one";
+        let long_history = format!(
+            "{}\nassistant:{}\nuser:turn two",
+            short_history,
+            "x".repeat(150)
+        );
+
+        // Turn 1: session-a learns the short history.
+        let idx1 = policy
+            .select_worker_with_fallback_headers(
+                &workers,
+                Some("session-a\x1f"),
+                Some(short_history),
+                None,
+            )
+            .unwrap();
+
+        // Turn 2: exact session hit, with a much longer history.
+        let idx2 = policy
+            .select_worker_with_fallback_headers(
+                &workers,
+                Some("session-a\x1f"),
+                Some(&long_history),
+                None,
+            )
+            .unwrap();
+        assert_eq!(idx1, idx2);
+
+        // A request without a session id must still match the grown
+        // history (0.5 threshold): the stale short history alone would
+        // only match ~13% of the long key and fall to min-load.
+        workers[0].increment_load();
+        let idx3 = policy
+            .select_worker_with_fallback_headers(&workers, Some(""), Some(&long_history), None)
+            .unwrap();
+        assert_eq!(idx3, idx1, "grown history must be learned on session hit");
     }
 
     #[test]

--- a/src/policies/mod.rs
+++ b/src/policies/mod.rs
@@ -32,6 +32,14 @@ pub use round_robin::RoundRobinPolicy;
 /// Key is lowercase header name, value is header value
 pub type RequestHeaders = HashMap<String, String>;
 
+/// Per-request routing metadata returned by policies that can explain why a
+/// worker was selected. Older/simple policies can leave `decision` unset.
+#[derive(Debug, Clone)]
+pub struct RoutingSelection {
+    pub index: usize,
+    pub decision: Option<&'static str>,
+}
+
 /// Core trait for load balancing policies
 ///
 /// This trait provides a unified interface for implementing routing algorithms
@@ -60,6 +68,37 @@ pub trait LoadBalancingPolicy: Send + Sync + Debug {
         request_text: Option<&str>,
         headers: Option<&RequestHeaders>,
     ) -> Option<usize>;
+
+    /// Select a single worker with an optional fallback routing key.
+    ///
+    /// Most policies only understand one routing key, so the default implementation
+    /// ignores the fallback and preserves existing behavior.
+    fn select_worker_with_fallback_headers(
+        &self,
+        workers: &[Arc<dyn Worker>],
+        request_text: Option<&str>,
+        fallback_text: Option<&str>,
+        headers: Option<&RequestHeaders>,
+    ) -> Option<usize> {
+        let _ = fallback_text;
+        self.select_worker_with_headers(workers, request_text, headers)
+    }
+
+    /// Select a worker and optionally return an implementation-specific
+    /// decision label for per-request tracing.
+    fn select_worker_with_fallback_headers_with_decision(
+        &self,
+        workers: &[Arc<dyn Worker>],
+        request_text: Option<&str>,
+        fallback_text: Option<&str>,
+        headers: Option<&RequestHeaders>,
+    ) -> Option<RoutingSelection> {
+        self.select_worker_with_fallback_headers(workers, request_text, fallback_text, headers)
+            .map(|index| RoutingSelection {
+                index,
+                decision: None,
+            })
+    }
 
     /// Select a pair of workers (prefill and decode) for PD routing
     ///

--- a/src/protocols/spec.rs
+++ b/src/protocols/spec.rs
@@ -596,8 +596,6 @@ pub struct ChatCompletionRequest {
 }
 
 impl ChatCompletionRequest {
-    const SESSION_ID_ROUTING_TERMINATOR: &'static str = "\x1f";
-
     /// Build a routing key from text-like chat history and tool schemas.
     ///
     /// This lets cache-aware routing consider the full conversational prefix
@@ -760,13 +758,6 @@ impl ChatCompletionRequest {
             Some(session_id.to_string())
         }
     }
-
-    pub fn extract_session_id_key_for_routing(&self) -> Option<String> {
-        self.extract_session_id_for_routing().map(|mut session_id| {
-            session_id.push_str(Self::SESSION_ID_ROUTING_TERMINATOR);
-            session_id
-        })
-    }
 }
 
 impl GenerationRequest for ChatCompletionRequest {
@@ -785,7 +776,7 @@ impl GenerationRequest for ChatCompletionRequest {
         }
 
         // Fall back to session_id when the chat body has no usable history text.
-        if let Some(session_id) = self.extract_session_id_key_for_routing() {
+        if let Some(session_id) = self.extract_session_id_for_routing() {
             return session_id;
         }
 
@@ -3481,7 +3472,7 @@ mod tests {
     }
 
     #[test]
-    fn test_chat_session_id_routing_key_has_terminator() {
+    fn test_chat_session_id_routing_key() {
         let json = r#"{
             "model": "gpt-4",
             "messages": [{"role": "user", "content": "Hello"}],
@@ -3489,13 +3480,11 @@ mod tests {
         }"#;
 
         let request: ChatCompletionRequest = serde_json::from_str(json).unwrap();
+        // Session affinity is exact-match: the routing key is the raw,
+        // unmodified session id.
         assert_eq!(
             request.extract_session_id_for_routing().as_deref(),
             Some("session-1")
-        );
-        assert_eq!(
-            request.extract_session_id_key_for_routing().as_deref(),
-            Some("session-1\x1f")
         );
     }
 

--- a/src/protocols/spec.rs
+++ b/src/protocols/spec.rs
@@ -605,6 +605,44 @@ impl ChatCompletionRequest {
     pub fn extract_full_history_routing_text(&self) -> String {
         let mut parts = Vec::new();
 
+        // Tool/function schemas come first: they are stable across turns of a
+        // conversation, so prefix-matching a later turn can keep matching the
+        // unchanged schema block. Appending them after the (growing) message
+        // history would stop the match at the first new message.
+        if let Some(tools) = &self.tools {
+            let mut tools_by_name: Vec<&Tool> = tools.iter().collect();
+            tools_by_name.sort_by(|a, b| a.function.name.cmp(&b.function.name));
+
+            for tool in tools_by_name {
+                let parameters = serde_json::to_string(&tool.function.parameters)
+                    .unwrap_or_else(|_| "{}".to_string());
+                let description = tool.function.description.as_deref().unwrap_or("").trim();
+                parts.push(format!(
+                    "tool_schema:{}:{}:{}",
+                    tool.function.name.trim(),
+                    description,
+                    parameters
+                ));
+            }
+        }
+
+        if let Some(functions) = &self.functions {
+            let mut functions_by_name: Vec<&Function> = functions.iter().collect();
+            functions_by_name.sort_by(|a, b| a.name.cmp(&b.name));
+
+            for function in functions_by_name {
+                let parameters = serde_json::to_string(&function.parameters)
+                    .unwrap_or_else(|_| "{}".to_string());
+                let description = function.description.as_deref().unwrap_or("").trim();
+                parts.push(format!(
+                    "function_schema:{}:{}:{}",
+                    function.name.trim(),
+                    description,
+                    parameters
+                ));
+            }
+        }
+
         for message in &self.messages {
             match message {
                 ChatMessage::System { content, .. } => match content {
@@ -707,40 +745,6 @@ impl ChatCompletionRequest {
                     parts.push(format!("function:{}:{}", name.trim(), content.trim()));
                 }
                 _ => {}
-            }
-        }
-
-        if let Some(tools) = &self.tools {
-            let mut tools_by_name: Vec<&Tool> = tools.iter().collect();
-            tools_by_name.sort_by(|a, b| a.function.name.cmp(&b.function.name));
-
-            for tool in tools_by_name {
-                let parameters = serde_json::to_string(&tool.function.parameters)
-                    .unwrap_or_else(|_| "{}".to_string());
-                let description = tool.function.description.as_deref().unwrap_or("").trim();
-                parts.push(format!(
-                    "tool_schema:{}:{}:{}",
-                    tool.function.name.trim(),
-                    description,
-                    parameters
-                ));
-            }
-        }
-
-        if let Some(functions) = &self.functions {
-            let mut functions_by_name: Vec<&Function> = functions.iter().collect();
-            functions_by_name.sort_by(|a, b| a.name.cmp(&b.name));
-
-            for function in functions_by_name {
-                let parameters = serde_json::to_string(&function.parameters)
-                    .unwrap_or_else(|_| "{}".to_string());
-                let description = function.description.as_deref().unwrap_or("").trim();
-                parts.push(format!(
-                    "function_schema:{}:{}:{}",
-                    function.name.trim(),
-                    description,
-                    parameters
-                ));
             }
         }
 

--- a/src/protocols/spec.rs
+++ b/src/protocols/spec.rs
@@ -64,7 +64,13 @@ use std::collections::HashMap;
 pub enum ChatMessage {
     System {
         role: String,
-        content: String,
+        content: SystemMessageContent,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        name: Option<String>,
+    },
+    Developer {
+        role: String,
+        content: SystemMessageContent,
         #[serde(skip_serializing_if = "Option::is_none")]
         name: Option<String>,
     },
@@ -157,11 +163,42 @@ impl<'de> Deserialize<'de> for ChatMessage {
             }),
             "system" => Ok(ChatMessage::System {
                 role: role.to_string(),
-                content: value
-                    .get("content")
-                    .and_then(|c| c.as_str())
-                    .unwrap_or("")
-                    .to_string(),
+                // Strict OpenAI compatibility: array-formatted content may only
+                // contain text parts. A present but unparseable content (e.g.
+                // image_url parts) is a hard error (4xx, 422 via axum's Json
+                // extractor) instead of silently degrading to an empty string;
+                // missing/null still defaults to empty text for backward
+                // compatibility.
+                content: match value.get("content") {
+                    None | Some(Value::Null) => SystemMessageContent::Text(String::new()),
+                    Some(c) => serde_json::from_value(c.clone()).map_err(|e| {
+                        D::Error::custom(format!(
+                            "system message content must be a string or an array of text parts: {e}"
+                        ))
+                    })?,
+                },
+                name: value.get("name").and_then(|n| {
+                    if n.is_null() {
+                        None
+                    } else {
+                        n.as_str().map(String::from)
+                    }
+                }),
+            }),
+            "developer" => Ok(ChatMessage::Developer {
+                role: role.to_string(),
+                // Same strict string-or-text-parts shape as system messages:
+                // array-formatted content may only contain text parts, and a
+                // present but unparseable content is a hard error instead of
+                // being silently rewritten to an empty string.
+                content: match value.get("content") {
+                    None | Some(Value::Null) => SystemMessageContent::Text(String::new()),
+                    Some(c) => serde_json::from_value(c.clone()).map_err(|e| {
+                        D::Error::custom(format!(
+                            "developer message content must be a string or an array of text parts: {e}"
+                        ))
+                    })?,
+                },
                 name: value.get("name").and_then(|n| {
                     if n.is_null() {
                         None
@@ -268,6 +305,31 @@ pub struct StructuredOutputsParams {
 pub enum UserMessageContent {
     Text(String),
     Parts(Vec<ContentPart>),
+}
+
+// System and developer messages are strictly OpenAI-compatible:
+// array-formatted content may only contain text parts. Unlike User messages,
+// non-text parts (e.g. image_url) are rejected at deserialization time and
+// surface as a 4xx instead of being silently dropped or forwarded.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum SystemMessageContent {
+    Text(String),
+    Parts(Vec<SystemContentPart>),
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(tag = "type")]
+pub enum SystemContentPart {
+    #[serde(rename = "text")]
+    Text {
+        text: String,
+        // Unknown extension fields (e.g. prompt_cache_breakpoint) are
+        // preserved for transparent forwarding instead of being silently
+        // dropped by the typed parse/reserialize round-trip.
+        #[serde(flatten)]
+        extra: serde_json::Map<String, Value>,
+    },
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -533,6 +595,176 @@ pub struct ChatCompletionRequest {
     pub other: serde_json::Map<String, serde_json::Value>,
 }
 
+impl ChatCompletionRequest {
+    const SESSION_ID_ROUTING_TERMINATOR: &'static str = "\x1f";
+
+    /// Build a routing key from text-like chat history and tool schemas.
+    ///
+    /// This lets cache-aware routing consider the full conversational prefix
+    /// rather than only a session identifier.
+    pub fn extract_full_history_routing_text(&self) -> String {
+        let mut parts = Vec::new();
+
+        for message in &self.messages {
+            match message {
+                ChatMessage::System { content, .. } => match content {
+                    SystemMessageContent::Text(text) if !text.trim().is_empty() => {
+                        parts.push(format!("system:{}", text.trim()));
+                    }
+                    SystemMessageContent::Parts(content_parts) => {
+                        for part in content_parts {
+                            let SystemContentPart::Text { text, .. } = part;
+                            if !text.trim().is_empty() {
+                                parts.push(format!("system:{}", text.trim()));
+                            }
+                        }
+                    }
+                    _ => {}
+                },
+                ChatMessage::Developer { content, .. } => match content {
+                    SystemMessageContent::Text(text) if !text.trim().is_empty() => {
+                        parts.push(format!("developer:{}", text.trim()));
+                    }
+                    SystemMessageContent::Parts(content_parts) => {
+                        for part in content_parts {
+                            let SystemContentPart::Text { text, .. } = part;
+                            if !text.trim().is_empty() {
+                                parts.push(format!("developer:{}", text.trim()));
+                            }
+                        }
+                    }
+                    _ => {}
+                },
+                ChatMessage::User { content, .. } => match content {
+                    UserMessageContent::Text(text) if !text.trim().is_empty() => {
+                        parts.push(format!("user:{}", text.trim()));
+                    }
+                    UserMessageContent::Parts(content_parts) => {
+                        for part in content_parts {
+                            if let ContentPart::Text { text } = part {
+                                if !text.trim().is_empty() {
+                                    parts.push(format!("user:{}", text.trim()));
+                                }
+                            }
+                        }
+                    }
+                    _ => {}
+                },
+                ChatMessage::Assistant {
+                    content,
+                    tool_calls,
+                    function_call,
+                    ..
+                } => {
+                    if let Some(content) = content {
+                        if !content.trim().is_empty() {
+                            parts.push(format!("assistant:{}", content.trim()));
+                        }
+                    }
+
+                    if let Some(calls) = tool_calls {
+                        for call in calls {
+                            if let Some(arguments) = &call.function.arguments {
+                                if !arguments.trim().is_empty() {
+                                    parts.push(format!(
+                                        "assistant_tool_call:{}:{}",
+                                        call.function.name.trim(),
+                                        arguments.trim()
+                                    ));
+                                }
+                            }
+                        }
+                    }
+
+                    if let Some(call) = function_call {
+                        if let Some(arguments) = &call.arguments {
+                            if !arguments.trim().is_empty() {
+                                parts.push(format!(
+                                    "assistant_function_call:{}:{}",
+                                    call.name.trim(),
+                                    arguments.trim()
+                                ));
+                            }
+                        }
+                    }
+                }
+                ChatMessage::Tool { content, .. } => {
+                    if let Some(text) = content.as_str() {
+                        if !text.trim().is_empty() {
+                            parts.push(format!("tool:{}", text.trim()));
+                        }
+                    } else if let Some(arr) = content.as_array() {
+                        for item in arr {
+                            if let Some(text) = item.get("text").and_then(|t| t.as_str()) {
+                                if !text.trim().is_empty() {
+                                    parts.push(format!("tool:{}", text.trim()));
+                                }
+                            }
+                        }
+                    }
+                }
+                ChatMessage::Function { content, name, .. } if !content.trim().is_empty() => {
+                    parts.push(format!("function:{}:{}", name.trim(), content.trim()));
+                }
+                _ => {}
+            }
+        }
+
+        if let Some(tools) = &self.tools {
+            let mut tools_by_name: Vec<&Tool> = tools.iter().collect();
+            tools_by_name.sort_by(|a, b| a.function.name.cmp(&b.function.name));
+
+            for tool in tools_by_name {
+                let parameters = serde_json::to_string(&tool.function.parameters)
+                    .unwrap_or_else(|_| "{}".to_string());
+                let description = tool.function.description.as_deref().unwrap_or("").trim();
+                parts.push(format!(
+                    "tool_schema:{}:{}:{}",
+                    tool.function.name.trim(),
+                    description,
+                    parameters
+                ));
+            }
+        }
+
+        if let Some(functions) = &self.functions {
+            let mut functions_by_name: Vec<&Function> = functions.iter().collect();
+            functions_by_name.sort_by(|a, b| a.name.cmp(&b.name));
+
+            for function in functions_by_name {
+                let parameters = serde_json::to_string(&function.parameters)
+                    .unwrap_or_else(|_| "{}".to_string());
+                let description = function.description.as_deref().unwrap_or("").trim();
+                parts.push(format!(
+                    "function_schema:{}:{}:{}",
+                    function.name.trim(),
+                    description,
+                    parameters
+                ));
+            }
+        }
+
+        parts.join("\n")
+    }
+
+    pub fn extract_session_id_for_routing(&self) -> Option<String> {
+        let session_params = self.session_params.as_ref()?;
+        let session_id = session_params.get("session_id")?.as_str()?.trim();
+        if session_id.is_empty() {
+            None
+        } else {
+            Some(session_id.to_string())
+        }
+    }
+
+    pub fn extract_session_id_key_for_routing(&self) -> Option<String> {
+        self.extract_session_id_for_routing().map(|mut session_id| {
+            session_id.push_str(Self::SESSION_ID_ROUTING_TERMINATOR);
+            session_id
+        })
+    }
+}
+
 impl GenerationRequest for ChatCompletionRequest {
     fn is_stream(&self) -> bool {
         self.stream
@@ -543,18 +775,16 @@ impl GenerationRequest for ChatCompletionRequest {
     }
 
     fn extract_text_for_routing(&self) -> String {
-        // Use session_id from session_params for session-based routing
-        if let Some(ref session_params) = self.session_params {
-            if let Some(session_id) = session_params.get("session_id") {
-                if let Some(session_id_str) = session_id.as_str() {
-                    if !session_id_str.trim().is_empty() {
-                        return session_id_str.to_string();
-                    }
-                }
-            }
+        let full_history = self.extract_full_history_routing_text();
+        if !full_history.is_empty() {
+            return full_history;
         }
 
-        // Return empty string if no session_id - let routing policy handle this case
+        // Fall back to session_id when the chat body has no usable history text.
+        if let Some(session_id) = self.extract_session_id_key_for_routing() {
+            return session_id;
+        }
+
         String::new()
     }
 }
@@ -3247,6 +3477,25 @@ mod tests {
     }
 
     #[test]
+    fn test_chat_session_id_routing_key_has_terminator() {
+        let json = r#"{
+            "model": "gpt-4",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "session_params": {"session_id": "session-1"}
+        }"#;
+
+        let request: ChatCompletionRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(
+            request.extract_session_id_for_routing().as_deref(),
+            Some("session-1")
+        );
+        assert_eq!(
+            request.extract_session_id_key_for_routing().as_deref(),
+            Some("session-1\x1f")
+        );
+    }
+
+    #[test]
     fn test_chat_completion_request_with_null_model() {
         let json = r#"{
             "model": null,
@@ -3683,9 +3932,12 @@ mod tests {
         let message: ChatMessage = serde_json::from_str(json).unwrap();
 
         match message {
-            ChatMessage::System { content, .. } => {
-                assert_eq!(content, "You are a helpful assistant.");
-            }
+            ChatMessage::System { content, .. } => match content {
+                SystemMessageContent::Text(text) => {
+                    assert_eq!(text, "You are a helpful assistant.");
+                }
+                _ => panic!("Expected text system message"),
+            },
             _ => panic!("Expected System message"),
         }
     }
@@ -3706,6 +3958,89 @@ mod tests {
             },
             _ => panic!("Expected User message"),
         }
+    }
+
+    #[test]
+    fn test_chat_message_developer_array_content_round_trip() {
+        // Array-formatted developer content must survive the typed
+        // parse/reserialize forwarding round-trip instead of being silently
+        // rewritten to an empty string.
+        let json = r#"{
+            "role": "developer",
+            "content": [{"type": "text", "text": "Inspect before editing."}]
+        }"#;
+
+        let message: ChatMessage = serde_json::from_str(json).unwrap();
+
+        match &message {
+            ChatMessage::Developer { content, .. } => match content {
+                SystemMessageContent::Parts(parts) => {
+                    assert_eq!(parts.len(), 1);
+                    match &parts[0] {
+                        SystemContentPart::Text { text, .. } => {
+                            assert_eq!(text, "Inspect before editing.");
+                        }
+                    }
+                }
+                other => panic!("Expected Parts developer content, got: {:?}", other),
+            },
+            _ => panic!("Expected Developer message"),
+        }
+
+        let serialized = serde_json::to_value(&message).unwrap();
+        assert_eq!(
+            serialized,
+            serde_json::from_str::<serde_json::Value>(json).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_chat_message_developer_array_content_rejects_non_text_parts() {
+        let json = r#"{
+            "role": "developer",
+            "content": [{"type": "image_url", "image_url": {"url": "https://example.com/x.png"}}]
+        }"#;
+
+        let err = serde_json::from_str::<ChatMessage>(json).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("developer message content must be a string or an array of text parts"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_chat_message_system_text_part_preserves_extension_fields() {
+        // Valid extra fields on text parts (e.g. prompt_cache_breakpoint)
+        // must survive the parse/reserialize forwarding round-trip instead
+        // of being silently dropped.
+        let json = r#"{
+            "role": "system",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "Be helpful",
+                    "prompt_cache_breakpoint": {"mode": "explicit"}
+                }
+            ]
+        }"#;
+
+        let message: ChatMessage = serde_json::from_str(json).unwrap();
+        let serialized = serde_json::to_value(&message).unwrap();
+
+        assert_eq!(
+            serialized,
+            serde_json::json!({
+                "role": "system",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "Be helpful",
+                        "prompt_cache_breakpoint": {"mode": "explicit"}
+                    }
+                ]
+            })
+        );
     }
 
     #[test]

--- a/src/routers/http/router.rs
+++ b/src/routers/http/router.rs
@@ -502,13 +502,42 @@ impl Router {
         })
     }
 
-    /// Select worker for a specific model considering circuit breaker state
+    /// Select worker for a specific model considering circuit breaker state.
+    /// Test helper; production routing uses `_with_fallback_trace`.
+    #[cfg(test)]
     fn select_worker_for_model(
         &self,
         model_id: Option<&str>,
         text: Option<&str>,
         headers: Option<&HeaderMap>,
     ) -> Option<Arc<dyn Worker>> {
+        self.select_worker_for_model_with_fallback(model_id, text, None, headers)
+    }
+
+    /// Select worker for a specific model, optionally allowing policies to use
+    /// a fallback routing key when the primary key has weak affinity.
+    /// Test helper; production routing uses `_with_fallback_trace`.
+    #[cfg(test)]
+    fn select_worker_for_model_with_fallback(
+        &self,
+        model_id: Option<&str>,
+        text: Option<&str>,
+        fallback_text: Option<&str>,
+        headers: Option<&HeaderMap>,
+    ) -> Option<Arc<dyn Worker>> {
+        self.select_worker_for_model_with_fallback_trace(model_id, text, fallback_text, headers)
+            .map(|(worker, _decision)| worker)
+    }
+
+    /// Select worker and return a policy-specific routing decision label when
+    /// available. Used only for per-request tracing headers.
+    fn select_worker_for_model_with_fallback_trace(
+        &self,
+        model_id: Option<&str>,
+        text: Option<&str>,
+        fallback_text: Option<&str>,
+        headers: Option<&HeaderMap>,
+    ) -> Option<(Arc<dyn Worker>, Option<&'static str>)> {
         // Get workers for the specified model (O(1) lookup if model_id is provided)
         let workers = match model_id {
             Some(model) => self.worker_registry.get_by_model_fast(model),
@@ -533,8 +562,42 @@ impl Router {
         // Convert headers for policies that need them (e.g., consistent_hash)
         let request_headers = Self::headers_to_request_headers(headers);
 
-        let idx = policy.select_worker_with_headers(&available, text, request_headers.as_ref())?;
-        Some(available[idx].clone())
+        let selection = policy.select_worker_with_fallback_headers_with_decision(
+            &available,
+            text,
+            fallback_text,
+            request_headers.as_ref(),
+        )?;
+        Some((available[selection.index].clone(), selection.decision))
+    }
+
+    /// Compute the chat routing keys for the policy that will serve this
+    /// model. cache_aware gets the \x1f-terminated session key plus the
+    /// full-history fallback; every other policy keeps the pre-change
+    /// routing text (raw session id, no fallback) so hash-based policies
+    /// do not see the terminator.
+    fn chat_routing_keys(
+        &self,
+        model_id: Option<&str>,
+        body: &ChatCompletionRequest,
+    ) -> (String, Option<String>) {
+        let policy = match model_id {
+            Some(model) => self.policy_registry.get_policy_or_default(model),
+            None => self.policy_registry.get_default_policy(),
+        };
+
+        if policy.name() == "cache_aware" {
+            (
+                body.extract_session_id_key_for_routing()
+                    .unwrap_or_default(),
+                Some(body.extract_full_history_routing_text()),
+            )
+        } else {
+            (
+                body.extract_session_id_for_routing().unwrap_or_default(),
+                None,
+            )
+        }
     }
 
     pub async fn route_typed_request<T: GenerationRequest + serde::Serialize + Clone>(
@@ -544,15 +607,63 @@ impl Router {
         route: &str,
         model_id: Option<&str>,
     ) -> Response {
+        let text = typed_req.extract_text_for_routing();
+
+        self.route_typed_request_with_routing_text(headers, typed_req, route, model_id, text)
+            .await
+    }
+
+    pub async fn route_typed_request_with_routing_text<
+        T: GenerationRequest + serde::Serialize + Clone,
+    >(
+        &self,
+        headers: Option<&HeaderMap>,
+        typed_req: &T,
+        route: &str,
+        model_id: Option<&str>,
+        text: String,
+    ) -> Response {
+        self.route_typed_request_with_routing_text_fallback(
+            headers, typed_req, route, model_id, text, None,
+        )
+        .await
+    }
+
+    pub async fn route_typed_request_with_routing_text_fallback<
+        T: GenerationRequest + serde::Serialize + Clone,
+    >(
+        &self,
+        headers: Option<&HeaderMap>,
+        typed_req: &T,
+        route: &str,
+        model_id: Option<&str>,
+        text: String,
+        fallback_text: Option<String>,
+    ) -> Response {
         let start = Instant::now();
         let is_stream = typed_req.is_stream();
-        let text = typed_req.extract_text_for_routing();
 
         let response = RetryExecutor::execute_response_with_retry(
             &self.retry_config,
             // operation per attempt
             |_: u32| async {
-                let worker = match self.select_worker_for_model(model_id, Some(&text), headers) {
+                let selected_worker = if fallback_text.is_some() {
+                    self.select_worker_for_model_with_fallback_trace(
+                        model_id,
+                        Some(&text),
+                        fallback_text.as_deref(),
+                        headers,
+                    )
+                } else {
+                    self.select_worker_for_model_with_fallback_trace(
+                        model_id,
+                        Some(&text),
+                        None,
+                        headers,
+                    )
+                };
+
+                let (worker, routing_decision) = match selected_worker {
                     Some(w) => w,
                     None => {
                         RouterMetrics::record_request_error(route, "no_available_workers");
@@ -594,6 +705,7 @@ impl Router {
                         worker.url(),
                         is_stream,
                         load_incremented,
+                        routing_decision,
                     )
                     .await;
 
@@ -647,6 +759,34 @@ impl Router {
             }
         }
         worker_url.to_string()
+    }
+
+    fn add_routing_trace_headers(
+        headers: &mut HeaderMap,
+        worker_url: &str,
+        dp_rank: Option<usize>,
+        decision: Option<&str>,
+    ) {
+        if let Ok(value) = HeaderValue::from_str(worker_url) {
+            headers.insert("x-vllm-router-worker", value);
+        }
+        let base_worker = match dp_utils::extract_dp_rank(worker_url) {
+            Ok((base, _)) => base,
+            Err(_) => worker_url,
+        };
+        if let Ok(value) = HeaderValue::from_str(base_worker) {
+            headers.insert("x-vllm-router-base-worker", value);
+        }
+        if let Some(rank) = dp_rank {
+            if let Ok(value) = HeaderValue::from_str(&rank.to_string()) {
+                headers.insert("x-vllm-router-dp-rank", value);
+            }
+        }
+        if let Some(decision) = decision {
+            if let Ok(value) = HeaderValue::from_str(decision) {
+                headers.insert("x-vllm-router-decision", value);
+            }
+        }
     }
 
     // Generic simple routing for GET/POST without JSON body
@@ -764,6 +904,7 @@ impl Router {
     }
 
     // Send typed request directly without conversion
+    #[allow(clippy::too_many_arguments)]
     async fn send_typed_request<T: serde::Serialize>(
         &self,
         headers: Option<&HeaderMap>,
@@ -772,6 +913,7 @@ impl Router {
         worker_url: &str,
         is_stream: bool,
         load_incremented: bool, // Whether load was incremented for this request
+        routing_decision: Option<&str>,
     ) -> Response {
         let (mut request_builder, extracted_dp_rank, request_url) =
             if self.intra_node_data_parallel_size > 1 {
@@ -877,7 +1019,13 @@ impl Router {
 
         if !is_stream {
             // For non-streaming requests, preserve headers
-            let response_headers = header_utils::preserve_response_headers(res.headers());
+            let mut response_headers = header_utils::preserve_response_headers(res.headers());
+            Self::add_routing_trace_headers(
+                &mut response_headers,
+                worker_url,
+                extracted_dp_rank,
+                routing_decision,
+            );
 
             let response = match res.bytes().await {
                 Ok(body) => {
@@ -918,6 +1066,12 @@ impl Router {
             let mut response_headers = header_utils::preserve_response_headers(res.headers());
             // Ensure we set the correct content-type for SSE
             response_headers.insert(CONTENT_TYPE, HeaderValue::from_static("text/event-stream"));
+            Self::add_routing_trace_headers(
+                &mut response_headers,
+                &worker_url,
+                extracted_dp_rank,
+                routing_decision,
+            );
 
             let stream = res.bytes_stream();
             let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
@@ -972,6 +1126,12 @@ impl Router {
             let mut response_headers = header_utils::preserve_response_headers(res.headers());
             // Ensure we set the correct content-type for SSE
             response_headers.insert(CONTENT_TYPE, HeaderValue::from_static("text/event-stream"));
+            Self::add_routing_trace_headers(
+                &mut response_headers,
+                worker_url,
+                extracted_dp_rank,
+                routing_decision,
+            );
 
             let stream = res.bytes_stream();
             let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
@@ -1464,8 +1624,19 @@ impl RouterTrait for Router {
         body: &ChatCompletionRequest,
         model_id: Option<&str>,
     ) -> Response {
-        self.route_typed_request(headers, body, "/v1/chat/completions", model_id)
-            .await
+        // Chat routing key: try session_id affinity first, then fall back to
+        // prefix-matching the full chat history (cache_aware only).
+        let (text, fallback_text) = self.chat_routing_keys(model_id, body);
+
+        self.route_typed_request_with_routing_text_fallback(
+            headers,
+            body,
+            "/v1/chat/completions",
+            model_id,
+            text,
+            fallback_text,
+        )
+        .await
     }
 
     async fn route_completion(
@@ -1876,6 +2047,79 @@ mod tests {
             circuit_breaker_config: CircuitBreakerConfig::default(),
             _worker_loads: Arc::new(rx),
             _load_monitor_handle: None,
+        }
+    }
+
+    /// Create a test router with the cache_aware policy.
+    fn create_test_cache_aware_router() -> Router {
+        let worker_registry = Arc::new(WorkerRegistry::new());
+        let policy_registry = Arc::new(PolicyRegistry::new(
+            crate::config::types::PolicyConfig::CacheAware {
+                cache_threshold: 0.3,
+                balance_abs_threshold: 64,
+                balance_rel_threshold: 1.5,
+                eviction_interval_secs: 0,
+                max_tree_size: 10000,
+            },
+        ));
+
+        let worker1 = BasicWorker::new("http://worker1:8080".to_string(), WorkerType::Regular);
+        let worker2 = BasicWorker::new("http://worker2:8080".to_string(), WorkerType::Regular);
+        worker_registry.register(Arc::new(worker1));
+        worker_registry.register(Arc::new(worker2));
+
+        let (_, rx) = tokio::sync::watch::channel(HashMap::new());
+        Router {
+            worker_registry,
+            policy_registry,
+            worker_startup_timeout_secs: 5,
+            worker_startup_check_interval_secs: 1,
+            intra_node_data_parallel_size: 1,
+            api_key: None,
+            client: Client::new(),
+            retry_config: RetryConfig::default(),
+            circuit_breaker_config: CircuitBreakerConfig::default(),
+            _worker_loads: Arc::new(rx),
+            _load_monitor_handle: None,
+        }
+    }
+
+    fn chat_request_with_session() -> ChatCompletionRequest {
+        serde_json::from_str(
+            r#"{
+                "model": "test-model",
+                "messages": [{"role": "user", "content": "hello"}],
+                "session_params": {"session_id": "session-123"}
+            }"#,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn test_chat_routing_keys_cache_aware_uses_terminated_key_and_fallback() {
+        let router = create_test_cache_aware_router();
+        let body = chat_request_with_session();
+
+        let (text, fallback) = router.chat_routing_keys(Some("test-model"), &body);
+        assert_eq!(text, "session-123\u{1f}");
+        assert_eq!(fallback.as_deref(), Some("user:hello"));
+    }
+
+    #[test]
+    fn test_chat_routing_keys_hash_policies_keep_raw_session_id() {
+        // Hash-based policies must keep the pre-change routing text: the raw
+        // session id without the cache_aware \x1f terminator, so existing
+        // session affinities survive rolling router upgrades.
+        let routers = [
+            create_test_regular_router(),
+            create_test_consistent_hash_router(),
+        ];
+        let body = chat_request_with_session();
+
+        for router in routers {
+            let (text, fallback) = router.chat_routing_keys(Some("test-model"), &body);
+            assert_eq!(text, "session-123", "policy must not see the terminator");
+            assert_eq!(fallback, None);
         }
     }
 

--- a/src/routers/http/router.rs
+++ b/src/routers/http/router.rs
@@ -613,7 +613,7 @@ impl Router {
             .await
     }
 
-    pub async fn route_typed_request_with_routing_text<
+    async fn route_typed_request_with_routing_text<
         T: GenerationRequest + serde::Serialize + Clone,
     >(
         &self,
@@ -629,7 +629,7 @@ impl Router {
         .await
     }
 
-    pub async fn route_typed_request_with_routing_text_fallback<
+    async fn route_typed_request_with_routing_text_fallback<
         T: GenerationRequest + serde::Serialize + Clone,
     >(
         &self,

--- a/src/routers/http/router.rs
+++ b/src/routers/http/router.rs
@@ -572,10 +572,9 @@ impl Router {
     }
 
     /// Compute the chat routing keys for the policy that will serve this
-    /// model. cache_aware gets the \x1f-terminated session key plus the
-    /// full-history fallback; every other policy keeps the pre-change
-    /// routing text (raw session id, no fallback) so hash-based policies
-    /// do not see the terminator.
+    /// model. cache_aware gets the raw session id (exact-match affinity) plus
+    /// the full-history fallback; every other policy keeps the same raw
+    /// session id with no fallback, preserving pre-change hash behavior.
     fn chat_routing_keys(
         &self,
         model_id: Option<&str>,
@@ -586,17 +585,11 @@ impl Router {
             None => self.policy_registry.get_default_policy(),
         };
 
+        let session_id = body.extract_session_id_for_routing().unwrap_or_default();
         if policy.name() == "cache_aware" {
-            (
-                body.extract_session_id_key_for_routing()
-                    .unwrap_or_default(),
-                Some(body.extract_full_history_routing_text()),
-            )
+            (session_id, Some(body.extract_full_history_routing_text()))
         } else {
-            (
-                body.extract_session_id_for_routing().unwrap_or_default(),
-                None,
-            )
+            (session_id, None)
         }
     }
 
@@ -2096,20 +2089,20 @@ mod tests {
     }
 
     #[test]
-    fn test_chat_routing_keys_cache_aware_uses_terminated_key_and_fallback() {
+    fn test_chat_routing_keys_cache_aware_uses_session_key_and_fallback() {
         let router = create_test_cache_aware_router();
         let body = chat_request_with_session();
 
         let (text, fallback) = router.chat_routing_keys(Some("test-model"), &body);
-        assert_eq!(text, "session-123\u{1f}");
+        assert_eq!(text, "session-123");
         assert_eq!(fallback.as_deref(), Some("user:hello"));
     }
 
     #[test]
     fn test_chat_routing_keys_hash_policies_keep_raw_session_id() {
         // Hash-based policies must keep the pre-change routing text: the raw
-        // session id without the cache_aware \x1f terminator, so existing
-        // session affinities survive rolling router upgrades.
+        // session id with no fallback, so existing session affinities survive
+        // rolling router upgrades.
         let routers = [
             create_test_regular_router(),
             create_test_consistent_hash_router(),
@@ -2118,7 +2111,7 @@ mod tests {
 
         for router in routers {
             let (text, fallback) = router.chat_routing_keys(Some("test-model"), &body);
-            assert_eq!(text, "session-123", "policy must not see the terminator");
+            assert_eq!(text, "session-123", "policy must see the raw session id");
             assert_eq!(fallback, None);
         }
     }

--- a/tests/test_prompt_input.rs
+++ b/tests/test_prompt_input.rs
@@ -45,6 +45,31 @@ fn test_chat_routing_extracts_array_developer_content() {
 }
 
 #[test]
+fn test_chat_routing_schemas_precede_growing_history() {
+    // Stable tool schemas must come before the message history so later
+    // turns keep a matchable prefix: appending schemas after the growing
+    // history would stop prefix matching at the first new message.
+    let request: ChatCompletionRequest = serde_json::from_str(
+        r#"{
+            "model": "test-model",
+            "messages": [{"role": "system", "content": "Use tools."}],
+            "tools": [
+                {"type": "function", "function": {"name": "read_file", "parameters": {"type": "object"}}}
+            ]
+        }"#,
+    )
+    .unwrap();
+
+    let routing = request.extract_full_history_routing_text();
+    let tool_pos = routing.find("tool_schema:").unwrap();
+    let msg_pos = routing.find("system:").unwrap();
+    assert!(
+        tool_pos < msg_pos,
+        "tool schemas must precede message history in the routing key: {routing}"
+    );
+}
+
+#[test]
 fn test_chat_routing_uses_full_history_by_default() {
     let request_a: ChatCompletionRequest = serde_json::from_str(
         r#"{

--- a/tests/test_prompt_input.rs
+++ b/tests/test_prompt_input.rs
@@ -1,5 +1,7 @@
 /// Tests for PromptInput enum supporting str, list[str], list[int], list[list[int]]
-use vllm_router_rs::protocols::spec::{CompletionRequest, PromptInput};
+use vllm_router_rs::protocols::spec::{
+    ChatCompletionRequest, CompletionRequest, GenerationRequest, PromptInput,
+};
 
 #[test]
 fn test_prompt_input_single_string() {
@@ -20,6 +22,179 @@ fn test_prompt_input_single_string() {
     assert!(!req.prompt.is_empty());
     assert!(!req.prompt.is_token_based());
     assert_eq!(req.prompt.extract_text_for_routing(), "Hello, world!");
+}
+
+#[test]
+fn test_chat_routing_extracts_array_developer_content() {
+    let request: ChatCompletionRequest = serde_json::from_str(
+        r#"{
+            "model": "test-model",
+            "messages": [
+                {"role": "developer", "content": [
+                    {"type": "text", "text": "Inspect before editing."}
+                ]},
+                {"role": "user", "content": "Fix bug A"}
+            ]
+        }"#,
+    )
+    .unwrap();
+
+    let routing = request.extract_text_for_routing();
+    assert!(routing.contains("developer:Inspect before editing."));
+    assert!(routing.contains("user:Fix bug A"));
+}
+
+#[test]
+fn test_chat_routing_uses_full_history_by_default() {
+    let request_a: ChatCompletionRequest = serde_json::from_str(
+        r#"{
+            "model": "test-model",
+            "messages": [
+                {"role": "system", "content": "You are a coding agent."},
+                {"role": "developer", "content": "Always inspect before editing."},
+                {"role": "user", "content": "Fix bug A"}
+            ],
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "read_file",
+                        "description": "Read a file",
+                        "parameters": {"type": "object", "properties": {"path": {"type": "string"}}}
+                    }
+                }
+            ]
+        }"#,
+    )
+    .unwrap();
+
+    let request_b: ChatCompletionRequest = serde_json::from_str(
+        r#"{
+            "model": "test-model",
+            "messages": [
+                {"role": "system", "content": "You are a coding agent."},
+                {"role": "developer", "content": "Always inspect before editing."},
+                {"role": "user", "content": "Fix bug B with a different suffix"}
+            ],
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "read_file",
+                        "description": "Read a file",
+                        "parameters": {"type": "object", "properties": {"path": {"type": "string"}}}
+                    }
+                }
+            ]
+        }"#,
+    )
+    .unwrap();
+
+    let routing_a = request_a.extract_text_for_routing();
+    let routing_b = request_b.extract_text_for_routing();
+
+    assert_ne!(routing_a, routing_b);
+    assert!(routing_a.contains("system:You are a coding agent."));
+    assert!(routing_a.contains("developer:Always inspect before editing."));
+    assert!(routing_a.contains("user:Fix bug A"));
+    assert!(routing_a.contains("tool_schema:read_file:Read a file:"));
+    assert!(routing_b.contains("user:Fix bug B with a different suffix"));
+}
+
+#[test]
+fn test_chat_routing_sorts_tools_for_full_history() {
+    let request_a: ChatCompletionRequest = serde_json::from_str(
+        r#"{
+            "model": "test-model",
+            "messages": [{"role": "system", "content": "Use tools."}],
+            "tools": [
+                {"type": "function", "function": {"name": "write_file", "parameters": {"type": "object"}}},
+                {"type": "function", "function": {"name": "read_file", "parameters": {"type": "object"}}}
+            ]
+        }"#,
+    )
+    .unwrap();
+
+    let request_b: ChatCompletionRequest = serde_json::from_str(
+        r#"{
+            "model": "test-model",
+            "messages": [{"role": "system", "content": "Use tools."}],
+            "tools": [
+                {"type": "function", "function": {"name": "read_file", "parameters": {"type": "object"}}},
+                {"type": "function", "function": {"name": "write_file", "parameters": {"type": "object"}}}
+            ]
+        }"#,
+    )
+    .unwrap();
+
+    assert_eq!(
+        request_a.extract_text_for_routing(),
+        request_b.extract_text_for_routing()
+    );
+}
+
+#[test]
+fn test_chat_routing_falls_back_to_session_id_without_history_text() {
+    let request: ChatCompletionRequest = serde_json::from_str(
+        r#"{
+            "model": "test-model",
+            "messages": [],
+            "session_params": {"session_id": "session-123"}
+        }"#,
+    )
+    .unwrap();
+
+    // The session key carries the \x1f terminator to avoid prefix collisions.
+    assert_eq!(request.extract_text_for_routing(), "session-123\u{1f}");
+}
+
+#[test]
+fn test_chat_full_history_routing_includes_volatile_turns() {
+    let request_a: ChatCompletionRequest = serde_json::from_str(
+        r#"{
+            "model": "test-model",
+            "messages": [
+                {"role": "system", "content": "You are a coding agent."},
+                {"role": "developer", "content": "Always inspect before editing."},
+                {"role": "user", "content": "Fix bug A"},
+                {"role": "assistant", "content": "I will inspect it.", "tool_calls": [
+                    {"id": "call_1", "type": "function", "function": {"name": "read_file", "arguments": "{\"path\":\"a.rs\"}"}}
+                ]},
+                {"role": "tool", "tool_call_id": "call_1", "content": [{"type": "text", "text": "file contents"}]}
+            ],
+            "tools": [
+                {"type": "function", "function": {"name": "read_file", "description": "Read a file", "parameters": {"type": "object"}}}
+            ]
+        }"#,
+    )
+    .unwrap();
+
+    let request_b: ChatCompletionRequest = serde_json::from_str(
+        r#"{
+            "model": "test-model",
+            "messages": [
+                {"role": "system", "content": "You are a coding agent."},
+                {"role": "developer", "content": "Always inspect before editing."},
+                {"role": "user", "content": "Fix bug B"}
+            ],
+            "tools": [
+                {"type": "function", "function": {"name": "read_file", "description": "Read a file", "parameters": {"type": "object"}}}
+            ]
+        }"#,
+    )
+    .unwrap();
+
+    let full_a = request_a.extract_full_history_routing_text();
+    let full_b = request_b.extract_full_history_routing_text();
+    assert_eq!(request_a.extract_text_for_routing(), full_a);
+    assert_eq!(request_b.extract_text_for_routing(), full_b);
+    assert_ne!(full_a, full_b);
+    assert!(full_a.contains("user:Fix bug A"));
+    assert!(full_a.contains("assistant:I will inspect it."));
+    assert!(full_a.contains("assistant_tool_call:read_file:{\"path\":\"a.rs\"}"));
+    assert!(full_a.contains("tool:file contents"));
+    assert!(full_a.contains("tool_schema:read_file:Read a file:"));
+    assert!(full_b.contains("user:Fix bug B"));
 }
 
 #[test]

--- a/tests/test_prompt_input.rs
+++ b/tests/test_prompt_input.rs
@@ -169,8 +169,8 @@ fn test_chat_routing_falls_back_to_session_id_without_history_text() {
     )
     .unwrap();
 
-    // The session key carries the \x1f terminator to avoid prefix collisions.
-    assert_eq!(request.extract_text_for_routing(), "session-123\u{1f}");
+    // Session affinity is exact-match: the routing key is the raw session id.
+    assert_eq!(request.extract_text_for_routing(), "session-123");
 }
 
 #[test]


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Cache-aware routing for `/v1/chat/completions` the way a real agent session works — sticky by `session_params.session_id` when that is enough, fall back to prefix-tree match on the full chat history when it is not, and still load-balance when workers are far enough apart.

For each chat request the `cache_aware` policy now receives two routing keys:

- **Primary**: the raw `session_params.session_id`, matched by **exact string equality** in a dedicated per-model session map (no prefix semantics, so `session-1` can never collide with `session-12`). Session entries are aged by last access (TTL sweep) and capped per model.
- **Fallback**: the serialized chat history (name-sorted tool schemas first, then system/developer/user/assistant/tool messages). Probed as a prefix-tree key at the configured `--cache-threshold` when the session map misses.

A session miss therefore still lands on the worker whose KV cache holds the conversation prefix; a miss on both keys falls back to min-load. If workers are imbalanced past the abs/rel gates, affinity is broken for min-load as before. This behavior is hardcoded (no new config knobs).

Additional behavior:

- Per-request decision labels (`session_id_match`, `full_history_match`, `load_balance`, `empty_history_min_load`, …) are emitted to `vllm_router_cache_aware_decisions_total{decision=…}` (exactly one final decision per request) and echoed in `x-vllm-router-decision` response headers alongside `x-vllm-router-worker` / `x-vllm-router-base-worker` / `x-vllm-router-dp-rank` (streaming and non-streaming).
- Stale-entry cleanup: dead tree tenants and dead session-map entries are dropped lazily on lookup and eagerly on worker removal.
- New `developer` chat role, with strict string-or-text-parts content: array-formatted content (text-only parts) is forwarded intact, non-text parts are a hard 4xx, mirroring the existing strict system-message handling.
- The min-load (imbalanced) path also teaches the session map and the prefix tree the full chat history, so a later balanced request can discover prefixes learned during load spikes.
- Session hits teach the tree the grown conversation history, so clients that later drop the session id still match the current prefix.

Compatibility notes:

- Hash-based policies (`consistent_hash`, `rendezvous_hash`) keep the pre-change routing text (raw session id); only `cache_aware` sees the session map and fallback.
- `SystemContentPart::Text` preserves unknown extension fields (e.g. `prompt_cache_breakpoint`) via `#[serde(flatten)]` across the parse/reserialize forwarding round-trip.

## Test Plan

```bash
cargo fmt --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --lib --bins
cargo test --test '*'
python -m black --check py_src/ py_test/
python -m ruff check py_src/ py_test/
pytest py_test/unit py_test/integration --ignore=py_test/e2e
```

New tests:

- `src/policies/cache_aware.rs`: exact-match session affinity + full-history fallback selection, empty-history session semantics (`empty_history_min_load`), imbalanced path teaches session map + full history, stale session-entry cleanup on worker removal, session-entry TTL/capacity eviction, header-key fallback.
- `src/protocols/spec.rs`: developer array-content round-trip + non-text-part rejection, system text-part extension-field preservation, raw session-id routing key.
- `src/routers/http/router.rs`: `chat_routing_keys` gives `cache_aware` the session key + fallback while hash policies keep the raw session id.
- `tests/test_prompt_input.rs`: full-history routing-key fixtures (tool sorting, volatile turns, array developer content).
- `py_test/integration/load_balancing/test_cache_aware.py`: stable agent prefix keeps chat affinity on one worker.

## Test Result

```text
cargo test --lib --bins     500 passed; 0 failed
cargo test --test '*'       all suites passed (test_openai_router_health 503 is a pre-existing macOS-only failure, also present on pristine main)
cargo clippy --all-targets --all-features -- -D warnings   clean
python -m black --check / ruff check   clean
pytest py_test/unit/test_arg_parser.py   20 passed, 1 skipped
```

Mutation probes: replacing the exact-match session map lookup with the old prefix-tree probe makes `test_cache_aware_empty_history_uses_exact_session_match` route `session-12` onto the `session-1` worker (shared string prefix); removing the history insert from the min-load path makes `test_cache_aware_imbalanced_path_teaches_full_history` fail.

Not yet run in this environment: `py_test/integration` (needs the rebuilt PyO3 extension) and a GPU smoke (`pip install -e .` after building).

### Performance evaluation

Eval: Qwen3.5-4B, Codex SWE-bench Pro cold-transcript replay (**25 sessions × 4 turns**, 100 requests), `max_tokens=256`, `session_serial` fire mode. **DP baseline** (data-parallel vLLM without the router) vs the router with the cache-aware chat routing and the `lb_mid` preset (`cache=0.3, abs=2, rel=1.5`). Cold start per case; `--enable-prefix-caching` on every backend. `Prompt%` is the prefix-cache hit rate; queue/prefill/decode are Prometheus means; TTFT/E2E are client means.

**NPU (Ascend, prefix block 1024), `max_num_batched_tokens=2048`**

| C | Case | Prompt% | Queue s | Prefill s | Decode s | TTFT s | E2E s |
|--:|------|--------:|--------:|----------:|---------:|-------:|------:|
| 4 | DP baseline | 20.5 | 0.27 | 2.59 | 7.80 | 2.95 | 10.74 |
| 4 | cache-aware | **59.5** | **0.17** | **1.35** | **5.25** | **1.64** | **6.87** |
| 8 | DP baseline | 20.7 | 1.40 | 2.84 | 11.84 | 4.41 | 16.23 |
| 8 | cache-aware | **50.1** | **0.99** | **1.82** | **7.87** | **2.97** | **10.82** |

C4: TTFT **−1.31 s**, E2E **−3.87 s**. C8: TTFT **−1.44 s**, E2E **−5.40 s**.
DP baseline Prompt% collapses to ~21% at `bt=2048`; session-id + full-history fallback restores ~50–60% and improves every measured column.

**GPU (H800), C4 / `max_tokens=256` / `bt=2048`**

| C | Case | Prompt% | Queue s | Prefill s | Decode s | TTFT s | E2E s |
|--:|------|--------:|--------:|----------:|---------:|-------:|------:|
| 4 | DP baseline | 38.0 | 0.88 | 7.66 | 18.24 | 8.71 | 26.93 |
| 4 | cache-aware | **50.1** | 0.85 | **6.40** | **14.25** | **7.46** | **21.70** |

Prompt/prefill/decode/TTFT/E2E all improve; queue is essentially unchanged (0.88 s vs 0.85 s mean). Client fire mode matters: these numbers assume `session_serial` — turn *n+1* waits for turn *n*, the serving shape of a real agent session.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
</details>
