### PR TITLE
Fix vulnerable Python packages in router image

### DIFF
--- a/Dockerfile.router
+++ b/Dockerfile.router
@@ -26,8 +26,6 @@ RUN apt-get update && apt upgrade -y && apt-get install -y \
     curl \
     && rm -rf /var/lib/apt/lists/*
 
-RUN pip3 install --upgrade pip
-
 # Create app directory
 WORKDIR /app
 
@@ -43,7 +41,14 @@ COPY pyproject.toml ./
 COPY README.md ./
 
 # Install Python dependencies if using Python launcher
-RUN pip install setuptools-rust wheel build requests
+RUN pip install --upgrade \
+    pip \
+    "setuptools>=83.0.0" \
+    "msgpack>=1.2.1" \
+    setuptools-rust \
+    wheel \
+    build \
+    requests
 
 # Expose default router port
 EXPOSE 8080

--- a/Dockerfile.router
+++ b/Dockerfile.router
@@ -41,14 +41,16 @@ COPY pyproject.toml ./
 COPY README.md ./
 
 # Install Python dependencies if using Python launcher
-RUN pip install --upgrade \
+RUN pip install --no-cache-dir --upgrade \
     pip \
     "setuptools>=83.0.0" \
     "msgpack>=1.2.1" \
     setuptools-rust \
     wheel \
     build \
-    requests
+    requests \
+    && python -c "import msgpack, setuptools; assert tuple(map(int, msgpack.__version__.split('.'))) >= (1, 2, 1); assert tuple(map(int, setuptools.__version__.split('.'))) >= (83, 0, 0)" \
+    && rm -rf /root/.cache/pip /usr/local/lib/python3.12/ensurepip
 
 # Expose default router port
 EXPOSE 8080

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,10 @@
 [build-system]
-requires = ["setuptools>=45", "wheel", "setuptools-rust>=1.5.2"]
+requires = [
+    "setuptools>=45; python_version < '3.10'",
+    "setuptools>=83.0.0; python_version >= '3.10'",
+    "wheel",
+    "setuptools-rust>=1.5.2",
+]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
## Summary

- upgrade `setuptools` to `>=83.0.0` in the final Python 3.12 router image
- upgrade image `msgpack` to `>=1.2.1`
- require `setuptools>=83.0.0` for PEP 517 builds on Python 3.10+
- preserve the existing setuptools floor on Python 3.8/3.9 because setuptools 83 requires Python 3.10
- install image dependencies without retaining pip's download cache
- remove the final image's `ensurepip` bundle after installation

These changes address `GHSA-6v7p-g79w-8964`, `CVE-2025-47273`, and `CVE-2026-59890` from the Trivy check on #216.

The first rerun confirmed that the installed distributions were clean (`msgpack 1.2.2` and `setuptools 84.0.0`), but Trivy still found `msgpack 1.1.2` and `setuptools 70.3.0` vendored in the Python base image's bundled bootstrap wheel. The runtime does not need `ensurepip` after dependencies are installed, so the stale bundle is removed in the same image layer.

The Buildkite install commands already use `pip -U` and select the newest Python-compatible setuptools. `msgpack` remains image-only because it is not an application dependency and version 1.2.1 requires Python 3.10.

## Validation

- image build asserts the installed `msgpack` and `setuptools` versions
- parsed `pyproject.toml` with `tomllib`
- verified the setuptools markers select the original floor on Python 3.9 and version 83 on Python 3.10
- `git diff --check`

Docker/Trivy could not be run locally because Docker is unavailable in the current environment; the GitHub Actions rerun is the image-level validation.