### PR TITLE
[Bugfix]:Cached_tokens always returns -1

### DIFF
--- a/src/routers/http/logprobs_merge.rs
+++ b/src/routers/http/logprobs_merge.rs
@@ -6,6 +6,73 @@
 use serde_json::Value;
 use tracing::debug;
 
+/// Merge usage metadata from prefill response into decode response.
+///
+/// Prefer the prefill-side cached_tokens, because vLLM decode-side cached token
+/// accounting may temporarily report invalid placeholder values such as -1.
+pub fn merge_usage_in_json(prefill_json: &Value, decode_json: &mut Value) -> bool {
+    let Some(prefill_usage) = prefill_json.get("usage") else {
+        return false;
+    };
+
+    let prefill_cached = prefill_usage
+        .get("prompt_tokens_details")
+        .and_then(|v| v.get("cached_tokens"))
+        .or_else(|| {
+            prefill_usage
+                .get("input_tokens_details")
+                .and_then(|v| v.get("cached_tokens"))
+        });
+
+    let Some(prefill_cached) = prefill_cached else {
+        return false;
+    };
+
+    let decode_usage = match decode_json.get_mut("usage") {
+        Some(v) => v,
+        None => {
+            decode_json["usage"] = prefill_usage.clone();
+            return true;
+        }
+    };
+
+    let Some(decode_usage_obj) = decode_usage.as_object_mut() else {
+        return false;
+    };
+
+    let details_target = if decode_usage_obj.contains_key("prompt_tokens_details") {
+        "prompt_tokens_details"
+    } else if decode_usage_obj.contains_key("input_tokens_details") {
+        "input_tokens_details"
+    } else {
+        "prompt_tokens_details"
+    };
+
+    let decode_details = decode_usage_obj
+        .entry(details_target.to_string())
+        .or_insert(Value::Object(serde_json::Map::new()));
+
+    let Some(decode_details_obj) = decode_details.as_object_mut() else {
+        return false;
+    };
+
+    let should_replace = match decode_details_obj.get("cached_tokens") {
+        Some(existing) => existing.as_i64().map_or(true, |v| v <= 0),
+        None => true,
+    };
+
+    if should_replace {
+        decode_details_obj.insert("cached_tokens".to_string(), prefill_cached.clone());
+        debug!(
+            "[USAGE MERGE] Replaced decode cached_tokens with prefill value {}",
+            prefill_cached
+        );
+        return true;
+    }
+
+    false
+}
+
 /// Merge prompt_logprobs from prefill response into decode response.
 ///
 /// Handles both Completions API (prompt_logprobs in choices) and
@@ -25,7 +92,7 @@ use tracing::debug;
 /// # Returns
 /// * `bool` - Whether any logprobs were merged
 pub fn merge_logprobs_in_json(prefill_json: &Value, decode_json: &mut Value) -> bool {
-    let mut merged = false;
+    let mut merged = merge_usage_in_json(prefill_json, decode_json);
 
     // 1. Try to merge meta_info/input_token_logprobs (for Generate API)
     if let (Some(prefill_meta), Some(decode_meta)) = (
@@ -335,6 +402,176 @@ mod tests {
         assert_eq!(merged_offsets[2].as_i64().unwrap(), 11); // Prompt token " test"
         assert_eq!(merged_offsets[3].as_i64().unwrap(), 16); // Decode token " output" (0 + 16)
         assert_eq!(merged_offsets[4].as_i64().unwrap(), 23); // Decode token " token" (7 + 16)
+    }
+
+    #[test]
+    fn test_merge_usage_prefill_cached_tokens_over_decode_invalid_value() {
+        let prefill_json = json!({
+            "usage": {
+                "prompt_tokens": 100,
+                "completion_tokens": 1,
+                "total_tokens": 101,
+                "prompt_tokens_details": {
+                    "cached_tokens": 50
+                }
+            }
+        });
+
+        let mut decode_json = json!({
+            "usage": {
+                "prompt_tokens": 100,
+                "completion_tokens": 10,
+                "total_tokens": 110,
+                "prompt_tokens_details": {
+                    "cached_tokens": -1
+                }
+            }
+        });
+
+        let merged = merge_usage_in_json(&prefill_json, &mut decode_json);
+        assert!(merged);
+        assert_eq!(
+            decode_json["usage"]["prompt_tokens_details"]["cached_tokens"],
+            json!(50)
+        );
+    }
+
+    #[test]
+    fn test_merge_usage_keeps_valid_decode_cached_tokens() {
+        let prefill_json = json!({
+            "usage": {
+                "prompt_tokens": 100,
+                "completion_tokens": 1,
+                "total_tokens": 101,
+                "prompt_tokens_details": {
+                    "cached_tokens": 50
+                }
+            }
+        });
+
+        let mut decode_json = json!({
+            "usage": {
+                "prompt_tokens": 100,
+                "completion_tokens": 10,
+                "total_tokens": 110,
+                "prompt_tokens_details": {
+                    "cached_tokens": 12
+                }
+            }
+        });
+
+        let merged = merge_usage_in_json(&prefill_json, &mut decode_json);
+        assert!(!merged);
+        assert_eq!(
+            decode_json["usage"]["prompt_tokens_details"]["cached_tokens"],
+            json!(12)
+        );
+    }
+
+    #[test]
+    fn test_merge_usage_fills_missing_cached_tokens() {
+        let prefill_json = json!({
+            "usage": {
+                "prompt_tokens": 100,
+                "completion_tokens": 1,
+                "total_tokens": 101,
+                "prompt_tokens_details": {
+                    "cached_tokens": 50
+                }
+            }
+        });
+
+        let mut decode_json = json!({
+            "usage": {
+                "prompt_tokens": 100,
+                "completion_tokens": 10,
+                "total_tokens": 110,
+                "prompt_tokens_details": {}
+            }
+        });
+
+        let merged = merge_usage_in_json(&prefill_json, &mut decode_json);
+        assert!(merged);
+        assert_eq!(
+            decode_json["usage"]["prompt_tokens_details"]["cached_tokens"],
+            json!(50)
+        );
+    }
+
+    #[test]
+    fn test_merge_usage_uses_input_tokens_details_fallback() {
+        let prefill_json = json!({
+            "usage": {
+                "input_tokens": 100,
+                "output_tokens": 1,
+                "total_tokens": 101,
+                "input_tokens_details": {
+                    "cached_tokens": 41
+                }
+            }
+        });
+
+        let mut decode_json = json!({
+            "usage": {
+                "input_tokens": 100,
+                "output_tokens": 10,
+                "total_tokens": 110,
+                "prompt_tokens_details": {
+                    "cached_tokens": -1
+                }
+            }
+        });
+
+        let merged = merge_usage_in_json(&prefill_json, &mut decode_json);
+        assert!(merged);
+        assert_eq!(
+            decode_json["usage"]["prompt_tokens_details"]["cached_tokens"],
+            json!(41)
+        );
+    }
+
+    #[test]
+    fn test_merge_usage_copies_usage_when_decode_missing() {
+        let prefill_json = json!({
+            "usage": {
+                "prompt_tokens": 100,
+                "completion_tokens": 1,
+                "total_tokens": 101,
+                "prompt_tokens_details": {
+                    "cached_tokens": 50
+                }
+            }
+        });
+
+        let mut decode_json = json!({
+            "choices": [{ "message": { "content": "ok" } }]
+        });
+
+        let merged = merge_usage_in_json(&prefill_json, &mut decode_json);
+        assert!(merged);
+        assert_eq!(decode_json["usage"]["prompt_tokens_details"]["cached_tokens"], json!(50));
+    }
+
+    #[test]
+    fn test_merge_usage_noop_without_prefill_usage() {
+        let prefill_json = json!({ "choices": [{ "message": { "content": "ok" } }] });
+        let mut decode_json = json!({
+            "usage": {
+                "prompt_tokens": 100,
+                "completion_tokens": 10,
+                "total_tokens": 110,
+                "prompt_tokens_details": {
+                    "cached_tokens": -1
+                }
+            }
+        });
+
+        let merged = merge_usage_in_json(&prefill_json, &mut decode_json);
+        assert!(!merged);
+        assert_eq!(
+            decode_json["usage"]["prompt_tokens_details"]["cached_tokens"],
+            json!(-1)
+        );
     }
 
     #[test]

--- a/src/routers/http/logprobs_merge.rs
+++ b/src/routers/http/logprobs_merge.rs
@@ -57,7 +57,7 @@ pub fn merge_usage_in_json(prefill_json: &Value, decode_json: &mut Value) -> boo
     };
 
     let should_replace = match decode_details_obj.get("cached_tokens") {
-        Some(existing) => existing.as_i64().map_or(true, |v| v <= 0),
+        Some(existing) => existing.as_i64().is_none_or(|v| v <= 0),
         None => true,
     };
 
@@ -549,7 +549,10 @@ mod tests {
 
         let merged = merge_usage_in_json(&prefill_json, &mut decode_json);
         assert!(merged);
-        assert_eq!(decode_json["usage"]["prompt_tokens_details"]["cached_tokens"], json!(50));
+        assert_eq!(
+            decode_json["usage"]["prompt_tokens_details"]["cached_tokens"],
+            json!(50)
+        );
     }
 
     #[test]

--- a/src/routers/http/vllm_pd_router.rs
+++ b/src/routers/http/vllm_pd_router.rs
@@ -694,45 +694,6 @@ impl VllmPDRouter {
             RouterMetrics::record_pd_decode_error(decode_http);
         }
 
-        if needs_logprobs && !is_streaming {
-            debug!("Logprobs requested and non-streaming - merging prefill and decode logprobs");
-
-            let status = decode_response.status();
-            let resp_headers = decode_response.headers().clone();
-            let decode_body = decode_response
-                .bytes()
-                .await
-                .map_err(|e| format!("Failed to read decode response: {}", e))?;
-
-            let mut decode_json: Value = serde_json::from_slice(&decode_body)
-                .map_err(|e| format!("Failed to parse decode response as JSON: {}", e))?;
-
-            let empty_json = Value::Null;
-            let prefill_json_ref = prefill_response_json.unwrap_or(&empty_json);
-            let merged = logprobs_merge::merge_logprobs_in_json(prefill_json_ref, &mut decode_json);
-            if merged {
-                debug!("Successfully merged logprobs from prefill and decode responses");
-            } else {
-                warn!("No logprobs were merged (might be expected if logprobs not in response)");
-            }
-
-            let merged_body = serde_json::to_vec(&decode_json)
-                .map_err(|e| format!("Failed to serialize merged response: {}", e))?;
-
-            let mut response_builder = axum::http::Response::builder().status(status);
-            for (name, value) in resp_headers.iter() {
-                response_builder = response_builder.header(name, value);
-            }
-            return response_builder
-                .body(axum::body::Body::from(merged_body))
-                .map_err(|e| format!("Failed to build response: {}", e));
-        }
-
-        debug!(
-            "No logprobs merging needed (streaming={}, needs_logprobs={})",
-            is_streaming, needs_logprobs
-        );
-
         let status = decode_response.status();
 
         if is_streaming {
@@ -752,18 +713,50 @@ impl VllmPDRouter {
             });
         }
 
-        // Non-streaming, no logprobs: read entire body
-        let decode_headers = decode_response.headers().clone();
-        let body = decode_response
+        // All non-streaming PD responses must normalize usage before returning.
+        // This is required even when logprobs are not requested because decode-side
+        // cached_tokens can temporarily report invalid placeholders like -1 and would
+        // otherwise override the valid value from prefill.
+        debug!(
+            "Non-streaming PD response: normalizing usage and optional logprobs before return"
+        );
+
+        let resp_headers = decode_response.headers().clone();
+        let decode_body = decode_response
             .bytes()
             .await
             .map_err(|e| format!("Failed to read decode response: {}", e))?;
+
+        let mut decode_json: Value = serde_json::from_slice(&decode_body)
+            .map_err(|e| format!("Failed to parse decode response as JSON: {}", e))?;
+
+        let empty_json = Value::Null;
+        let prefill_json_ref = prefill_response_json.unwrap_or(&empty_json);
+
+        let merged_usage = logprobs_merge::merge_usage_in_json(prefill_json_ref, &mut decode_json);
+        let merged_logprobs = if needs_logprobs {
+            logprobs_merge::merge_logprobs_in_json(prefill_json_ref, &mut decode_json)
+        } else {
+            false
+        };
+
+        if merged_usage || merged_logprobs {
+            debug!(
+                "Successfully normalized prefill metadata in decode response (usage={}, logprobs={})",
+                merged_usage,
+                merged_logprobs
+            );
+        }
+
+        let merged_body = serde_json::to_vec(&decode_json)
+            .map_err(|e| format!("Failed to serialize merged response: {}", e))?;
+
         let mut response_builder = axum::http::Response::builder().status(status);
-        for (name, value) in decode_headers.iter() {
+        for (name, value) in resp_headers.iter() {
             response_builder = response_builder.header(name, value);
         }
         response_builder
-            .body(axum::body::Body::from(body))
+            .body(axum::body::Body::from(merged_body))
             .map_err(|e| format!("Failed to build response: {}", e))
     }
 
@@ -1498,11 +1491,11 @@ impl VllmPDRouter {
             .and_then(|v| v.as_bool())
             .unwrap_or(false);
 
-        // If logprobs requested and non-streaming, merge prefill and decode logprobs
-        if needs_logprobs && !is_streaming {
-            debug!("Logprobs requested and non-streaming - merging prefill and decode logprobs");
+        // For non-streaming responses, always prefer the prefill-side cached token metadata
+        // if the decode-side value is missing or invalid (for example, -1 from a partial decode).
+        if !is_streaming {
+            debug!("Non-streaming PD response: merging usage metadata from prefill into decode result");
 
-            // Read decode response body
             let decode_body =
                 decode_response
                     .bytes()
@@ -1514,22 +1507,27 @@ impl VllmPDRouter {
                         ),
                     })?;
 
-            // Parse decode response as JSON
             let mut decode_json: Value =
                 serde_json::from_slice(&decode_body).map_err(|e| PDRouterError::NetworkError {
                     message: format!("Failed to parse decode response as JSON: {}", e),
                 })?;
 
-            // Merge logprobs from prefill into decode response
-            let merged =
-                logprobs_merge::merge_logprobs_in_json(&prefill_response_json, &mut decode_json);
-            if merged {
-                debug!("Successfully merged logprobs from prefill and decode responses");
+            let merged_usage =
+                logprobs_merge::merge_usage_in_json(&prefill_response_json, &mut decode_json);
+            let merged_logprobs = if needs_logprobs {
+                logprobs_merge::merge_logprobs_in_json(&prefill_response_json, &mut decode_json)
             } else {
-                warn!("No logprobs were merged (might be expected if logprobs not in response)");
+                false
+            };
+
+            if merged_usage || merged_logprobs {
+                debug!(
+                    "Successfully merged prefill metadata into decode response (usage={}, logprobs={})",
+                    merged_usage,
+                    merged_logprobs
+                );
             }
 
-            // Serialize merged response
             let merged_body =
                 serde_json::to_vec(&decode_json).map_err(|e| PDRouterError::NetworkError {
                     message: format!("Failed to serialize merged response: {}", e),
@@ -1542,32 +1540,32 @@ impl VllmPDRouter {
                 }
             }
 
-            response_builder.body(Body::from(merged_body)).map_err(|e| {
+            return response_builder.body(Body::from(merged_body)).map_err(|e| {
                 PDRouterError::NetworkError {
                     message: format!("Failed to build response from {}: {}", decode_url, e),
                 }
-            })
-        } else {
-            // No logprobs merging needed - return decode response as-is (streaming or no logprobs)
-            debug!(
-                "No logprobs merging needed (streaming={}, needs_logprobs={})",
-                is_streaming, needs_logprobs
-            );
-
-            let mut response_builder = Response::builder().status(status);
-            for (key, value) in headers.iter() {
-                if key != "transfer-encoding" && key != "content-length" {
-                    response_builder = response_builder.header(key, value);
-                }
-            }
-
-            let body = Body::from_stream(decode_response.bytes_stream());
-            response_builder
-                .body(body)
-                .map_err(|e| PDRouterError::NetworkError {
-                    message: format!("Failed to build response from {}: {}", decode_url, e),
-                })
+            });
         }
+
+        // Streaming responses are returned directly without any merge step.
+        debug!(
+            "No logprobs merging needed (streaming={}, needs_logprobs={})",
+            is_streaming, needs_logprobs
+        );
+
+        let mut response_builder = Response::builder().status(status);
+        for (key, value) in headers.iter() {
+            if key != "transfer-encoding" && key != "content-length" {
+                response_builder = response_builder.header(key, value);
+            }
+        }
+
+        let body = Body::from_stream(decode_response.bytes_stream());
+        response_builder
+            .body(body)
+            .map_err(|e| PDRouterError::NetworkError {
+                message: format!("Failed to build response from {}: {}", decode_url, e),
+            })
     }
 
     /// Create a new vLLM PD router

--- a/src/routers/http/vllm_pd_router.rs
+++ b/src/routers/http/vllm_pd_router.rs
@@ -717,9 +717,7 @@ impl VllmPDRouter {
         // This is required even when logprobs are not requested because decode-side
         // cached_tokens can temporarily report invalid placeholders like -1 and would
         // otherwise override the valid value from prefill.
-        debug!(
-            "Non-streaming PD response: normalizing usage and optional logprobs before return"
-        );
+        debug!("Non-streaming PD response: normalizing usage and optional logprobs before return");
 
         let resp_headers = decode_response.headers().clone();
         let decode_body = decode_response
@@ -727,8 +725,22 @@ impl VllmPDRouter {
             .await
             .map_err(|e| format!("Failed to read decode response: {}", e))?;
 
-        let mut decode_json: Value = serde_json::from_slice(&decode_body)
-            .map_err(|e| format!("Failed to parse decode response as JSON: {}", e))?;
+        let mut decode_json: Value = match serde_json::from_slice(&decode_body) {
+            Ok(json) => json,
+            Err(_) => {
+                let mut response_builder = axum::http::Response::builder().status(status);
+                for (name, value) in resp_headers.iter() {
+                    if name != axum::http::header::CONTENT_LENGTH
+                        && name != axum::http::header::TRANSFER_ENCODING
+                    {
+                        response_builder = response_builder.header(name, value);
+                    }
+                }
+                return response_builder
+                    .body(axum::body::Body::from(decode_body))
+                    .map_err(|e| format!("Failed to build response from decode: {}", e));
+            }
+        };
 
         let empty_json = Value::Null;
         let prefill_json_ref = prefill_response_json.unwrap_or(&empty_json);
@@ -753,7 +765,11 @@ impl VllmPDRouter {
 
         let mut response_builder = axum::http::Response::builder().status(status);
         for (name, value) in resp_headers.iter() {
-            response_builder = response_builder.header(name, value);
+            if name != axum::http::header::CONTENT_LENGTH
+                && name != axum::http::header::TRANSFER_ENCODING
+            {
+                response_builder = response_builder.header(name, value);
+            }
         }
         response_builder
             .body(axum::body::Body::from(merged_body))
@@ -1494,7 +1510,9 @@ impl VllmPDRouter {
         // For non-streaming responses, always prefer the prefill-side cached token metadata
         // if the decode-side value is missing or invalid (for example, -1 from a partial decode).
         if !is_streaming {
-            debug!("Non-streaming PD response: merging usage metadata from prefill into decode result");
+            debug!(
+                "Non-streaming PD response: merging usage metadata from prefill into decode result"
+            );
 
             let decode_body =
                 decode_response
@@ -1507,10 +1525,22 @@ impl VllmPDRouter {
                         ),
                     })?;
 
-            let mut decode_json: Value =
-                serde_json::from_slice(&decode_body).map_err(|e| PDRouterError::NetworkError {
-                    message: format!("Failed to parse decode response as JSON: {}", e),
-                })?;
+            let mut decode_json: Value = match serde_json::from_slice(&decode_body) {
+                Ok(json) => json,
+                Err(_) => {
+                    let mut response_builder = Response::builder().status(status);
+                    for (key, value) in headers.iter() {
+                        if key != "transfer-encoding" && key != "content-length" {
+                            response_builder = response_builder.header(key, value);
+                        }
+                    }
+                    return response_builder.body(Body::from(decode_body)).map_err(|e| {
+                        PDRouterError::NetworkError {
+                            message: format!("Failed to build response from {}: {}", decode_url, e),
+                        }
+                    });
+                }
+            };
 
             let merged_usage =
                 logprobs_merge::merge_usage_in_json(&prefill_response_json, &mut decode_json);


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
In PD disaggregation mode, ensure that "usage.prompt_tokens_details.cached_tokens" preferentially uses the valid value returned by the prefill stage.

If the "cached_tokens" value returned by the decode stage is missing or invalid (e.g., "< 0"), automatically fall back to the prefill value.

Preserve the existing "logprobs" merging logic without introducing regressions.

Add regression tests to ensure the fix remains effective.

## Test Plan
This test plan is designed to verify the PD (Prefill/Decode) disaggregation fix for `cached_tokens` handling.

### Objective

Ensure that the final response keeps the valid prefill-side `cached_tokens` value instead of allowing an invalid decode-side value such as `-1` to override it.

### Core scenarios to cover

1. Invalid decode value overrides valid prefill value
- Prefill: `cached_tokens = 50`
- Decode: `cached_tokens = -1`
- Expected: final value is `50`

2. Valid decode value is preserved
- Prefill: `cached_tokens = 50`
- Decode: `cached_tokens = 12`
- Expected: final value remains `12`

3. Decode value is missing
- Decode has no `cached_tokens`
- Expected: value is filled from prefill

4. Fallback compatibility
- Prefill uses `input_tokens_details.cached_tokens`
- Expected: logic reads the fallback correctly

5. Decode usage missing entirely
- Expected: prefill usage is copied into decode JSON

6. No prefill usage present
- Expected: merge is a no-op and no overwrite occurs

## Test Result
### Result summary

-`6 passed`
-`0 failed`

### Evidence

The test run output included:

```text
running 6 tests
...
test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 484 filtered out
```
