### PR TITLE
ci: publish multi-arch (amd64+arm64) Docker images for vllm-router

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,0 +1,138 @@
+# Build and publish the vllm-router image (multi-arch: linux/amd64 + linux/arm64)
+#
+# Triggers:
+#   - push to main        -> build happens automatically
+#   - workflow_dispatch   -> manual build, optional extra image tag
+#
+# Output (GHCR, image name defaults to ghcr.io/<owner>/<repo>):
+#   <image>:latest
+#   <image>:sha-<short-sha>                    (multi-arch manifest)
+#   <image>:<custom-tag>                       (manual dispatch only, optional)
+#   <image>:sha-<short-sha>-amd64|-arm64       (per-arch, kept for debugging)
+#
+# arm64 is built natively on GitHub's ARM runner (ubuntu-24.04-arm).
+# If native ARM runners are unavailable (e.g. private repos), change the arm64
+# runner in the matrix below to "ubuntu-latest": the QEMU step will then build
+# arm64 via emulation instead (slower, but no ARM runner needed).
+
+name: build-image
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: 'Extra tag to publish in addition to latest / sha-<commit> (e.g. v0.1.15)'
+        required: false
+        type: string
+        default: ''
+      build_arm64:
+        description: 'Also build the linux/arm64 image'
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: build-image-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: build (${{ matrix.platform }})
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            platform: linux/amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            platform: linux/arm64
+            runner: ubuntu-24.04-arm
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Set up QEMU (arm64)
+        if: ${{ matrix.arch == 'arm64' && github.event.inputs.build_arm64 != 'false' }}
+        uses: docker/setup-qemu-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute image tags
+        id: tags
+        run: |
+          SHORT_SHA=${GITHUB_SHA:0:7}
+          echo "short_sha=${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+          IMAGE="ghcr.io/${GITHUB_REPOSITORY,,}"   # registry names must be lowercase
+          TAGS="${IMAGE}:sha-${SHORT_SHA}-${{ matrix.arch }}"
+          CUSTOM="${{ github.event.inputs.image_tag }}"
+          if [ -n "$CUSTOM" ]; then
+            CUSTOM_CLEAN=$(echo "$CUSTOM" | tr -cd 'a-zA-Z0-9._-')
+            TAGS="${TAGS},${IMAGE}:${CUSTOM_CLEAN}-${{ matrix.arch }}"
+          fi
+          echo "tags=${TAGS}" >> "$GITHUB_OUTPUT"
+          echo "Pushing: ${TAGS}"
+
+      - name: Build and push
+        if: ${{ !(matrix.arch == 'arm64' && github.event.inputs.build_arm64 == 'false') }}
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.router
+          platforms: ${{ matrix.platform }}
+          push: true
+          tags: ${{ steps.tags.outputs.tags }}
+          cache-from: type=gha,scope=${{ matrix.platform }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.platform }}
+
+  manifest:
+    name: publish multi-arch manifest
+    needs: build
+    runs-on: ubuntu-latest
+    if: ${{ needs.build.result == 'success' }}
+    timeout-minutes: 15
+    steps:
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create and push multi-arch manifest
+        run: |
+          set -euo pipefail
+          SHORT_SHA=${GITHUB_SHA:0:7}
+          IMAGE="ghcr.io/${GITHUB_REPOSITORY,,}"   # registry names must be lowercase
+          SOURCES=("${IMAGE}:sha-${SHORT_SHA}-amd64")
+          if docker buildx imagetools inspect "${IMAGE}:sha-${SHORT_SHA}-arm64" >/dev/null 2>&1; then
+            SOURCES+=("${IMAGE}:sha-${SHORT_SHA}-arm64")
+          fi
+          echo "Combining: ${SOURCES[*]}"
+          docker buildx imagetools create -t "${IMAGE}:latest" "${SOURCES[@]}"
+          docker buildx imagetools create -t "${IMAGE}:sha-${SHORT_SHA}" "${SOURCES[@]}"
+          CUSTOM="${{ github.event.inputs.image_tag }}"
+          if [ -n "$CUSTOM" ]; then
+            CUSTOM_CLEAN=$(echo "$CUSTOM" | tr -cd 'a-zA-Z0-9._-')
+            docker buildx imagetools create -t "${IMAGE}:${CUSTOM_CLEAN}" "${SOURCES[@]}"
+          fi

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -80,14 +80,18 @@ jobs:
 
       - name: Compute image tags
         id: tags
+        # pass the dispatch input through an env var, never interpolate it into the
+        # script (script-injection hardening: https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable)
+        env:
+          IMAGE_TAG: ${{ github.event.inputs.image_tag }}
         run: |
           SHORT_SHA=${GITHUB_SHA:0:7}
           echo "short_sha=${SHORT_SHA}" >> "$GITHUB_OUTPUT"
           IMAGE="ghcr.io/${GITHUB_REPOSITORY,,}"   # registry names must be lowercase
           TAGS="${IMAGE}:sha-${SHORT_SHA}-${{ matrix.arch }}"
-          CUSTOM="${{ github.event.inputs.image_tag }}"
-          if [ -n "$CUSTOM" ]; then
-            CUSTOM_CLEAN=$(echo "$CUSTOM" | tr -cd 'a-zA-Z0-9._-')
+          # sanitize and cap so "<custom>-arm64" stays within Docker's 128-char tag limit
+          CUSTOM_CLEAN=$(printf '%s' "$IMAGE_TAG" | tr -cd 'a-zA-Z0-9._-' | cut -c1-120)
+          if [ -n "$CUSTOM_CLEAN" ]; then
             TAGS="${TAGS},${IMAGE}:${CUSTOM_CLEAN}-${{ matrix.arch }}"
           fi
           echo "tags=${TAGS}" >> "$GITHUB_OUTPUT"
@@ -120,6 +124,8 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create and push multi-arch manifest
+        env:
+          IMAGE_TAG: ${{ github.event.inputs.image_tag }}
         run: |
           set -euo pipefail
           SHORT_SHA=${GITHUB_SHA:0:7}
@@ -131,8 +137,9 @@ jobs:
           echo "Combining: ${SOURCES[*]}"
           docker buildx imagetools create -t "${IMAGE}:latest" "${SOURCES[@]}"
           docker buildx imagetools create -t "${IMAGE}:sha-${SHORT_SHA}" "${SOURCES[@]}"
-          CUSTOM="${{ github.event.inputs.image_tag }}"
-          if [ -n "$CUSTOM" ]; then
-            CUSTOM_CLEAN=$(echo "$CUSTOM" | tr -cd 'a-zA-Z0-9._-')
+          # same sanitize+cap as the build step so the custom tag matches
+          # the per-arch custom tags it was built with
+          CUSTOM_CLEAN=$(printf '%s' "$IMAGE_TAG" | tr -cd 'a-zA-Z0-9._-' | cut -c1-120)
+          if [ -n "$CUSTOM_CLEAN" ]; then
             docker buildx imagetools create -t "${IMAGE}:${CUSTOM_CLEAN}" "${SOURCES[@]}"
           fi


### PR DESCRIPTION
## Summary

Adds a `build-image` workflow that builds and publishes multi-arch (**linux/amd64 + linux/arm64**) images from `Dockerfile.router`. Closes #230.

## What it does

- **Triggers**: push to `main`, plus manual `workflow_dispatch` with an optional extra tag (e.g. a release version) and an optional arm64 toggle.
- **Native per-arch builds** (no QEMU emulation for the long Rust compile):
  - `linux/amd64` → `ubuntu-latest`
  - `linux/arm64` → `ubuntu-24.04-arm` (GitHub ARM runner public preview)
- **Publishes to GHCR** with a multi-arch manifest:
  - `ghcr.io/<owner>/<repo>:latest`
  - `ghcr.io/<owner>/<repo>:sha-<7-char-commit>`
  - `ghcr.io/<owner>/<repo>:<custom-tag>` (manual dispatch only)
  - per-arch tags `sha-<commit>-amd64` / `-arm64`, kept for debugging
- **Caching**: buildkit `type=gha`, scoped per platform, so routine rebuilds are much faster than cold starts.

## How it was tested

Ran end-to-end on a fork — both arch jobs + the manifest job green:

- Run: https://github.com/Potterluo/router/actions/runs/33492459562
- Published manifest verified to contain both platforms:

```bash
docker buildx imagetools inspect ghcr.io/potterluo/router:latest
# -> linux/amd64 ... linux/arm64
```

Also validated with `actionlint` (clean).

## Notes / review asks

- Image name defaults to `ghcr.io/${{ github.repository }}` (= `ghcr.io/vllm-project/router`). If you'd rather publish to Docker Hub or a different namespace (e.g. `vllm-router` under the vllm org), say the word and I'll adjust the default.
- `ubuntu-24.04-arm` is GitHub's ARM runner public preview — fine for this public repo. As a fallback the workflow already runs the QEMU setup step for arm64, so switching the matrix runner to `ubuntu-latest` would build via emulation instead if ARM runners are ever unavailable (private mirrors etc.).
- The action versions (`checkout@v4`, `docker/*@v3|v6`) currently print Node 20 deprecation warnings and run on a Node 24 fallback; happy to bump them in this PR or a follow-up as the maintainers prefer.
- No changes to `Dockerfile.router` itself — the diff is a single new workflow file.