### PR TITLE
fix: skip unhealthy workers in proxy GET endpoints

### DIFF
--- a/src/routers/http/router.rs
+++ b/src/routers/http/router.rs
@@ -338,11 +338,12 @@ impl Router {
     }
 
     fn select_first_worker(&self) -> Result<String, String> {
+        // Prefer a healthy worker so proxy GETs (e.g. /v1/models) don't 500
+        // when the first registered worker is temporarily down.
         let workers = self.worker_registry.get_all();
-        if workers.is_empty() {
-            Err("No workers are available".to_string())
-        } else {
-            Ok(workers[0].url().to_string())
+        match workers.into_iter().find(|w| w.is_healthy()) {
+            Some(worker) => Ok(worker.url().to_string()),
+            None => Err("No healthy workers are available".to_string()),
         }
     }
 
@@ -1826,6 +1827,30 @@ mod tests {
         let url = result.unwrap();
         // DashMap doesn't guarantee order, so just check we get one of the workers
         assert!(url == "http://worker1:8080" || url == "http://worker2:8080");
+    }
+
+    #[test]
+    fn test_select_first_worker_skips_unhealthy() {
+        let router = create_test_regular_router();
+        // Mark worker1 unhealthy; select_first_worker must not return it.
+        for w in router.worker_registry.get_all() {
+            if w.url() == "http://worker1:8080" {
+                w.set_healthy(false);
+            }
+        }
+        let result = router.select_first_worker();
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "http://worker2:8080");
+    }
+
+    #[test]
+    fn test_select_first_worker_all_unhealthy() {
+        let router = create_test_regular_router();
+        for w in router.worker_registry.get_all() {
+            w.set_healthy(false);
+        }
+        let result = router.select_first_worker();
+        assert!(result.is_err());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Purpose

Fixes #135 — `/v1/models` (and other proxy GET endpoints) returns 500 when any worker is unhealthy.

`select_first_worker` returned the first registered worker without checking health state. `worker_registry.get_all()` returns all workers including unhealthy ones, so when the first worker was temporarily down, `proxy_get_request` proxied to a dead worker and returned 500. This affected `/v1/models`, `/get_server_info`, and `/get_model_info` — all of which route through `proxy_get_request` → `select_first_worker`.

Root-cause fix in the shared helper: filter for a healthy worker (`is_healthy()`) before returning; fall back to the existing error path when none are healthy.

## Test Plan

New unit tests in `routers::http::router::tests`:
- `test_select_first_worker_skips_unhealthy` — marks worker1 unhealthy, asserts worker2 is selected
- `test_select_first_worker_all_unhealthy` — marks all unhealthy, asserts error

## Test Result

```
running 3 tests
test routers::http::router::tests::test_select_first_worker_regular ... ok
test routers::http::router::tests::test_select_first_worker_skips_unhealthy ... ok
test routers::http::router::tests::test_select_first_worker_all_unhealthy ... ok

test result: ok. 3 passed; 0 failed
```

Built with `cargo test --lib routers::http::router::tests::test_select_first_worker` (rust:latest container, aarch64).