### PR TITLE
Spread stateless consistent-hash requests across healthy workers

### DIFF
--- a/src/policies/consistent_hash.rs
+++ b/src/policies/consistent_hash.rs
@@ -5,6 +5,7 @@
 //! consistently routed to the same worker for better cache locality.
 
 use std::collections::BTreeMap;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, RwLock};
 
 use tracing::debug;
@@ -30,6 +31,9 @@ pub struct ConsistentHashPolicy {
     hash_ring: RwLock<BTreeMap<u64, String>>,
     /// Current set of workers (for detecting changes)
     current_workers: RwLock<Vec<String>>,
+    /// Stateless requests have no affinity key. Spread them over healthy
+    /// workers instead of hashing the empty fallback to one worker forever.
+    stateless_counter: AtomicUsize,
 }
 
 impl ConsistentHashPolicy {
@@ -37,7 +41,22 @@ impl ConsistentHashPolicy {
         Self {
             hash_ring: RwLock::new(BTreeMap::new()),
             current_workers: RwLock::new(Vec::new()),
+            stateless_counter: AtomicUsize::new(0),
         }
+    }
+
+    fn select_stateless_worker(
+        &self,
+        workers: &[Arc<dyn Worker>],
+        healthy_indices: &[usize],
+    ) -> usize {
+        let offset = self.stateless_counter.fetch_add(1, Ordering::Relaxed);
+        let selected_idx = healthy_indices[offset % healthy_indices.len()];
+        let worker_url = workers[selected_idx].url();
+        workers[selected_idx].increment_processed();
+        RouterMetrics::record_processed_request(worker_url);
+        RouterMetrics::record_policy_decision("consistent_hash_stateless_round_robin", worker_url);
+        selected_idx
     }
 
     /// MurmurHash64A implementation from Facebook's mcrouter/lib/fbi/hash.c
@@ -340,6 +359,24 @@ impl LoadBalancingPolicy for ConsistentHashPolicy {
             return None;
         }
 
+        // An explicitly supplied affinity key must never be silently treated
+        // as stateless. This catches callers that intended sticky routing but
+        // accidentally emitted an empty header.
+        if headers
+            .and_then(|values| values.get("x-session-id"))
+            .is_some_and(String::is_empty)
+        {
+            return None;
+        }
+
+        // Chat requests without session_params deliberately expose an empty
+        // routing string. Hashing it maps every stateless request to the same
+        // worker. Use bounded round-robin over the current healthy set.
+        let header_key = headers.and_then(hash_key::extract_hash_key_from_headers);
+        if request_text.map_or(true, str::is_empty) && header_key.is_none() {
+            return Some(self.select_stateless_worker(workers, &healthy_indices));
+        }
+
         // Update hash ring if needed
         self.update_hash_ring(workers);
 
@@ -477,6 +514,7 @@ impl LoadBalancingPolicy for ConsistentHashPolicy {
             let mut current = self.current_workers.write().unwrap();
             current.clear();
         }
+        self.stateless_counter.store(0, Ordering::Relaxed);
         info!("Consistent hash policy reset - hash ring cleared");
     }
 

--- a/tests/test_consistent_hash_policy.rs
+++ b/tests/test_consistent_hash_policy.rs
@@ -58,6 +58,43 @@ mod consistent_hash_policy_tests {
     }
 
     #[test]
+    fn test_concurrent_stateless_requests_use_every_healthy_worker() {
+        let policy = Arc::new(ConsistentHashPolicy::new());
+        let workers = Arc::new(create_test_workers());
+        let selections = (0..64)
+            .map(|_| {
+                let policy = Arc::clone(&policy);
+                let workers = Arc::clone(&workers);
+                std::thread::spawn(move || {
+                    policy
+                        .select_worker_with_headers(workers.as_slice(), Some(""), None)
+                        .expect("a healthy worker must be selected")
+                })
+            })
+            .map(|thread| thread.join().expect("routing thread must not panic"))
+            .collect::<Vec<_>>();
+
+        for worker_idx in 0..workers.len() {
+            assert!(
+                selections.contains(&worker_idx),
+                "stateless requests never reached worker {worker_idx}: {selections:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_explicit_empty_session_id_fails_closed() {
+        let policy = ConsistentHashPolicy::new();
+        let workers = create_test_workers();
+        let headers = create_headers(&[("x-session-id", "")]);
+
+        assert_eq!(
+            policy.select_worker_with_headers(&workers, Some(""), Some(&headers)),
+            None
+        );
+    }
+
+    #[test]
     fn test_consistent_routing_same_session() {
         let policy = ConsistentHashPolicy::new();
         let workers = create_test_workers();


### PR DESCRIPTION
## Problem
The consistent-hash policy hashes an empty extracted routing key. Stateless chat requests therefore collapse onto one replica even when every replica is healthy.

## Change
- round-robin requests that contain neither an affinity header nor request text
- preserve consistent hashing for every nonempty affinity key
- fail closed when `X-Session-ID` is explicitly supplied but empty

## Tests
`cargo test --test test_consistent_hash_policy`

26 passed, including 64 concurrent stateless selections across every healthy worker and existing sticky-routing coverage. `cargo fmt` passes.