### PR TITLE
[Bugfix][Build] Bump base image to bookworm

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -111,7 +111,7 @@ steps:
                 - |
                   apt-get update && apt-get install -y pkg-config libssl-dev protobuf-compiler python3 curl
                   curl -LsSf https://astral.sh/uv/install.sh | sh
-                  export PATH="$HOME/.local/bin:$PATH"
+                  source /root/.local/bin/env
                   uv venv /tmp/venv --seed
                   . /tmp/venv/bin/activate
                   uv pip install -U pip setuptools wheel setuptools-rust build
@@ -186,7 +186,7 @@ steps:
                 - |
                   apt-get update && apt-get install -y pkg-config libssl-dev protobuf-compiler python3 curl
                   curl -LsSf https://astral.sh/uv/install.sh | sh
-                  export PATH="$HOME/.local/bin:$PATH"
+                  source /root/.local/bin/env
                   uv venv /tmp/venv --seed
                   . /tmp/venv/bin/activate
                   uv pip install -U pip setuptools wheel setuptools-rust

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,7 +2,7 @@
 # This pipeline runs automated checks, builds, and tests for the vLLM Router project
 
 env:
-  RUST_IMAGE: "rust:1.95.0-bullseye"
+  RUST_IMAGE: "rust:1.95.0-bookworm"
   # Pin the ROCm nightly used by the MoRI lane so dependency changes are explicit.
   ROCM_VLLM_IMAGE: "vllm/vllm-openai-rocm:nightly@sha256:d22922d540810d90c5a3eafe91d3b4a62c2b881f3e990d0b7180b2875a5d176d"
   # Disable incremental compilation for consistent CI builds

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -109,8 +109,12 @@ steps:
                 - bash
                 - -c
                 - |
-                  apt-get update && apt-get install -y pkg-config libssl-dev protobuf-compiler python3 python3-pip
-                  pip3 install -U pip setuptools wheel setuptools-rust build
+                  apt-get update && apt-get install -y pkg-config libssl-dev protobuf-compiler python3 curl
+                  curl -LsSf https://astral.sh/uv/install.sh | sh
+                  export PATH="$HOME/.local/bin:$PATH"
+                  uv venv /tmp/venv --seed
+                  . /tmp/venv/bin/activate
+                  uv pip install -U pip setuptools wheel setuptools-rust build
                   python3 -m build
         artifact_paths:
           - "dist/*.whl"
@@ -180,10 +184,14 @@ steps:
                 - bash
                 - -c
                 - |
-                  apt-get update && apt-get install -y pkg-config libssl-dev protobuf-compiler python3 python3-pip
-                  pip3 install -U pip setuptools wheel setuptools-rust
-                  pip3 install -e .[dev]
-                  pip3 install pytest pytest-cov pytest-asyncio
+                  apt-get update && apt-get install -y pkg-config libssl-dev protobuf-compiler python3 curl
+                  curl -LsSf https://astral.sh/uv/install.sh | sh
+                  export PATH="$HOME/.local/bin:$PATH"
+                  uv venv /tmp/venv --seed
+                  . /tmp/venv/bin/activate
+                  uv pip install -U pip setuptools wheel setuptools-rust
+                  uv pip install -e .[dev]
+                  uv pip install pytest pytest-cov pytest-asyncio
                   pytest py_test/ -v --ignore=py_test/e2e --cov=vllm_router --cov-report=xml --cov-report=term
         artifact_paths:
           - "coverage.xml"

--- a/Dockerfile.router
+++ b/Dockerfile.router
@@ -1,5 +1,5 @@
 # Dockerfile for vllm-router
-FROM rustlang/rust:nightly-bullseye as rust-builder
+FROM rustlang/rust:nightly-bookworm AS rust-builder
 
 # Install system dependencies
 RUN apt-get update && apt-get install -y \
@@ -19,7 +19,7 @@ COPY src ./src
 RUN cargo build --release
 
 # Python stage with Rust binary
-FROM python:3.12-slim-bullseye
+FROM python:3.12-slim-bookworm
 
 # Install system dependencies
 RUN apt-get update && apt upgrade -y && apt-get install -y \


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Bullseye is EOL and caused failing builds. Also, pytest ci fails for similar reasons and we instead switch to uv installation to avoid this.

See e.g. this failing build and pytest: https://buildkite.com/vllm/router/builds/759/canvas?sid=01a07ad2-ac4c-40a2-9a23-c9f5a211f98d&tab=output

FYI trivy fails fixed in https://github.com/vllm-project/router/pull/212.

## Test Plan

CI passes

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
