### PR TITLE
[CI]: Fix CI failures from EOL bullseye base images

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -109,9 +109,11 @@ steps:
                 - bash
                 - -c
                 - |
-                  apt-get update && apt-get install -y pkg-config libssl-dev protobuf-compiler python3 python3-pip
-                  pip3 install -U pip setuptools wheel setuptools-rust build
-                  python3 -m build
+                  apt-get update && apt-get install -y pkg-config libssl-dev protobuf-compiler python3 python3-pip python3-dev python3-venv
+                  python3 -m venv /tmp/venv
+                  source /tmp/venv/bin/activate
+                  pip install -U pip setuptools wheel setuptools-rust build
+                  python -m build
         artifact_paths:
           - "dist/*.whl"
           - "dist/*.tar.gz"
@@ -180,10 +182,12 @@ steps:
                 - bash
                 - -c
                 - |
-                  apt-get update && apt-get install -y pkg-config libssl-dev protobuf-compiler python3 python3-pip
-                  pip3 install -U pip setuptools wheel setuptools-rust
-                  pip3 install -e .[dev]
-                  pip3 install pytest pytest-cov pytest-asyncio
+                  apt-get update && apt-get install -y pkg-config libssl-dev protobuf-compiler python3 python3-pip python3-dev python3-venv
+                  python3 -m venv /tmp/venv
+                  source /tmp/venv/bin/activate
+                  pip install -U pip setuptools wheel setuptools-rust
+                  pip install -e .[dev]
+                  pip install pytest pytest-cov pytest-asyncio
                   pytest py_test/ -v --ignore=py_test/e2e --cov=vllm_router --cov-report=xml --cov-report=term
         artifact_paths:
           - "coverage.xml"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,8 +2,6 @@
 # This pipeline runs automated checks, builds, and tests for the vLLM Router project
 
 env:
-  # Debian 11 (bullseye) LTS ended 2026-08-31; bullseye-security metadata is
-  # expired, which breaks `apt-get update` and the Python wheel build job.
   RUST_IMAGE: "rust:1.95.0-bookworm"
   # Pin the ROCm nightly used by the MoRI lane so dependency changes are explicit.
   ROCM_VLLM_IMAGE: "vllm/vllm-openai-rocm:nightly@sha256:d22922d540810d90c5a3eafe91d3b4a62c2b881f3e990d0b7180b2875a5d176d"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,7 +2,9 @@
 # This pipeline runs automated checks, builds, and tests for the vLLM Router project
 
 env:
-  RUST_IMAGE: "rust:1.95.0-bullseye"
+  # Debian 11 (bullseye) LTS ended 2026-08-31; bullseye-security metadata is
+  # expired, which breaks `apt-get update` and the Python wheel build job.
+  RUST_IMAGE: "rust:1.95.0-bookworm"
   # Pin the ROCm nightly used by the MoRI lane so dependency changes are explicit.
   ROCM_VLLM_IMAGE: "vllm/vllm-openai-rocm:nightly@sha256:d22922d540810d90c5a3eafe91d3b4a62c2b881f3e990d0b7180b2875a5d176d"
   # Disable incremental compilation for consistent CI builds

--- a/.buildkite/release-pipeline.yml
+++ b/.buildkite/release-pipeline.yml
@@ -95,8 +95,8 @@ steps:
     command: |
       buildkite-agent artifact download "target/release/vllm-router" .
       chmod +x target/release/vllm-router
-      docker run --rm -v "$$PWD:/workdir" -w /workdir debian:bullseye ./target/release/vllm-router --version
-      docker run --rm -v "$$PWD:/workdir" -w /workdir debian:bullseye ./target/release/vllm-router --help
+      docker run --rm -v "$$PWD:/workdir" -w /workdir debian:bookworm ./target/release/vllm-router --version
+      docker run --rm -v "$$PWD:/workdir" -w /workdir debian:bookworm ./target/release/vllm-router --help
     agents:
       queue: "cpu_queue_release"
 

--- a/Dockerfile.router
+++ b/Dockerfile.router
@@ -26,8 +26,6 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y \
     curl \
     && rm -rf /var/lib/apt/lists/*
 
-RUN pip3 install --upgrade pip
-
 # Create app directory
 WORKDIR /app
 
@@ -42,8 +40,14 @@ COPY py_src ./py_src
 COPY pyproject.toml ./
 COPY README.md ./
 
-# Install Python dependencies if using Python launcher
-RUN pip install setuptools-rust wheel build requests
+# Install the Python launcher's runtime dependency, then drop pip from the
+# final image: the router does not need pip at runtime, and pip's vendored
+# msgpack/setuptools trip vulnerability scanners (GHSA-6v7p-g79w-8964,
+# CVE-2025-47273, CVE-2026-59890). Removing ensurepip also removes the
+# bundled pip wheel, which carries the same vendored copies.
+RUN pip3 install --no-cache-dir requests \
+    && pip3 uninstall -y pip \
+    && rm -rf /usr/local/lib/python3.12/ensurepip
 
 # Expose default router port
 EXPOSE 8080

--- a/Dockerfile.router
+++ b/Dockerfile.router
@@ -22,7 +22,7 @@ RUN cargo build --release
 FROM python:3.12-slim-bookworm
 
 # Install system dependencies
-RUN apt-get update && apt upgrade -y && apt-get install -y \
+RUN apt-get update && apt-get upgrade -y && apt-get install -y \
     curl \
     && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile.router
+++ b/Dockerfile.router
@@ -1,5 +1,5 @@
 # Dockerfile for vllm-router
-FROM rustlang/rust:nightly-bullseye as rust-builder
+FROM rustlang/rust:nightly-bookworm as rust-builder
 
 # Install system dependencies
 RUN apt-get update && apt-get install -y \
@@ -19,7 +19,7 @@ COPY src ./src
 RUN cargo build --release
 
 # Python stage with Rust binary
-FROM python:3.12-slim-bullseye
+FROM python:3.12-slim-bookworm
 
 # Install system dependencies
 RUN apt-get update && apt upgrade -y && apt-get install -y \


### PR DESCRIPTION
## Description

Debian 11 (bullseye) LTS ended on 2026-08-31 and the `bullseye-security` repository is no longer refreshed. Its `InRelease` metadata has now expired, so `apt-get update` fails inside any bullseye-based image:

```
E: Release file for http://deb.debian.org/debian-security/dists/bullseye-security/InRelease
is expired (invalid since 11h 24min 17s). Updates for this repository will not be applied.
```

This broke the `:python: Build Python Wheel` Buildkite job (`apt-get update && apt-get install python3-pip` chain stops → `pip3: command not found`), e.g. [router build #773](https://buildkite.com/vllm/router/builds/773), with all downstream jobs failing as `waiting_failed`. The same expired repos also broke the Trivy GHA job at the `docker build` step on every branch, including `main`.

## Changes

**1. Move off EOL bullseye (`57185c9`, `0263c2c`)**
- `.buildkite/pipeline.yml`: `RUST_IMAGE` `rust:1.95.0-bullseye` → `rust:1.95.0-bookworm`
- `Dockerfile.router`: `rustlang/rust:nightly-bullseye` → `nightly-bookworm`; `python:3.12-slim-bullseye` → `python:3.12-slim-bookworm`
- `.buildkite/release-pipeline.yml`: smoke-test the release binary on `debian:bookworm` (binary is built on manylinux_2_28 / glibc 2.28, still within bookworm's glibc 2.36)

**2. Use a venv for pip on bookworm (`dd9603f`)**
Debian 12 marks the system Python as externally managed (PEP 668), so bare `pip3 install` fails with `externally-managed-environment` ([build #778](https://buildkite.com/vllm/router/builds/778)). The wheel-build and python-test jobs now install `python3-venv` (+ explicit `python3-dev` for the PyO3 build) and run `pip`/`python`/`pytest` inside a venv. Also uses `apt-get upgrade` instead of `apt upgrade` in `Dockerfile.router` per review (apt's CLI is not stable for scripting).

**3. Drop pip from the runtime image (`2416eb2`)**
The Trivy scan of the built image flagged pip's own vendored `msgpack` 1.1.2 (GHSA-6v7p-g79w-8964, HIGH) and `setuptools` 70.3.0 (CVE-2025-47273 HIGH, CVE-2026-59890 MEDIUM). These live inside pip's `_vendor` tree, so no surrounding package change can clear them, and pip will not bump the vendored setuptools ([pypa/pip#14031](https://github.com/pypa/pip/issues/14031)). The runtime image only needs `requests` for the optional Python launcher; the CMD runs the Rust binary directly. The final stage now installs `requests`, then uninstalls pip entirely and removes `ensurepip`'s bundled wheel (which carries the same vendored copies). This also drops the `setuptools-rust`/`wheel`/`build` build tools from the image.

## Verification

- Buildkite pre-merge pipeline passes on this branch (wheel build, python tests included)
- Trivy GHA job passes on this branch (`2416eb2`) — previously failing on all branches, including `main`
- Replacement image tags all exist on Docker Hub: `rust:1.95.0-bookworm`, `rustlang/rust:nightly-bookworm`, `python:3.12-slim-bookworm`, `debian:bookworm`
- Rust version is unchanged (1.95.0 / nightly); only the Debian suite changes