### PR TITLE
[Bugfix] Respect explicit token acquisition timeout

### DIFF
--- a/src/core/token_bucket.rs
+++ b/src/core/token_bucket.rs
@@ -101,32 +101,34 @@ impl TokenBucket {
         );
 
         // Wait for tokens to be available
-        tokio::time::timeout(wait_time, async {
-            loop {
-                // Check if we can acquire now
-                if self.try_acquire(tokens).await.is_ok() {
-                    return;
-                }
-
-                // Wait for notification or small interval
-                tokio::select! {
-                    _ = self.notify.notified() => {},
-                    _ = tokio::time::sleep(Duration::from_millis(10)) => {},
-                }
-            }
-        })
-        .await?;
+        tokio::time::timeout(wait_time, self.wait_for_tokens(tokens)).await?;
 
         Ok(())
     }
 
     /// Acquire tokens with custom timeout
+    ///
+    /// Waiting under contention uses the caller's budget, rather than an
+    /// estimate of the time until the next refill.
     pub async fn acquire_timeout(
         &self,
         tokens: f64,
         timeout: Duration,
     ) -> Result<(), tokio::time::error::Elapsed> {
-        tokio::time::timeout(timeout, self.acquire(tokens)).await?
+        tokio::time::timeout(timeout, self.wait_for_tokens(tokens)).await
+    }
+
+    async fn wait_for_tokens(&self, tokens: f64) {
+        loop {
+            if self.try_acquire(tokens).await.is_ok() {
+                return;
+            }
+
+            tokio::select! {
+                _ = self.notify.notified() => {},
+                _ = tokio::time::sleep(Duration::from_millis(10)) => {},
+            }
+        }
     }
 
     /// Return tokens to the bucket (for cancelled requests)

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -16,6 +16,10 @@ use tracing_opentelemetry::OpenTelemetrySpanExt;
 
 pub use crate::core::token_bucket::TokenBucket;
 
+#[cfg(test)]
+#[path = "middleware_queue_timeout_tests.rs"]
+mod queue_timeout_tests;
+
 use crate::metrics::RouterMetrics;
 use crate::server::AppState;
 

--- a/src/middleware_queue_timeout_tests.rs
+++ b/src/middleware_queue_timeout_tests.rs
@@ -1,12 +1,31 @@
 use super::*;
 
 async fn queue_results(queue_timeout: Duration, age: Duration) -> [Result<(), StatusCode>; 2] {
+    let now = Instant::now();
+    queue_results_with_timestamp(queue_timeout, age, now, now.checked_sub(age)).await
+}
+
+async fn queue_results_with_timestamp(
+    queue_timeout: Duration,
+    age: Duration,
+    now: Instant,
+    backdated: Option<Instant>,
+) -> [Result<(), StatusCode>; 2] {
+    let queued_at = match backdated {
+        Some(queued_at) => queued_at,
+        None => {
+            // Preserve the requested age even if the clock cannot be backdated.
+            // Falling back to `now` without waiting would change the test case.
+            tokio::time::sleep(age).await;
+            now
+        }
+    };
+    // Start token replenishment only after any fallback aging delay.
     let bucket = Arc::new(TokenBucket::new(1, 1));
     bucket.try_acquire(1.0).await.unwrap();
     let (tx, rx) = mpsc::channel(2);
     let (first_tx, first_rx) = oneshot::channel();
     let (second_tx, second_rx) = oneshot::channel();
-    let queued_at = Instant::now() - age;
     for permit_tx in [first_tx, second_tx] {
         tx.send(QueuedRequest {
             queued_at,
@@ -23,6 +42,20 @@ async fn queue_results(queue_timeout: Duration, age: Duration) -> [Result<(), St
     })
     .await
     .expect("queue permits must resolve within the test deadline")
+}
+
+#[tokio::test]
+async fn unrepresentable_backdate_preserves_age_without_refilling_bucket() {
+    assert_eq!(
+        queue_results_with_timestamp(
+            Duration::from_secs(4),
+            Duration::from_millis(3970),
+            Instant::now(),
+            None,
+        )
+        .await,
+        [Err(StatusCode::REQUEST_TIMEOUT); 2],
+    );
 }
 
 #[tokio::test]

--- a/src/middleware_queue_timeout_tests.rs
+++ b/src/middleware_queue_timeout_tests.rs
@@ -1,0 +1,58 @@
+use super::*;
+
+async fn queue_results(queue_timeout: Duration, age: Duration) -> [Result<(), StatusCode>; 2] {
+    let bucket = Arc::new(TokenBucket::new(1, 1));
+    bucket.try_acquire(1.0).await.unwrap();
+    let (tx, rx) = mpsc::channel(2);
+    let (first_tx, first_rx) = oneshot::channel();
+    let (second_tx, second_rx) = oneshot::channel();
+    let queued_at = Instant::now() - age;
+    for permit_tx in [first_tx, second_tx] {
+        tx.send(QueuedRequest {
+            queued_at,
+            permit_tx,
+        })
+        .await
+        .unwrap();
+    }
+    drop(tx);
+    let processor = QueueProcessor::new(bucket, rx, queue_timeout);
+    tokio::time::timeout(Duration::from_secs(6), async {
+        let ((), first, second) = tokio::join!(processor.run(), first_rx, second_rx);
+        [first.unwrap(), second.unwrap()]
+    })
+    .await
+    .expect("queue permits must resolve within the test deadline")
+}
+
+#[tokio::test]
+async fn queued_waiters_can_use_the_configured_budget() {
+    assert_eq!(
+        queue_results(Duration::from_secs(4), Duration::ZERO).await,
+        [Ok(()), Ok(())],
+    );
+}
+
+#[tokio::test]
+async fn queue_short_timeout_still_rejects_waiters() {
+    assert_eq!(
+        queue_results(Duration::from_millis(30), Duration::ZERO).await,
+        [Err(StatusCode::REQUEST_TIMEOUT); 2],
+    );
+}
+
+#[tokio::test]
+async fn already_expired_queue_entries_are_rejected() {
+    assert_eq!(
+        queue_results(Duration::from_secs(4), Duration::from_secs(5)).await,
+        [Err(StatusCode::REQUEST_TIMEOUT); 2],
+    );
+}
+
+#[tokio::test]
+async fn time_already_spent_in_queue_is_not_granted_again() {
+    assert_eq!(
+        queue_results(Duration::from_secs(4), Duration::from_millis(3970)).await,
+        [Err(StatusCode::REQUEST_TIMEOUT); 2],
+    );
+}

--- a/tests/queue_timeout_http_test.rs
+++ b/tests/queue_timeout_http_test.rs
@@ -1,0 +1,79 @@
+//! Exercise the production queue and admission middleware over loopback HTTP.
+
+use axum::{middleware::from_fn_with_state, routing::post, Router};
+use std::{sync::Arc, time::Duration};
+use tokio::{sync::mpsc, task::JoinHandle};
+use vllm_router_rs::{
+    config::RouterConfig,
+    middleware::{concurrency_limit_middleware, QueueProcessor},
+    routers::RouterFactory,
+    server::{AppContext, AppState},
+};
+
+struct AbortOnDrop(JoinHandle<()>);
+
+impl Drop for AbortOnDrop {
+    fn drop(&mut self) {
+        self.0.abort();
+    }
+}
+
+#[tokio::test]
+async fn queued_http_requests_survive_more_than_one_refill_wait() {
+    let context = Arc::new(
+        AppContext::new(
+            RouterConfig::default(),
+            reqwest::Client::new(),
+            1,
+            Some(1),
+            vec![],
+        )
+        .unwrap(),
+    );
+    let router = RouterFactory::create_router(&context).await.unwrap();
+    let (queue_tx, queue_rx) = mpsc::channel(2);
+    let processor = QueueProcessor::new(
+        Arc::clone(&context.rate_limiter),
+        queue_rx,
+        Duration::from_secs(4),
+    );
+    let mut queue_task = AbortOnDrop(tokio::spawn(processor.run()));
+    let state = Arc::new(AppState {
+        router: Arc::from(router),
+        context: Arc::clone(&context),
+        concurrency_queue_tx: Some(queue_tx),
+        router_manager: None,
+    });
+    let app = Router::new()
+        .route(
+            "/v1/responses",
+            post(|| async {
+                // Prevent an immediately returned token from masking contention.
+                tokio::time::sleep(Duration::from_millis(300)).await;
+                "admitted"
+            }),
+        )
+        .layer(from_fn_with_state(state, concurrency_limit_middleware));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let mut server = AbortOnDrop(tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    }));
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(6))
+        .build()
+        .unwrap();
+    context.rate_limiter.try_acquire(1.0).await.unwrap();
+    let url = format!("http://{address}/v1/responses");
+    let (first, second) = tokio::join!(client.post(&url).send(), client.post(&url).send(),);
+    let first = first.unwrap();
+    let second = second.unwrap();
+    let statuses = (first.status(), second.status());
+    let bodies = (first.text().await.unwrap(), second.text().await.unwrap());
+    server.0.abort();
+    assert!((&mut server.0).await.unwrap_err().is_cancelled());
+    queue_task.0.abort();
+    let _ = (&mut queue_task.0).await;
+    assert_eq!(statuses, (reqwest::StatusCode::OK, reqwest::StatusCode::OK));
+    assert_eq!(bodies, ("admitted".to_owned(), "admitted".to_owned()));
+}

--- a/tests/token_bucket_timeout_probe.rs
+++ b/tests/token_bucket_timeout_probe.rs
@@ -1,0 +1,68 @@
+//! Local regression probe for the explicit acquisition timeout budget.
+
+use std::time::{Duration, Instant};
+use vllm_router_rs::core::token_bucket::TokenBucket;
+
+#[tokio::test]
+async fn concurrent_waiters_can_use_the_full_explicit_budget() {
+    let bucket = TokenBucket::new(1, 1);
+    bucket.try_acquire(1.0).await.unwrap();
+    let started = Instant::now();
+    let budget = Duration::from_secs(4);
+    let (first, second) = tokio::join!(
+        bucket.acquire_timeout(1.0, budget),
+        bucket.acquire_timeout(1.0, budget),
+    );
+    eprintln!(
+        "elapsed={:?}; first={first:?}; second={second:?}",
+        started.elapsed()
+    );
+    assert!(
+        first.is_ok() && second.is_ok(),
+        "both tokens refill within the four-second budget"
+    );
+}
+
+#[tokio::test]
+async fn unavailable_tokens_still_obey_short_timeout() {
+    let bucket = TokenBucket::new(1, 1);
+    bucket.try_acquire(1.0).await.unwrap();
+    let result = tokio::time::timeout(
+        Duration::from_secs(2),
+        bucket.acquire_timeout(1.0, Duration::from_millis(30)),
+    )
+    .await
+    .expect("the explicit timeout must finish without waiting for a refill");
+    assert!(result.is_err());
+    assert!(bucket.try_acquire(1.0).await.is_err());
+}
+
+#[tokio::test]
+async fn returned_tokens_wake_waiting_acquisition() {
+    let bucket = TokenBucket::new(1, 1);
+    bucket.try_acquire(1.0).await.unwrap();
+    let (result, ()) = tokio::join!(
+        bucket.acquire_timeout(1.0, Duration::from_millis(500)),
+        async {
+            tokio::time::sleep(Duration::from_millis(30)).await;
+            bucket.return_tokens(1.0).await;
+        },
+    );
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn dropping_waiter_does_not_consume_future_tokens() {
+    let bucket = TokenBucket::new(1, 1);
+    bucket.try_acquire(1.0).await.unwrap();
+    {
+        let waiter = bucket.acquire_timeout(1.0, Duration::from_secs(4));
+        tokio::pin!(waiter);
+        tokio::select! {
+            result = &mut waiter => panic!("acquisition finished before cancellation: {result:?}"),
+            _ = tokio::time::sleep(Duration::from_millis(30)) => {},
+        }
+    }
+    bucket.return_tokens(1.0).await;
+    assert!(bucket.try_acquire(1.0).await.is_ok());
+}


### PR DESCRIPTION
## Purpose

Fixes #247 by honoring the caller's explicit token acquisition deadline under
contention. Previously, acquire_timeout wrapped acquire, whose initial
estimated-refill timeout could expire much sooner than the configured queue
budget. QueueProcessor could consequently send HTTP 408 despite enough time
remaining for token refills.

Share the existing polling helper between the two methods. Preserve legacy
acquire behavior, token refill policy and all public signatures. No new
dependencies, queue-capacity changes, FIFO promises or drain behavior.

## Test Plan

```bash
cargo +1.95.0 test --locked --lib --test api_endpoints_test --test token_bucket_timeout_probe --test queue_timeout_http_test -- --test-threads=4
cargo +1.95.0 fmt --check
cargo +1.95.0 clippy --locked --all-targets --all-features -- -D warnings
```

## Test Result

- Eleven focused tests pass locally on Linux/WSL: 9 added plus 2 existing.
- Complete library target: 488 passed. Complete API endpoint test target:
  47 passed. The library count includes the focused library cases above.
- Latest CI-pinned Rust 1.95.0 run on the independent submission checkout:
  488 + 47 + 1 HTTP + 4 token tests = 540 passed, no failures/ignored/filtered.
- Same real loopback HTTP regression on unchanged baseline production source:
  two 408 responses; candidate: two 200 responses and complete expected bodies.
- Covers contention, short deadlines, returned tokens, dropped waiters,
  expired queue entries and time already spent queued.
- Full cargo fmt --check and strict all-target/all-feature Clippy with
  -D warnings pass under the CI-pinned Rust 1.95.0, without lint allowances.
  Diff whitespace checks pass. This was local, not an upstream CI run.
- Rust 1.98.0 reports four baseline lint categories; clean-baseline comparison
  reproduced them. No lint-policy changes included. Behavioral tests listed
  above have now also passed under 1.95.0. Neither local run is upstream CI.

Tests use the production queue and middleware with a local terminal handler;
no real inference/GPU or full repository/performance validation is claimed.
Implementation and verification are AI-assisted with Codex. The contributor
confirmed human review and personally signed off commit
`520303f1052ea01285e1906ea1c68d01b31a902d`.

## Description checklist

- [x] Purpose and related issue provided.
- [x] Reproducible test commands provided.
- [x] Before/after results and validation boundaries provided.
