### PR TITLE
[Feature] Add EPD routing with JSON metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4843,6 +4843,7 @@ dependencies = [
  "rustls",
  "serde",
  "serde_json",
+ "sha2",
  "strum",
  "tempfile",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ tower-http = { version = "0.6", features = [
 ] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+sha2 = "0.10"
 bytes = "1.8.0"
 rand = "0.9.2"
 reqwest = { version = "0.13", features = ["stream", "blocking", "json"] }

--- a/docs/epd.md
+++ b/docs/epd.md
@@ -1,0 +1,95 @@
+# Encoder + PD / E/P/D routing (experimental)
+
+The native Rust router can orchestrate remote encoders before forwarding a chat
+request to a combined prefill/decode worker or separate P and D workers. Embeddings move through vLLM's EC
+connector; the router only handles JSON placeholder metadata and transfer handles.
+No PyTorch dependency or tensor deserialization is needed in the router.
+
+Use vLLM with JSON metadata inputs (vllm-project/vllm#56090). Configure E workers
+as EC producers and PD workers as matching EC consumers, as for the vLLM encoder
+disaggregation example. The example connector needs a shared filesystem; NIXL
+and Mooncake need their usual backend dependencies and network connectivity.
+
+```bash
+cargo build --release --bin vllm-router
+target/release/vllm-router \
+  --host 0.0.0.0 --port 8000 \
+  --worker-urls http://pd0:8000 http://pd1:8000 \
+  --policy random \
+  --epd-config '{
+    "encoder_urls": ["http://e0:8000", "http://e1:8000"],
+    "consumer_zmq_addrs": {
+      "http://pd0:8000": "tcp://pd0:14579",
+      "http://pd1:8000": "tcp://pd1:14579"
+    }
+  }'
+```
+
+`consumer_zmq_addrs` is for Mooncake PUSH and must map each configured PD HTTP URL
+to that worker's configured EC control address. For NIXL PULL or the shared-file
+example connector, omit this map. The PD worker is selected before encoding so
+the producer and the HTTP request use the same destination. Encoder requests
+are distributed round-robin per media item.
+
+Send ordinary OpenAI chat requests to `/v1/chat/completions`. Each raw media item
+is sent to an encoder. Published metadata replaces that item with an embeds
+reference; missing metadata preserves the original media for vLLM's fallback.
+Repeated images keep their original positions and independent transfer IDs.
+Other request fields, including sampling options, pass through unchanged.
+Text-only and existing embeds inputs do not call the encoders. PD responses,
+including SSE streams, use the existing transparent forwarding path.
+
+Encoder failures are returned without submitting a partially prepared PD
+request. There is no automatic replay of EPD requests in this prototype.
+Abandoned Mooncake pushes receive best-effort cancellation over their existing
+ZMQ control channel; backend expiration remains the fallback if cancellation
+cannot reach the consumer. After a successful PD response header, the consumer
+owns request completion/abort cleanup.
+
+## Scope
+
+- Native binary CLI only; the Python launcher does not expose `--epd-config` yet.
+- Regular E+PD or static vLLM E/P/D mode, DP=1, no IGW.
+- Keep the existing backend's TP/PP constraints; this does not add parallelism support.
+- Static E URLs; E health-aware routing and dynamic consumer discovery are not added.
+- JSON metadata only, not legacy tensor-base64 metadata from old E servers.
+- No early metadata publication, encoder batching changes, or engine/scheduler changes.
+- Image E2E validation is performed separately; do not infer audio/video coverage
+  or production readiness from the metadata rewrite code alone.
+
+## Separate prefill and decode
+
+Add `--epd-config` to the existing static P/D router. Its EC control address map
+must reference **P**, not D. P is an EC consumer and KV producer; D is only a KV
+consumer. Both accept JSON placeholder metadata (`--enable-mm-embeds`).
+For Qwen3.5 with current vLLM NIXL KV transfer, P and D also require
+`VLLM_SSM_CONV_STATE_LAYOUT=DS` for Mamba state transfer.
+
+```bash
+target/release/vllm-router --host 0.0.0.0 --port 8000 \
+  --vllm-pd-disaggregation --kv-connector nixl \
+  --prefill http://p0:8000 --prefill http://p1:8000 \
+  --decode http://d0:8000 --decode http://d1:8000 --policy random \
+  --epd-config '{
+    "encoder_urls": ["http://e0:8000", "http://e1:8000"],
+    "consumer_zmq_addrs": {
+      "http://p0:8000": "tcp://p0:14579",
+      "http://p1:8000": "tcp://p1:14579"
+    }
+  }'
+```
+
+The router selects P/D, prepares E metadata for P, then uses the existing KV
+handoff. D receives the same placeholder layout with KV transfer parameters,
+without P's EC handles. P errors or missing NIXL KV handles stop the pipeline.
+Dynamic P/D discovery is not supported with EPD yet.
+
+```bash
+cargo test --test test_pd_routing test_epd_handoff
+```
+
+Focused tests:
+
+```bash
+cargo test --lib routers::http::epd::tests
+```

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -6,6 +6,9 @@ use std::collections::HashMap;
 /// Main router configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RouterConfig {
+    /// Optional encoder orchestration for E+PD or E/P/D routing.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub epd: Option<EpdConfig>,
     /// Routing mode configuration
     pub mode: RoutingMode,
     /// Worker connection mode
@@ -84,6 +87,16 @@ pub struct RouterConfig {
 
 fn default_profile_timeout_secs() -> u64 {
     10
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EpdConfig {
+    pub encoder_urls: Vec<String>,
+    /// Mooncake consumer control addresses, keyed by the P or combined PD HTTP URL.
+    /// Omit for pull-based NIXL or the shared-file example connector.
+    #[serde(default)]
+    pub consumer_zmq_addrs: HashMap<String, String>,
 }
 
 fn default_history_backend() -> HistoryBackend {
@@ -478,6 +491,7 @@ impl Default for RouterConfig {
             history_backend: default_history_backend(),
             enable_profiling: false,
             profile_timeout_secs: default_profile_timeout_secs(),
+            epd: None,
             kv_connector: KvConnector::default(),
         }
     }
@@ -1052,6 +1066,7 @@ mod tests {
             history_backend: default_history_backend(),
             enable_profiling: false,
             profile_timeout_secs: default_profile_timeout_secs(),
+            epd: None,
             kv_connector: KvConnector::default(),
         };
 
@@ -1118,6 +1133,7 @@ mod tests {
             history_backend: default_history_backend(),
             enable_profiling: false,
             profile_timeout_secs: default_profile_timeout_secs(),
+            epd: None,
             kv_connector: KvConnector::default(),
         };
 
@@ -1180,6 +1196,7 @@ mod tests {
             history_backend: default_history_backend(),
             enable_profiling: false,
             profile_timeout_secs: default_profile_timeout_secs(),
+            epd: None,
             kv_connector: KvConnector::default(),
         };
 

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -19,6 +19,7 @@ impl ConfigValidator {
         Self::validate_mode(&config.mode, has_service_discovery)?;
         Self::validate_policy(&config.policy)?;
         Self::validate_server_settings(config)?;
+        Self::validate_epd(config)?;
 
         if let Some(discovery) = &config.discovery {
             Self::validate_discovery(discovery, &config.mode)?;
@@ -36,6 +37,64 @@ impl ConfigValidator {
         Self::validate_retry(&retry_cfg)?;
         Self::validate_circuit_breaker(&cb_cfg)?;
 
+        Ok(())
+    }
+
+    fn validate_epd(config: &RouterConfig) -> ConfigResult<()> {
+        let Some(epd) = &config.epd else {
+            return Ok(());
+        };
+        let worker_urls: Vec<&String> = match &config.mode {
+            RoutingMode::Regular { worker_urls } => worker_urls.iter().collect(),
+            RoutingMode::VllmPrefillDecode {
+                prefill_urls,
+                discovery_address: None,
+                ..
+            } => prefill_urls.iter().map(|(url, _)| url).collect(),
+            _ => {
+                return Err(ConfigError::ValidationFailed {
+                    reason: "EPD requires regular E+PD or static vLLM E/P/D routing".into(),
+                })
+            }
+        };
+        if config.intra_node_data_parallel_size != 1 || config.enable_igw {
+            return Err(ConfigError::ValidationFailed {
+                reason: "EPD currently requires DP=1 and proxy mode".into(),
+            });
+        }
+        if epd.encoder_urls.is_empty() {
+            return Err(ConfigError::MissingRequired {
+                field: "epd.encoder_urls".into(),
+            });
+        }
+        Self::validate_urls(&epd.encoder_urls)?;
+        if !epd.consumer_zmq_addrs.is_empty() {
+            if worker_urls.is_empty()
+                || epd.consumer_zmq_addrs.len() != worker_urls.len()
+                || worker_urls
+                    .iter()
+                    .any(|url| !epd.consumer_zmq_addrs.contains_key(*url))
+            {
+                return Err(ConfigError::ValidationFailed {
+                    reason:
+                        "EPD consumer_zmq_addrs must map every embedding consumer URL exactly once"
+                            .into(),
+                });
+            }
+            for addr in epd.consumer_zmq_addrs.values() {
+                let parsed = url::Url::parse(addr).map_err(|e| ConfigError::ValidationFailed {
+                    reason: format!("Invalid EC address: {e}"),
+                })?;
+                if parsed.scheme() != "tcp"
+                    || parsed.host_str().is_none()
+                    || parsed.port().is_none()
+                {
+                    return Err(ConfigError::ValidationFailed {
+                        reason: "EC addresses must be tcp://host:port".into(),
+                    });
+                }
+            }
+        }
         Ok(())
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -176,6 +176,7 @@ impl Router {
         };
 
         Ok(config::RouterConfig {
+            epd: None,
             mode,
             policy,
             host: self.host.clone(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -94,6 +94,9 @@ Examples:
 
 "#)]
 struct CliArgs {
+    /// E+PD or E/P/D encoder orchestration as JSON (encoder_urls, consumer_zmq_addrs).
+    #[arg(long)]
+    epd_config: Option<String>,
     /// Host address to bind the router server
     #[arg(long, default_value = "127.0.0.1")]
     host: String,
@@ -501,6 +504,14 @@ impl CliArgs {
 
         // Build RouterConfig
         Ok(RouterConfig {
+            epd: self
+                .epd_config
+                .as_deref()
+                .map(serde_json::from_str)
+                .transpose()
+                .map_err(|e| vllm_router_rs::config::ConfigError::ValidationFailed {
+                    reason: format!("Invalid --epd-config: {e}"),
+                })?,
             mode,
             policy,
             connection_mode,

--- a/src/routers/http/epd.rs
+++ b/src/routers/http/epd.rs
@@ -1,0 +1,585 @@
+use crate::config::EpdConfig;
+use axum::http::{HeaderMap, StatusCode};
+use futures_util::future::join_all;
+use reqwest::{Client, RequestBuilder};
+use serde_json::{json, Map, Value};
+use sha2::{Digest, Sha256};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Instant;
+use uuid::Uuid;
+
+type EpdError = (StatusCode, String);
+
+struct MediaItem {
+    message_index: usize,
+    content_index: usize,
+    kind: &'static str,
+    content_id: String,
+    transfer_id: String,
+    media: Value,
+}
+
+#[derive(Debug)]
+pub(super) struct EncoderStage {
+    config: EpdConfig,
+    next_encoder: AtomicUsize,
+}
+
+/// Cancel abandoned Mooncake pushes when preparation or the P/PD request ends early.
+pub(super) struct EcTransferGuard {
+    control_addr: String,
+    transfer_ids: Vec<String>,
+}
+
+impl EcTransferGuard {
+    fn retain(&mut self, transfer_ids: Vec<String>) {
+        let mut abandoned = Self {
+            control_addr: self.control_addr.clone(),
+            transfer_ids: std::mem::replace(&mut self.transfer_ids, transfer_ids),
+        };
+        abandoned
+            .transfer_ids
+            .retain(|id| !self.transfer_ids.contains(id));
+    }
+
+    pub(super) fn disarm(&mut self) {
+        self.transfer_ids.clear();
+    }
+}
+
+impl Drop for EcTransferGuard {
+    fn drop(&mut self) {
+        if self.transfer_ids.is_empty() {
+            return;
+        }
+        let transfer_ids = std::mem::take(&mut self.transfer_ids);
+        let control_addr = self.control_addr.clone();
+        // No blocking ZMQ operations on the HTTP runtime threads.
+        tokio::task::spawn_blocking(move || {
+            let context = zmq::Context::new();
+            for transfer_id in transfer_ids {
+                let result = (|| -> Result<(), zmq::Error> {
+                    let socket = context.socket(zmq::REQ)?;
+                    socket.set_linger(0)?;
+                    socket.set_sndtimeo(1000)?;
+                    socket.set_rcvtimeo(1000)?;
+                    socket.connect(&control_addr)?;
+                    let body = json!({
+                        "op": "cancel",
+                        "transfer_id": transfer_id,
+                        "abandon": true,
+                    })
+                    .to_string();
+                    socket.send(body.as_bytes(), 0)?;
+                    socket.recv_bytes(0)?;
+                    Ok(())
+                })();
+                if let Err(error) = result {
+                    tracing::warn!(%error, "Could not cancel abandoned EC transfer");
+                }
+            }
+        });
+    }
+}
+
+impl EncoderStage {
+    pub(super) fn new(config: EpdConfig) -> Self {
+        Self {
+            config,
+            next_encoder: AtomicUsize::new(0),
+        }
+    }
+
+    pub(super) async fn prepare(
+        &self,
+        client: &Client,
+        mut body: Value,
+        consumer_url: &str,
+        headers: Option<&HeaderMap>,
+        api_key: Option<&str>,
+    ) -> Result<(Value, Option<EcTransferGuard>), EpdError> {
+        let started = Instant::now();
+        let items = collect_media_items(&body)?;
+        if items.is_empty() {
+            return Ok((body, None));
+        }
+        let consumer_addr = self.config.consumer_zmq_addrs.get(consumer_url);
+        if !self.config.consumer_zmq_addrs.is_empty() && consumer_addr.is_none() {
+            return Err((
+                StatusCode::SERVICE_UNAVAILABLE,
+                "Selected embedding consumer has no EC control address".into(),
+            ));
+        }
+        let mut pending = consumer_addr.map(|control_addr| EcTransferGuard {
+            control_addr: control_addr.clone(),
+            transfer_ids: items.iter().map(|item| item.transfer_id.clone()).collect(),
+        });
+        let request_id = headers
+            .and_then(|h| h.get("x-request-id"))
+            .and_then(|v| v.to_str().ok())
+            .map(str::to_owned)
+            .unwrap_or_else(|| Uuid::new_v4().to_string());
+        let start = self.next_encoder.fetch_add(items.len(), Ordering::Relaxed);
+        let replies = join_all(items.iter().enumerate().map(|(index, item)| {
+            let encoder_url = &self.config.encoder_urls
+                [start.wrapping_add(index) % self.config.encoder_urls.len()];
+            let mut request = client
+                .post(format!(
+                    "{}/v1/chat/completions",
+                    encoder_url.trim_end_matches('/')
+                ))
+                .header(
+                    "x-request-id",
+                    format!("{request_id}:{index}:{}", item.transfer_id),
+                );
+            if let Some(key) = api_key {
+                request = request.bearer_auth(key);
+            } else if let Some(auth) = headers.and_then(|h| h.get("authorization")) {
+                request = request.header("authorization", auth);
+            }
+            encode_item(request, item, &body, consumer_addr.map(String::as_str))
+        }))
+        .await;
+        let replies: Vec<Value> = replies.into_iter().collect::<Result<_, _>>()?;
+        let mut handles = Map::new();
+        let mut transfers = Vec::new();
+        let mut used_transfer_ids = Vec::new();
+        for (item, mut reply) in items.iter().zip(replies) {
+            let Some(Value::Object(mut params)) =
+                reply.get_mut("ec_transfer_params").map(Value::take)
+            else {
+                continue;
+            };
+            let entry = if let Some(reported) = params.remove(&item.content_id) {
+                Some((item.content_id.clone(), reported))
+            } else if params.len() == 1 {
+                params.into_iter().next()
+            } else {
+                None
+            };
+            let Some((hash, reported)) = entry else {
+                continue;
+            };
+            let Some(metadata) = reported
+                .get("metadata")
+                .and_then(Value::as_object)
+                .filter(|m| !m.is_empty())
+            else {
+                continue;
+            };
+            let metadata = flatten_metadata(metadata)?;
+            let kind = match item.kind {
+                "image_url" => "image_embeds",
+                "video_url" => "video_embeds",
+                _ => "audio_embeds",
+            };
+            body["messages"][item.message_index]["content"][item.content_index] = json!({
+                "type": kind,
+                (kind): metadata,
+                "uuid": item.content_id,
+            });
+            handles.insert(item.content_id.clone(), reported);
+            transfers.push(json!({
+                "mm_hash": hash,
+                "transfer_id": item.transfer_id,
+            }));
+            used_transfer_ids.push(item.transfer_id.clone());
+        }
+        let rewritten = transfers.len();
+        if rewritten > 0 {
+            if let Some(Value::Object(mut existing)) =
+                body.get_mut("ec_transfer_params").map(Value::take)
+            {
+                if let Some(Value::Array(mut previous)) = existing.remove("ec_items") {
+                    previous.append(&mut transfers);
+                    transfers = previous;
+                }
+                existing.extend(handles);
+                handles = existing;
+            }
+            handles.insert("ec_items".into(), Value::Array(transfers));
+            body["ec_transfer_params"] = Value::Object(handles);
+        }
+        if let Some(pending) = pending.as_mut() {
+            pending.retain(used_transfer_ids);
+        }
+        tracing::info!(
+            %request_id,
+            items = items.len(),
+            rewritten,
+            encode_ms = started.elapsed().as_secs_f64() * 1000.0,
+            "EPD encoder stage complete"
+        );
+        Ok((body, pending))
+    }
+}
+
+fn collect_media_items(body: &Value) -> Result<Vec<MediaItem>, EpdError> {
+    let messages = body
+        .get("messages")
+        .and_then(Value::as_array)
+        .ok_or_else(|| (StatusCode::BAD_REQUEST, "messages must be an array".into()))?;
+    let mut items = Vec::new();
+    for (message_index, message) in messages.iter().enumerate() {
+        let Some(content) = message.get("content").and_then(Value::as_array) else {
+            continue;
+        };
+        for (content_index, item) in content.iter().enumerate() {
+            let kind = match item.get("type").and_then(Value::as_str) {
+                Some("image_url") => "image_url",
+                Some("video_url") => "video_url",
+                Some("audio_url") => "audio_url",
+                _ => continue,
+            };
+            let url = item[kind]["url"]
+                .as_str()
+                .filter(|v| !v.is_empty())
+                .ok_or_else(|| {
+                    (
+                        StatusCode::BAD_REQUEST,
+                        format!("{kind}.url must be a nonempty string"),
+                    )
+                })?;
+            let content_id = format!("{:x}", Sha256::digest(url.as_bytes()));
+            let transfer_id = Uuid::new_v4().simple().to_string();
+            let mut media = item.clone();
+            media["uuid"] = json!(content_id);
+            items.push(MediaItem {
+                message_index,
+                content_index,
+                kind,
+                content_id,
+                transfer_id,
+                media,
+            });
+        }
+    }
+    Ok(items)
+}
+
+async fn encode_item(
+    request: RequestBuilder,
+    item: &MediaItem,
+    body: &Value,
+    consumer_addr: Option<&str>,
+) -> Result<Value, EpdError> {
+    let mut payload = json!({
+        "model": body.get("model"),
+        "stream": false,
+        "messages": [{"role": "user", "content": [item.media]}],
+    });
+    // Per-request preprocessing options must agree on both sides.
+    for key in ["mm_processor_kwargs", "media_io_kwargs"] {
+        if let Some(value) = body.get(key) {
+            payload[key] = value.clone();
+        }
+    }
+    if let Some(control_addr) = consumer_addr {
+        payload["ec_transfer_params"] = json!({
+            "consumer_zmq": control_addr,
+            "ec_items": [{"transfer_id": item.transfer_id}],
+        });
+    }
+    let request = request.json(&payload);
+    drop(payload);
+    let response = request.send().await.map_err(|e| {
+        (
+            StatusCode::BAD_GATEWAY,
+            format!("Encoder request failed: {e}"),
+        )
+    })?;
+    if !response.status().is_success() {
+        return Err((response.status(), "Encoder request failed".into()));
+    }
+    response.json::<Value>().await.map_err(|e| {
+        (
+            StatusCode::BAD_GATEWAY,
+            format!("Invalid encoder response: {e}"),
+        )
+    })
+}
+
+fn flatten_metadata(metadata: &Map<String, Value>) -> Result<Map<String, Value>, EpdError> {
+    metadata
+        .iter()
+        .map(|(key, value)| {
+            let values = value.as_array().ok_or_else(|| {
+                (
+                    StatusCode::BAD_GATEWAY,
+                    "Encoder metadata must contain numeric arrays".into(),
+                )
+            })?;
+            let mut flat = Vec::new();
+            for value in values {
+                match value {
+                    Value::Array(values) => flat.extend(values.iter().cloned()),
+                    value => flat.push(value.clone()),
+                }
+            }
+            if !flat.iter().all(Value::is_number) {
+                return Err((
+                    StatusCode::BAD_GATEWAY,
+                    "Encoder metadata must contain numeric arrays".into(),
+                ));
+            }
+            Ok((key.clone(), Value::Array(flat)))
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{extract::State, routing::post, Json, Router};
+    use std::sync::{Arc, Mutex};
+
+    #[derive(Clone)]
+    struct MockEncoder {
+        mode: &'static str,
+        seen: Arc<Mutex<Vec<Value>>>,
+    }
+
+    async fn encode(
+        State(state): State<MockEncoder>,
+        Json(body): Json<Value>,
+    ) -> (StatusCode, Json<Value>) {
+        let count = {
+            let mut seen = state.seen.lock().unwrap();
+            seen.push(body.clone());
+            seen.len()
+        };
+        if state.mode == "fail" {
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(json!({"error":"unavailable"})),
+            );
+        }
+        let uuid = body["messages"][0]["content"][0]["uuid"].as_str().unwrap();
+        let metadata = if state.mode == "empty" || (state.mode == "mixed" && count == 1) {
+            json!({})
+        } else if state.mode == "invalid" {
+            json!({"image_grid_thw": ["invalid"]})
+        } else {
+            json!({"image_grid_thw":[[1,2,3]]})
+        };
+        (
+            StatusCode::OK,
+            Json(json!({
+                "ec_transfer_params": {
+                    (format!("engine-{uuid}")): {
+                        "metadata": metadata,
+                        "peer_host": "encoder",
+                        "peer_port": 4321,
+                        "size_bytes": 128,
+                    },
+                },
+            })),
+        )
+    }
+
+    async fn mock(
+        mode: &'static str,
+    ) -> (
+        EncoderStage,
+        Arc<Mutex<Vec<Value>>>,
+        tokio::task::JoinHandle<()>,
+    ) {
+        let state = MockEncoder {
+            mode,
+            seen: Arc::new(Mutex::new(Vec::new())),
+        };
+        let seen = state.seen.clone();
+        let app = Router::new()
+            .route("/v1/chat/completions", post(encode))
+            .with_state(state);
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = format!("http://{}", listener.local_addr().unwrap());
+        let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+        let stage = EncoderStage::new(EpdConfig {
+            encoder_urls: vec![url],
+            consumer_zmq_addrs: Default::default(),
+        });
+        (stage, seen, server)
+    }
+
+    fn request() -> Value {
+        json!({
+            "model": "test",
+            "stream": true,
+            "max_tokens": 16,
+            "chat_template_kwargs": {"enable_thinking": false},
+            "mm_processor_kwargs": {"min_pixels": 64},
+            "messages": [{
+                "role": "user",
+                "content": [
+                    {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc"}},
+                    {"type": "text", "text": "compare"},
+                    {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc"}},
+                ],
+            }],
+        })
+    }
+
+    #[tokio::test]
+    async fn duplicate_images_keep_positions_and_distinct_transfers() {
+        let (stage, seen, server) = mock("normal").await;
+        let mut input = request();
+        input["ec_transfer_params"] = json!({
+            "opaque": {"backend_field": 42},
+            "ec_items": [{"mm_hash": "existing", "transfer_id": "existing-transfer"}],
+        });
+        let (body, pending) = stage
+            .prepare(&Client::new(), input.clone(), "pd", None, None)
+            .await
+            .unwrap();
+        assert!(pending.is_none());
+        let content = &body["messages"][0]["content"];
+        assert_eq!(
+            content[0]["image_embeds"]["image_grid_thw"],
+            json!([1, 2, 3])
+        );
+        assert_eq!(content[1], input["messages"][0]["content"][1]);
+        assert_eq!(content[0]["uuid"], content[2]["uuid"]);
+        let transfers = &body["ec_transfer_params"]["ec_items"];
+        assert_eq!(transfers.as_array().unwrap().len(), 3);
+        assert_eq!(transfers[0], input["ec_transfer_params"]["ec_items"][0]);
+        assert_eq!(
+            body["ec_transfer_params"]["opaque"],
+            input["ec_transfer_params"]["opaque"]
+        );
+        assert_eq!(transfers[1]["mm_hash"], transfers[2]["mm_hash"]);
+        assert_ne!(transfers[1]["transfer_id"], transfers[2]["transfer_id"]);
+        assert_eq!(
+            transfers[1]["mm_hash"],
+            format!("engine-{}", content[0]["uuid"].as_str().unwrap())
+        );
+        assert_eq!(
+            body["ec_transfer_params"][content[0]["uuid"].as_str().unwrap()]["peer_port"],
+            4321
+        );
+        assert_eq!(body["stream"], true);
+        assert_eq!(body["chat_template_kwargs"], input["chat_template_kwargs"]);
+        let requests = seen.lock().unwrap();
+        assert_eq!(requests.len(), 2);
+        assert!(requests
+            .iter()
+            .all(|r| r["stream"] == false && r.get("max_tokens").is_none()));
+        assert_eq!(
+            requests[0]["mm_processor_kwargs"],
+            input["mm_processor_kwargs"]
+        );
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn missing_metadata_preserves_original_media() {
+        let (stage, _, server) = mock("empty").await;
+        let mut input = request();
+        input["ec_transfer_params"] = json!({"opaque": {"backend_field": 42}});
+        let (body, _) = stage
+            .prepare(&Client::new(), input.clone(), "pd", None, None)
+            .await
+            .unwrap();
+        assert_eq!(body, input);
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn encoder_failure_does_not_forward_metadata_only_input() {
+        let (stage, _, server) = mock("fail").await;
+        let error = stage
+            .prepare(&Client::new(), request(), "pd", None, None)
+            .await
+            .err()
+            .unwrap();
+        assert_eq!(error.0, StatusCode::SERVICE_UNAVAILABLE);
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn existing_embeds_bypass_encoders() {
+        let (stage, seen, server) = mock("normal").await;
+        let input = json!({
+            "messages": [{
+                "role": "user",
+                "content": [{
+                    "type": "image_embeds",
+                    "image_embeds": {"image_grid_thw": [1, 2, 3]},
+                    "uuid": "known",
+                }],
+            }],
+        });
+        let (body, _) = stage
+            .prepare(&Client::new(), input.clone(), "pd", None, None)
+            .await
+            .unwrap();
+        assert_eq!(input, body);
+        assert!(seen.lock().unwrap().is_empty());
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn abandoned_pushes_cancel_the_selected_consumer() {
+        for mode in ["normal", "empty", "mixed", "invalid", "fail"] {
+            let (mut stage, seen, server) = mock(mode).await;
+            let (send_address, recv_address) = tokio::sync::oneshot::channel();
+            let control = tokio::task::spawn_blocking(move || {
+                let context = zmq::Context::new();
+                let socket = context.socket(zmq::REP).unwrap();
+                socket.set_rcvtimeo(5000).unwrap();
+                socket.set_linger(0).unwrap();
+                socket.bind("tcp://127.0.0.1:*").unwrap();
+                send_address
+                    .send(socket.get_last_endpoint().unwrap().unwrap())
+                    .unwrap();
+                let mut cancelled = Vec::new();
+                let expected = if mode == "mixed" { 1 } else { 2 };
+                for _ in 0..expected {
+                    let message: Value =
+                        serde_json::from_slice(&socket.recv_bytes(0).unwrap()).unwrap();
+                    cancelled.push(message);
+                    socket.send(b"{\"ok\":true}".as_slice(), 0).unwrap();
+                }
+                cancelled
+            });
+            let address = recv_address.await.unwrap();
+            stage
+                .config
+                .consumer_zmq_addrs
+                .insert("selected-pd".into(), address.clone());
+            let result = stage
+                .prepare(&Client::new(), request(), "selected-pd", None, None)
+                .await;
+            let ids: Vec<Value> = seen
+                .lock()
+                .unwrap()
+                .iter()
+                .map(|r| {
+                    assert_eq!(r["ec_transfer_params"]["consumer_zmq"], address);
+                    r["ec_transfer_params"]["ec_items"][0]["transfer_id"].clone()
+                })
+                .collect();
+            if matches!(mode, "invalid" | "fail") {
+                assert!(result.is_err());
+            } else {
+                let (_, mut pending) = result.unwrap();
+                if mode == "mixed" {
+                    let pending = pending.as_mut().unwrap();
+                    assert_eq!(pending.transfer_ids.len(), 1);
+                    pending.disarm();
+                }
+                drop(pending);
+            }
+            let cancelled = control.await.unwrap();
+            assert!(cancelled.iter().all(|r| r["op"] == "cancel"
+                && r["abandon"] == true
+                && ids.contains(&r["transfer_id"])));
+            if mode == "mixed" {
+                assert_eq!(cancelled[0]["transfer_id"], ids[0]);
+            } else {
+                assert_ne!(cancelled[0]["transfer_id"], cancelled[1]["transfer_id"]);
+            }
+            server.abort();
+        }
+    }
+}

--- a/src/routers/http/mod.rs
+++ b/src/routers/http/mod.rs
@@ -1,6 +1,7 @@
 //! HTTP router implementations
 
 pub mod dp_utils;
+mod epd;
 pub mod logprobs_merge;
 pub mod openai_router;
 pub mod pd_router;

--- a/src/routers/http/router.rs
+++ b/src/routers/http/router.rs
@@ -34,6 +34,7 @@ use tracing::{debug, error, info, warn};
 /// Regular router that uses injected load balancing policies
 #[derive(Debug)]
 pub struct Router {
+    epd: Option<super::epd::EncoderStage>,
     worker_registry: Arc<WorkerRegistry>,
     policy_registry: Arc<PolicyRegistry>,
     client: Client,
@@ -168,6 +169,11 @@ impl Router {
         };
 
         Ok(Router {
+            epd: ctx
+                .router_config
+                .epd
+                .clone()
+                .map(super::epd::EncoderStage::new),
             worker_registry: ctx.worker_registry.clone(),
             policy_registry: ctx.policy_registry.clone(),
             client: ctx.client.clone(),
@@ -1696,6 +1702,28 @@ impl RouterTrait for Router {
         let worker: &dyn Worker = workers[worker_idx].as_ref();
         let url = worker.endpoint_url(path);
 
+        let (body, mut transfers) = if let Some(epd) = &self.epd {
+            if *method == Method::POST && path == "/v1/chat/completions" {
+                match epd
+                    .prepare(
+                        &self.client,
+                        body,
+                        worker.url(),
+                        headers,
+                        self.api_key.as_deref(),
+                    )
+                    .await
+                {
+                    Ok(value) => value,
+                    Err(error) => return error.into_response(),
+                }
+            } else {
+                (body, None)
+            }
+        } else {
+            (body, None)
+        };
+
         debug!("Transparent proxy: forwarding to {}", url);
 
         // Build the request
@@ -1724,6 +1752,23 @@ impl RouterTrait for Router {
         }
 
         // Add authorization if configured
+        if self.epd.is_some() {
+            if let Some(headers) = headers {
+                for (name, value) in headers {
+                    if !matches!(
+                        name.as_str(),
+                        "host"
+                            | "content-length"
+                            | "content-type"
+                            | "connection"
+                            | "transfer-encoding"
+                    ) && !header_utils::TRACE_HEADER_NAMES.contains(&name.as_str())
+                    {
+                        request_builder = request_builder.header(name, value);
+                    }
+                }
+            }
+        }
         if let Some(ref key) = self.api_key {
             request_builder = request_builder.header("Authorization", format!("Bearer {}", key));
         }
@@ -1743,6 +1788,11 @@ impl RouterTrait for Router {
         {
             Ok(response) => {
                 let status = response.status();
+                if status.is_success() {
+                    if let Some(transfers) = transfers.as_mut() {
+                        transfers.disarm();
+                    }
+                }
                 let headers = response.headers().clone();
 
                 // Stream the response body
@@ -1793,6 +1843,7 @@ mod tests {
 
         let (_, rx) = tokio::sync::watch::channel(HashMap::new());
         Router {
+            epd: None,
             worker_registry,
             policy_registry,
             worker_startup_timeout_secs: 5,
@@ -1867,6 +1918,7 @@ mod tests {
         Router {
             worker_registry,
             policy_registry,
+            epd: None,
             worker_startup_timeout_secs: 5,
             worker_startup_check_interval_secs: 1,
             intra_node_data_parallel_size: 1,

--- a/src/routers/http/vllm_pd_router.rs
+++ b/src/routers/http/vllm_pd_router.rs
@@ -37,6 +37,7 @@ struct MooncakePrefillInfo {
 /// vLLM PD Router that extends PdRouterBase with vLLM-specific request handling
 #[derive(Debug)]
 pub struct VllmPDRouter {
+    epd: Option<super::epd::EncoderStage>,
     /// Underlying PD router for most functionality
     pd_router: PdRouterBase,
     /// Service discovery registry for dynamic ZMQ address resolution
@@ -1174,6 +1175,28 @@ impl VllmPDRouter {
             path
         );
 
+        let (original_request, mut ec_transfers) = if path == "/v1/chat/completions" {
+            if let Some(epd) = &self.epd {
+                match epd
+                    .prepare(
+                        &self.http_client,
+                        original_request,
+                        prefill_worker.base_url(),
+                        headers,
+                        std::env::var("OPENAI_API_KEY").ok().as_deref(),
+                    )
+                    .await
+                {
+                    Ok(prepared) => prepared,
+                    Err(error) => return Ok(error.into_response()),
+                }
+            } else {
+                (original_request, None)
+            }
+        } else {
+            (original_request, None)
+        };
+
         // Increment prefill load at the start of the prefill phase
         prefill_worker.increment_load();
 
@@ -1288,6 +1311,15 @@ impl VllmPDRouter {
             prefill_response.headers()
         );
 
+        if !prefill_response.status().is_success() {
+            prefill_worker.decrement_load();
+            let status = prefill_response.status();
+            let detail = prefill_response.text().await.unwrap_or_default();
+            return Err(PDRouterError::NetworkError {
+                message: format!("Prefill server {prefill_url} returned {status}: {detail}"),
+            });
+        }
+
         // Extract prefill response body to get kv_transfer_params
         let prefill_bytes = match prefill_response.bytes().await {
             Ok(bytes) => bytes,
@@ -1336,6 +1368,21 @@ impl VllmPDRouter {
         // Extract kv_transfer_params from prefill response if present
         let kv_transfer_params = prefill_response_json.get("kv_transfer_params").cloned();
 
+        if let Some(transfers) = ec_transfers.as_mut() {
+            transfers.disarm();
+        }
+        if self.epd.is_some()
+            && !matches!(self.kv_connector, KvConnector::Mooncake)
+            && !kv_transfer_params.as_ref().is_some_and(Value::is_object)
+        {
+            prefill_worker.decrement_load();
+            return Err(PDRouterError::NetworkError {
+                message:
+                    "Prefill returned no KV transfer parameters; refusing metadata-only decode"
+                        .into(),
+            });
+        }
+
         if let Some(ref params) = kv_transfer_params {
             debug!(
                 "Extracted kv_transfer_params from prefill response: {}",
@@ -1356,6 +1403,13 @@ impl VllmPDRouter {
 
         // Stage 2: Prepare decode request with kv_transfer_params
         let mut decode_request = original_request.clone();
+        if self.epd.is_some() {
+            // D receives the prompt layout and KV, not P's EC reservations.
+            decode_request
+                .as_object_mut()
+                .unwrap()
+                .remove("ec_transfer_params");
+        }
         if matches!(self.kv_connector, KvConnector::Mooncake) {
             // Mooncake: set decode params proactively from bootstrap info
             if let Some((bootstrap_addr, engine_id)) = self
@@ -1608,6 +1662,11 @@ impl VllmPDRouter {
             );
 
             Ok(Self {
+                epd: ctx
+                    .router_config
+                    .epd
+                    .clone()
+                    .map(super::epd::EncoderStage::new),
                 pd_router,
                 service_registry: Arc::new(service_registry),
                 http_client,
@@ -1697,6 +1756,11 @@ impl VllmPDRouter {
             }
 
             Ok(Self {
+                epd: ctx
+                    .router_config
+                    .epd
+                    .clone()
+                    .map(super::epd::EncoderStage::new),
                 pd_router,
                 service_registry: Arc::new(service_registry),
                 http_client,

--- a/src/server.rs
+++ b/src/server.rs
@@ -254,6 +254,25 @@ async fn v1_chat_completions(
     state.router.route_chat(Some(&headers), &body, None).await
 }
 
+async fn epd_chat_completions(
+    State(state): State<Arc<AppState>>,
+    headers: http::HeaderMap,
+    Json(body): Json<serde_json::Value>,
+) -> Response {
+    if let Err(response) = authorize_request(&state, &headers).await {
+        return response;
+    }
+    state
+        .router
+        .route_transparent(
+            Some(&headers),
+            "/v1/chat/completions",
+            &http::Method::POST,
+            body,
+        )
+        .await
+}
+
 async fn v1_completions(
     State(state): State<Arc<AppState>>,
     headers: http::HeaderMap,
@@ -721,7 +740,14 @@ pub fn build_app_with_request_tracing(
     let protected_routes = Router::new()
         .route("/generate", post(generate))
         .route("/inference/v1/generate", post(inference_generate))
-        .route("/v1/chat/completions", post(v1_chat_completions))
+        .route(
+            "/v1/chat/completions",
+            if app_state.context.router_config.epd.is_some() {
+                post(epd_chat_completions)
+            } else {
+                post(v1_chat_completions)
+            },
+        )
         .route("/v1/completions", post(v1_completions))
         .route("/rerank", post(rerank))
         .route("/v1/rerank", post(v1_rerank))

--- a/tests/api_endpoints_test.rs
+++ b/tests/api_endpoints_test.rs
@@ -60,6 +60,7 @@ impl TestContext {
             history_backend: vllm_router_rs::config::HistoryBackend::Memory,
             enable_profiling: false,
             profile_timeout_secs: 30,
+            epd: None,
             kv_connector: vllm_router_rs::config::KvConnector::Nixl,
         };
 
@@ -1392,6 +1393,7 @@ mod error_tests {
             history_backend: vllm_router_rs::config::HistoryBackend::Memory,
             enable_profiling: false,
             profile_timeout_secs: 30,
+            epd: None,
             kv_connector: vllm_router_rs::config::KvConnector::Nixl,
         };
 
@@ -1754,6 +1756,7 @@ mod pd_mode_tests {
             history_backend: vllm_router_rs::config::HistoryBackend::Memory,
             enable_profiling: false,
             profile_timeout_secs: 30,
+            epd: None,
             kv_connector: vllm_router_rs::config::KvConnector::Nixl,
         };
 
@@ -1919,6 +1922,7 @@ mod request_id_tests {
             history_backend: vllm_router_rs::config::HistoryBackend::Memory,
             enable_profiling: false,
             profile_timeout_secs: 30,
+            epd: None,
             kv_connector: vllm_router_rs::config::KvConnector::Nixl,
         };
 

--- a/tests/test_dp_routing.rs
+++ b/tests/test_dp_routing.rs
@@ -278,6 +278,7 @@ mod dp_e2e_tests {
             history_backend: vllm_router_rs::config::HistoryBackend::Memory,
             enable_profiling: false,
             profile_timeout_secs: 30,
+            epd: None,
             kv_connector: vllm_router_rs::config::KvConnector::Nixl,
         }
     }
@@ -326,6 +327,7 @@ mod dp_e2e_tests {
             history_backend: vllm_router_rs::config::HistoryBackend::Memory,
             enable_profiling: false,
             profile_timeout_secs: 30,
+            epd: None,
             kv_connector: vllm_router_rs::config::KvConnector::Nixl,
         }
     }

--- a/tests/test_pd_routing.rs
+++ b/tests/test_pd_routing.rs
@@ -5,6 +5,192 @@ mod test_pd_routing {
     };
     use vllm_router_rs::routers::RouterFactory;
 
+    #[tokio::test]
+    async fn test_epd_handoff_preserves_metadata_and_isolates_ec_handles() {
+        use axum::{
+            extract::State,
+            http::StatusCode,
+            response::IntoResponse,
+            routing::{get, post},
+            Json, Router,
+        };
+        use serde_json::{json, Value};
+        use std::sync::{Arc, Mutex};
+        use vllm_router_rs::config::{ConfigValidator, EpdConfig};
+
+        type Seen = Arc<Mutex<Vec<(String, Value)>>>;
+        async fn encode(
+            State(seen): State<Seen>,
+            Json(body): Json<Value>,
+        ) -> axum::response::Response {
+            seen.lock().unwrap().push(("E".into(), body.clone()));
+            if body["model"] == "encoder-fail" {
+                return (StatusCode::SERVICE_UNAVAILABLE, "injected encoder error").into_response();
+            }
+            let hash = body["messages"][0]["content"][0]["uuid"].as_str().unwrap();
+            Json(json!({
+                "ec_transfer_params": {
+                    (hash): {"metadata": {"image_grid_thw": [[1, 2, 3]]}},
+                },
+            }))
+            .into_response()
+        }
+        async fn prefill(
+            State(seen): State<Seen>,
+            Json(body): Json<Value>,
+        ) -> axum::response::Response {
+            seen.lock().unwrap().push(("P".into(), body.clone()));
+            if body["model"] == "fail" {
+                return (StatusCode::INTERNAL_SERVER_ERROR, "injected prefill error")
+                    .into_response();
+            }
+            if body["model"] == "missing-kv" {
+                return Json(json!({"choices":[]})).into_response();
+            }
+            Json(json!({
+                "kv_transfer_params": {
+                    "remote_engine_id": "P",
+                    "do_remote_prefill": true,
+                },
+            }))
+            .into_response()
+        }
+        async fn decode(
+            State(seen): State<Seen>,
+            Json(body): Json<Value>,
+        ) -> axum::response::Response {
+            seen.lock().unwrap().push(("D".into(), body.clone()));
+            if body["stream"] == true {
+                return ([("content-type", "text/event-stream")], "data: [DONE]\n\n")
+                    .into_response();
+            }
+            Json(json!({"choices":[{"message":{"content":"A"}}]})).into_response()
+        }
+        let seen: Seen = Arc::new(Mutex::new(Vec::new()));
+        let app = Router::new()
+            .route("/e/health", get(|| async { "ok" }))
+            .route("/p/health", get(|| async { "ok" }))
+            .route("/d/health", get(|| async { "ok" }))
+            .route("/e/v1/chat/completions", post(encode))
+            .route("/p/v1/chat/completions", post(prefill))
+            .route("/d/v1/chat/completions", post(decode))
+            .with_state(seen.clone());
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let base = format!("http://{}", listener.local_addr().unwrap());
+        let server = tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        let mut config = RouterConfig {
+            mode: RoutingMode::VllmPrefillDecode {
+                prefill_urls: vec![(format!("{base}/p"), None)],
+                decode_urls: vec![format!("{base}/d")],
+                prefill_policy: None,
+                decode_policy: None,
+                discovery_address: None,
+            },
+            policy: PolicyConfig::Random,
+            epd: Some(EpdConfig {
+                encoder_urls: vec![format!("{base}/e")],
+                consumer_zmq_addrs: Default::default(),
+            }),
+            worker_startup_timeout_secs: 5,
+            ..RouterConfig::default()
+        };
+        // Mooncake EC reservations belong to P, not D.
+        config
+            .epd
+            .as_mut()
+            .unwrap()
+            .consumer_zmq_addrs
+            .insert(format!("{base}/d"), "tcp://localhost:1234".into());
+        assert!(ConfigValidator::validate(&config).is_err());
+        config.epd.as_mut().unwrap().consumer_zmq_addrs.clear();
+        ConfigValidator::validate(&config).unwrap();
+        let context = Arc::new(
+            vllm_router_rs::server::AppContext::new(
+                config,
+                reqwest::Client::new(),
+                64,
+                None,
+                vec![],
+            )
+            .unwrap(),
+        );
+        let router = RouterFactory::create_router(&context).await.unwrap();
+        for (model, stream, status) in [
+            ("test", false, StatusCode::OK),
+            ("test", true, StatusCode::OK),
+            ("fail", false, StatusCode::INTERNAL_SERVER_ERROR),
+            ("missing-kv", false, StatusCode::INTERNAL_SERVER_ERROR),
+            ("encoder-fail", false, StatusCode::SERVICE_UNAVAILABLE),
+            ("bad-input", false, StatusCode::BAD_REQUEST),
+        ] {
+            seen.lock().unwrap().clear();
+            let mut body = json!({
+                "model": model,
+                "stream": stream,
+                "max_tokens": 16,
+                "structured_outputs": {"choice": ["A", "B"]},
+                "messages": [{
+                    "role": "user",
+                    "content": [
+                        {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc"}},
+                        {"type": "text", "text": "choose"},
+                    ],
+                }],
+            });
+            if model == "bad-input" {
+                body["messages"] = Value::Null;
+            }
+            let response = router
+                .route_transparent(
+                    None,
+                    "/v1/chat/completions",
+                    &axum::http::Method::POST,
+                    body,
+                )
+                .await;
+            assert_eq!(response.status(), status, "model={model}, stream={stream}");
+            let bytes = axum::body::to_bytes(response.into_body(), 4096)
+                .await
+                .unwrap();
+            if stream {
+                assert!(String::from_utf8_lossy(&bytes).contains("[DONE]"));
+            }
+            let seen = seen.lock().unwrap();
+            let phases: Vec<_> = seen.iter().map(|(phase, _)| phase.as_str()).collect();
+            assert_eq!(
+                phases,
+                match model {
+                    "bad-input" => vec![],
+                    "encoder-fail" => vec!["E"],
+                    "test" => vec!["E", "P", "D"],
+                    _ => vec!["E", "P"],
+                }
+            );
+            if seen.len() < 2 {
+                continue;
+            }
+            let p = &seen[1].1;
+            assert_eq!(p["max_tokens"], 1);
+            assert_eq!(p["stream"], false);
+            assert!(p["ec_transfer_params"]["ec_items"].is_array());
+            assert_eq!(
+                p["messages"][0]["content"][0]["image_embeds"]["image_grid_thw"],
+                json!([1, 2, 3])
+            );
+            if status.is_success() {
+                let d = &seen[2].1;
+                assert_eq!(d["max_tokens"], 16);
+                assert_eq!(d["messages"], p["messages"]);
+                assert_eq!(d["structured_outputs"], p["structured_outputs"]);
+                assert!(d.get("ec_transfer_params").is_none());
+                assert_eq!(d["kv_transfer_params"]["remote_engine_id"], "P");
+            }
+        }
+        server.abort();
+    }
+
     // ========================================================================
     // Phase 1: Basic PD Components and Router Creation
     // ========================================================================
@@ -129,6 +315,7 @@ mod test_pd_routing {
                 history_backend: vllm_router_rs::config::HistoryBackend::Memory,
                 enable_profiling: false,
                 profile_timeout_secs: 30,
+                epd: None,
                 kv_connector: vllm_router_rs::config::KvConnector::Nixl,
             };
 


### PR DESCRIPTION
## Purpose

Add E+PD and E/P/D orchestration through `--epd-config`, integrating encoder routing into vLLM Router instead of requiring a separate Python EPD proxy.

- Select P/PD before encoding, distribute media across E workers, and forward JSON metadata without PyTorch or tensor deserialization.
- Keep embedding transfers in EC backends; support Mooncake PUSH control and opaque NIXL/example handles. Reuse the existing P/D KV handoff, without forwarding P's EC handles to D.
- Preserve sampling fields and SSE responses; cancel abandoned Mooncake transfers.

Native CLI, static workers, DP=1 initially. Requires vLLM JSON metadata support (vllm-project/vllm#56090). See [usage and limitations](docs/epd.md).

Related to #34. No equivalent open PR found: #103 selects modality-specific prefill pools rather than orchestrating separate encoders.

## Validation

Native HTTP/SSE smoke passed for E+PD and E/P/D with mock backends, including duplicate images and encoder failures.

Earlier GPU runs: Qwen3.5-35B-A3B, Mooncake EC RDMA, concurrency 96, CUDA graphs through 16384 (no eager), structured choice; 200 warmup requests plus five repetitions of the first 1,200 MUIRBench questions, with caches retained.

**4E + 4PD: existing Python EPD proxy vs. vLLM Router**

| Metric | Python proxy (historical) | vLLM Router | Change |
| --- | ---: | ---: | ---: |
| Mean throughput (req/s) | 61.40 | 93.33 | +52.0% |
| Mean request latency (ms) | 1514.0 | 1019.0 | -32.7% |
| Pooled P99 latency (ms) | 5007.1 | 3051.0 | -39.1% |
| Accuracy, all final answers | 58.93% | 59.13% | +0.20 pp |

Same model, client settings and 8-GPU topology, with the proxy on E's node. The Python baseline was not rerun; different nodes/times prevent attributing the entire speedup to the router. Router had one recovered HTTP 502; latency and accuracy include that final response.

Separate **4E + 4P + 4D** validation with NIXL KV achieved **90.79 req/s, 58.98% accuracy**, with no request failures. This uses 12 GPUs and is not an equal-resource comparison with 4E + 4PD.

These are subset evaluations, not full MUIRBench scores. GPU runs predate the final code cleanup and have not been rerun afterward.

AI assistance was used for implementation and testing.
