### PR TITLE
Preserve repeated response headers

### DIFF
--- a/src/routers/header_utils.rs
+++ b/src/routers/header_utils.rs
@@ -29,7 +29,7 @@ pub fn preserve_response_headers(reqwest_headers: &HeaderMap) -> HeaderMap {
         let name_str = name.as_str().to_lowercase();
         if should_forward_header(&name_str) {
             // The original name and value are already valid, so we can just clone them
-            headers.insert(name.clone(), value.clone());
+            headers.append(name.clone(), value.clone());
         }
     }
 
@@ -92,4 +92,39 @@ pub fn propagate_headers(
         }
     }
     request
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_preserve_repeated_set_cookie_headers() {
+        let mut headers = HeaderMap::new();
+        headers.append("set-cookie", "a=1; Path=/".parse().unwrap());
+        headers.append("set-cookie", "b=2; Path=/".parse().unwrap());
+
+        let result = preserve_response_headers(&headers);
+        let cookies: Vec<_> = result
+            .get_all("set-cookie")
+            .iter()
+            .map(|value| value.to_str().unwrap())
+            .collect();
+
+        assert_eq!(cookies, ["a=1; Path=/", "b=2; Path=/"]);
+    }
+
+    #[test]
+    fn test_preserve_response_headers_filters_hop_by_hop_headers() {
+        let mut headers = HeaderMap::new();
+        headers.insert("content-type", "application/json".parse().unwrap());
+        headers.append("connection", "keep-alive".parse().unwrap());
+        headers.append("connection", "close".parse().unwrap());
+        headers.insert("transfer-encoding", "chunked".parse().unwrap());
+
+        let result = preserve_response_headers(&headers);
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result["content-type"], "application/json");
+    }
 }


### PR DESCRIPTION
## Purpose

The router kept only the last value when a backend returned several headers with the same name. For example, two `Set-Cookie` headers for `a=1` and `b=2` became just `b=2`.

Change `preserve_response_headers` from `HeaderMap::insert` to `append`. Both cookies now reach the client in their original order.

Fixes #262.

## Test Plan

Add two tests: one checks both cookie values; the other checks that `Content-Type` survives while `Connection` and `Transfer-Encoding` are removed.

- `cargo test --locked --lib --bins`
- `cargo fmt --all -- --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`

## Test Result

The cookie test failed before the fix. After the fix, all 486 library tests pass. Format and Clippy checks pass too.
